### PR TITLE
Adding Sentry exception logging to Parse server

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ addParseCloud();
 // "dotNetKey": optional key from Parse dashboard
 // "restAPIKey": optional key from Parse dashboard
 // "javascriptKey": optional key from Parse dashboard
+// "sentryDSN": optional Sentry DSN for logging errors
 function ParseServer(args) {
   if (!args.appId || !args.masterKey) {
     throw 'You must provide an appId and masterKey!';
@@ -98,6 +99,10 @@ function ParseServer(args) {
 
   router.mountOnto(api);
 
+  if (args.sentryDSN) {
+    var raven = require('raven')
+    api.use(raven.middleware.express.errorHandler(args.sentryDSN));
+  }
   api.use(middlewares.handleParseErrors);
 
   return api;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "mongodb": "~2.0.33",
     "multer": "~0.1.8",
     "parse": "~1.6.12",
+    "raven": "^0.10.0",
     "request": "^2.65.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Happy to also provide documentation on spinning up the open source [Sentry server](https://docs.getsentry.com/on-premise/), for those wanting to run that themselves as well.