### PR TITLE
Make license SPDX compatible in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/ParsePlatform/parse-server"
   },
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "dependencies": {
     "bcrypt": "~0.8",
     "body-parser": "~1.12.4",


### PR DESCRIPTION
This fixes the following npm warning:
`npm WARN parse-server@2.0.1 license should be a valid SPDX license expression`