### PR TITLE
Added map to schema object types, fixed expiresAt

### DIFF
--- a/RestWrite.js
+++ b/RestWrite.js
@@ -283,8 +283,7 @@ RestWrite.prototype.transformUser = function() {
           'action': 'login',
           'authProvider': 'password'
         },
-        restricted: false,
-        expiresAt: 0
+        restricted: false
       };
       var create = new RestWrite(this.config, Auth.master(this.config),
                                  '_Session', null, sessionData);

--- a/Schema.js
+++ b/Schema.js
@@ -282,6 +282,7 @@ function getType(obj) {
   case 'string':
   case 'number':
     return type;
+  case 'map':
   case 'object':
     if (!obj) {
       return undefined;

--- a/transform.js
+++ b/transform.js
@@ -46,6 +46,11 @@ function transformKeyValue(schema, className, restKey, restValue, options) {
   case '_session_token':
     key = '_session_token';
     break;
+  case 'expiresAt':
+  case '_expiresAt':
+    key = '_expiresAt';
+    timeField = true;
+    break;
   case '_rperm':
   case '_wperm':
     return {key: key, value: restValue};
@@ -641,6 +646,10 @@ function untransformObject(schema, className, mongoObject) {
       case 'createdAt':
       case '_created_at':
         restObject['createdAt'] = Parse._encode(new Date(mongoObject[key])).iso;
+        break;
+      case 'expiresAt':
+      case '_expiresAt':
+        restObject['expiresAt'] = Parse._encode(new Date(mongoObject[key])).iso;
         break;
       case '_auth_data_anonymous':
         restObject['authData'] = restObject['authData'] || {};

--- a/users.js
+++ b/users.js
@@ -55,6 +55,9 @@ function handleLogIn(req) {
       user.sessionToken = token;
       delete user.password;
 
+      var expiresAt = new Date();
+      expiresAt.setFullYear(expiresAt.getFullYear() + 1);
+
       var sessionData = {
         sessionToken: token,
         user: {
@@ -67,7 +70,7 @@ function handleLogIn(req) {
           'authProvider': 'password'
         },
         restricted: false,
-        expiresAt: 0,
+        expiresAt: Parse._encode(expiresAt).iso,
         installationId: req.info.installationId
       };
       var create = new RestWrite(req.config, Auth.master(req.config),


### PR DESCRIPTION
Looks like we also used "map" as an object type, in this case for the _Sessions.createdWith key.