### PR TITLE
update function and freeze schema

### DIFF
--- a/ExportAdapter.js
+++ b/ExportAdapter.js
@@ -111,9 +111,9 @@ ExportAdapter.prototype.redirectClassNameForKey = function(className, key) {
 // Returns a promise that resolves to the new schema.
 // This does not update this.schema, because in a situation like a
 // batch request, that could confuse other users of the schema.
-ExportAdapter.prototype.validateObject = function(className, object) {
+ExportAdapter.prototype.validateObject = function(className, object, freeze) {
   return this.loadSchema().then((schema) => {
-    return schema.validateObject(className, object);
+    return schema.validateObject(className, object, freeze);
   });
 };
 

--- a/RestWrite.js
+++ b/RestWrite.js
@@ -90,7 +90,8 @@ RestWrite.prototype.execute = function() {
 
 // Validates this operation against the schema.
 RestWrite.prototype.validateSchema = function() {
-  return this.config.database.validateObject(this.className, this.data);
+  var schemaFrozen = (process.env.NODE_ENV !== 'development') ? !(this.auth && this.auth.isMaster) : false;
+  return this.config.database.validateObject(this.className, this.data, schemaFrozen);
 };
 
 // Runs any beforeSave triggers against this operation.

--- a/Schema.js
+++ b/Schema.js
@@ -199,18 +199,18 @@ Schema.prototype.validateField = function(className, key, type, freeze) {
 
 // Given a schema promise, construct another schema promise that
 // validates this field once the schema loads.
-function thenValidateField(schemaPromise, className, key, type) {
+function thenValidateField(schemaPromise, className, key, type, freeze) {
   return schemaPromise.then((schema) => {
-    return schema.validateField(className, key, type);
+    return schema.validateField(className, key, type, freeze);
   });
 }
 
 // Validates an object provided in REST format.
 // Returns a promise that resolves to the new schema if this object is
 // valid.
-Schema.prototype.validateObject = function(className, object) {
+Schema.prototype.validateObject = function(className, object, freeze) {
   var geocount = 0;
-  var promise = this.validateClassName(className);
+  var promise = this.validateClassName(className, freeze);
   for (var key in object) {
     var expected = getType(object[key]);
     if (expected === 'geopoint') {
@@ -224,7 +224,7 @@ Schema.prototype.validateObject = function(className, object) {
     if (!expected) {
       continue;
     }
-    promise = thenValidateField(promise, className, key, expected);
+    promise = thenValidateField(promise, className, key, expected, freeze);
   }
   return promise;
 };

--- a/functions.js
+++ b/functions.js
@@ -13,7 +13,10 @@ function handleCloudFunction(req) {
     return new Promise(function (resolve, reject) {
       var response = createResponseObject(resolve, reject);
       var request = {
-        params: req.body || {}
+        params: req.body || {},
+        master : req.auth ? req.auth.isMaster : false,
+        user :  req.auth && req.auth.user ? req.auth.user : undefined,
+        installationId : req.auth && req.auth.installationId ? req.auth.installationId : undefined
       };
       Parse.Cloud.Functions[req.params.functionName](request, response);
     });
@@ -34,10 +37,10 @@ function createResponseObject(resolve, reject) {
     error: function(error) {
       reject(new Parse.Error(Parse.Error.SCRIPT_FAILED, error));
     }
-  }
+  };
 }
 
-router.route('POST', '/functions/:functionName', handleCloudFunction);
+router.route('POST', '/functions/:functionName+', handleCloudFunction);
 
 
 module.exports = router;


### PR DESCRIPTION
added user, isMaster, installationId on functions as   [Parse.Cloud.FunctionRequest](https://parse.com/docs/js/api/classes/Parse.Cloud.FunctionRequest.html) specs .

changed route path to  '/functions/:functionName+', that way function can be requested with extra path components as : Parse.Cloud.run('workflows/list', {}) 