### PR TITLE
Parse request.where from string into JSON

### DIFF
--- a/classes.js
+++ b/classes.js
@@ -33,6 +33,10 @@ function handleFind(req) {
     options.redirectClassNameForKey = String(req.body.redirectClassNameForKey);
   }
 
+  if(typeof req.body.where === 'string') {
+    req.body.where = JSON.parse(req.body.where);
+  }
+
   return rest.find(req.config, req.auth,
                    req.params.className, req.body.where, options)
     .then((response) => {


### PR DESCRIPTION
This change fixes for me `com.parse.ParseRequest$ParseRequestException: invalid key name: 0`, which is discussed in detail here: https://github.com/ParsePlatform/parse-server/issues/68. Seems like `body.where` is used as object when passed on, but Parse Android SDK sends it as JSON-encoded string. Not sure if it can break anything else, though.