### PR TITLE
Add Windows Support (bcrypt > bcrypt-node)

### DIFF
--- a/crypto.js
+++ b/crypto.js
@@ -1,6 +1,6 @@
 // Tools for encrypting and decrypting passwords.
 // Basically promise-friendly wrappers for bcrypt.
-var bcrypt = require('bcrypt');
+var bcrypt = require('bcrypt-nodejs');
 
 // Returns a promise for a hashed password string.
 function hash(password) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "BSD-3-Clause",
   "dependencies": {
-    "bcrypt": "~0.8",
+    "bcrypt-nodejs": "0.0.3",
     "body-parser": "~1.12.4",
     "deepcopy": "^0.5.0",
     "express": "~4.2.x",


### PR DESCRIPTION
- This commit replaces bcrypt with bcrypt-node, which has the same functionality as bcrypy - except that it is a pure Node implementation. This change is required to run parse-server on Windows (one can get bcrypt to compile on Windows, but it requires a few Gigabytes of dependencies).