### PR TITLE
Added ability to set server url for Parse JS client SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ There is a development wiki here on GitHub: https://github.com/ParsePlatform/par
 * cloud - The absolute path to your cloud code main.js file
 * fileKey - For migrated apps, this is necessary to provide access to files already hosted on Parse.
 * facebookAppIds - An array of valid Facebook application IDs.
+* serverURL - URL which will be used by Cloud Code functions to make requests against.
 
 #### Client key options:
 
@@ -45,6 +46,8 @@ var ParseServer = require('parse-server').ParseServer;
 
 var app = express();
 
+var port = process.env.PORT || 1337;
+
 // Specify the connection string for your mongodb database
 // and the location to your Parse cloud code
 var api = new ParseServer({
@@ -52,7 +55,8 @@ var api = new ParseServer({
   cloud: '/home/myApp/cloud/main.js', // Provide an absolute path
   appId: 'myAppId',
   masterKey: 'mySecretMasterKey',
-  fileKey: 'optionalFileKey'
+  fileKey: 'optionalFileKey',
+  serverURL: 'http://localhost:' + port + '/parse' // Don't forget to change to https if needed
 });
 
 // Serve the Parse API on the /parse URL prefix
@@ -63,7 +67,6 @@ app.get('/', function(req, res) {
   res.status(200).send('Express is running here.');
 });
 
-var port = process.env.PORT || 1337;
 app.listen(port, function() {
   console.log('parse-server-example running on port ' + port + '.');
 });

--- a/index.js
+++ b/index.js
@@ -72,6 +72,9 @@ function ParseServer(args) {
 
   // Initialize the node client SDK automatically
   Parse.initialize(args.appId, args.javascriptKey || '', args.masterKey);
+  if(args.serverURL) {
+    Parse.serverURL = args.serverURL;
+  }
 
   // This app serves the Parse API directly.
   // It's the equivalent of https://api.parse.com/1 in the hosted Parse API.


### PR DESCRIPTION
Here is the reason for this change: https://github.com/ParsePlatform/parse-server/issues/131
With this fix we can simply add new argument to ParseServer constructor:
```
var api = new ParseServer({
  databaseURI: '...',
  cloud: '...',
  appId: '...',
  ...
  serverUrl: 'http://localhost:' + port
});
```
After this piece of code JS client SDK will start communicating with local instance of Parse Server and not with parse.com.