### PR TITLE
Bugfix: session validation fails if the request does not include installationId

### DIFF
--- a/users.js
+++ b/users.js
@@ -70,9 +70,13 @@ function handleLogIn(req) {
           'authProvider': 'password'
         },
         restricted: false,
-        expiresAt: Parse._encode(expiresAt).iso,
-        installationId: req.info.installationId
+        expiresAt: Parse._encode(expiresAt).iso
       };
+      
+      if (req.info.installationId) {
+        sessionData.installationId = req.info.installationId
+      }
+      
       var create = new RestWrite(req.config, Auth.master(req.config),
                                  '_Session', null, sessionData);
       return create.execute();


### PR DESCRIPTION
Fixes the validation issues in https://github.com/ParsePlatform/parse-server/issues/85

Signed-off-by: Alexander Mays <maysale01@gmail.com>