### PR TITLE
Added multi-app support in DatabaseAdapter.js

### DIFF
--- a/DatabaseAdapter.js
+++ b/DatabaseAdapter.js
@@ -20,6 +20,7 @@ var adapter = ExportAdapter;
 var cache = require('./cache');
 var dbConnections = {};
 var databaseURI = 'mongodb://localhost:27017/parse';
+var appDatabaseURIs = {};
 
 function setAdapter(databaseAdapter) {
   adapter = databaseAdapter;
@@ -29,11 +30,17 @@ function setDatabaseURI(uri) {
   databaseURI = uri;
 }
 
+function setAppDatabaseURI(appId, uri) {
+  appDatabaseURIs[appId] = uri;
+}
+
 function getDatabaseConnection(appId) {
   if (dbConnections[appId]) {
     return dbConnections[appId];
   }
-  dbConnections[appId] = new adapter(databaseURI, {
+
+  var dbURI = (appDatabaseURIs[appId] ? appDatabaseURIs[appId] : databaseURI);
+  dbConnections[appId] = new adapter(dbURI, {
     collectionPrefix: cache.apps[appId]['collectionPrefix']
   });
   dbConnections[appId].connect();
@@ -44,5 +51,6 @@ module.exports = {
   dbConnections: dbConnections,
   getDatabaseConnection: getDatabaseConnection,
   setAdapter: setAdapter,
-  setDatabaseURI: setDatabaseURI
+  setDatabaseURI: setDatabaseURI,
+  setAppDatabaseURI: setAppDatabaseURI
 };

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function ParseServer(args) {
     FilesAdapter.setAdapter(args.filesAdapter);
   }
   if (args.databaseURI) {
-    DatabaseAdapter.setDatabaseURI(args.databaseURI);
+    DatabaseAdapter.setAppDatabaseURI(args.appId, args.databaseURI);
   }
   if (args.cloud) {
     addParseCloud();


### PR DESCRIPTION
When creating multiple instances of `ParseServer` to connect to different databases using a single server, the `databaseURI` was getting overwritten by the last defined connection string (issue: #116).  

This patch stores each connection string by `appId` so that they're not overwritten when creating new `ParseServer` objects.

This patch then allows the user to host multiple apps on the same server like this:-

```
var api = new ParseServer({appId:'app1', 'databaseUri:'mongodb://.../database1', ...});
var api2 = new ParseServer({appId:'app2', 'databaseUri:'mongodb://.../database2', ...});

app.use('/app1/parse', api);
app.use('/app2/parse', api2);
```