### PR TITLE
Added encoding to user name and password

### DIFF
--- a/ExportAdapter.js
+++ b/ExportAdapter.js
@@ -34,8 +34,19 @@ ExportAdapter.prototype.connect = function() {
     return this.connectionPromise;
   }
 
+  var usernameStart = this.mongoURI.indexOf('://') + 3;
+  var lastAtIndex = this.mongoURI.lastIndexOf('@');
+  var encodedMongoURI = this.mongoURI;
+  var username = null;
+  var password = null;
+  var split = null
+  if (lastAtIndex > 0) {
+    split = this.mongoURI.slice(usernameStart, lastAtIndex).split(':');
+    encodedMongoURI = this.mongoURI.slice(0, usernameStart) + encodeURIComponent(split[0]) + ':' + encodeURIComponent(split[1]) + this.mongoURI.slice(lastAtIndex);
+  }
+
   this.connectionPromise = Promise.resolve().then(() => {
-    return MongoClient.connect(this.mongoURI);
+    return MongoClient.connect(encodedMongoURI, {uri_decode_auth:true});
   }).then((db) => {
     this.db = db;
   });

--- a/index.js
+++ b/index.js
@@ -51,7 +51,14 @@ function ParseServer(args) {
   }
   if (args.cloud) {
     addParseCloud();
-    require(args.cloud);
+    if (typeof args.cloud === 'function') {
+      args.cloud(Parse)
+    } else if (typeof args.cloud === 'string') {
+      require(args.cloud);
+    } else {
+      throw "argument 'cloud' must either be a string or a function";
+    }
+
   }
 
   cache.apps[args.appId] = {

--- a/transform.js
+++ b/transform.js
@@ -691,7 +691,7 @@ function untransformObject(schema, className, mongoObject) {
           throw ('bad key in untransform: ' + key);
         } else {
           var expected = schema.getExpectedType(className, key);
-          if (expected == 'file') {
+          if (expected == 'file' && mongoObject[key]) {
             restObject[key] = {
               __type: 'File',
               name: mongoObject[key]


### PR DESCRIPTION
I have an `@` symbol in my mongo password.  I realize that I can specify a custom class for the DatabaseAdapter, but I believe the decoding of a username and password should be built in to the default implementation.