### PR TITLE
Added cloud funciton argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ addParseCloud();
 //                 and delete
 // "databaseURI": a uri like mongodb://localhost:27017/dbname to tell us
 //          what database this Parse API connects to.
-// "cloud": relative location to cloud code to require
+// "cloud": relative location to cloud code to require, or a function
+//          that is given an instance of Parse as a parameter.  Use this instance of Parse
+//          to register your cloud code hooks and functions.
 // "appId": the application id to host
 // "masterKey": the master key for requests to this app
 // "facebookAppIds": an array of valid Facebook Application IDs, required

--- a/index.js
+++ b/index.js
@@ -51,7 +51,14 @@ function ParseServer(args) {
   }
   if (args.cloud) {
     addParseCloud();
-    require(args.cloud);
+    if (typeof args.cloud === 'function') {
+      args.cloud(Parse)
+    } else if (typeof args.cloud === 'string') {
+      require(args.cloud);
+    } else {
+      throw "argument 'cloud' must either be a string or a function";
+    }
+
   }
 
   cache.apps[args.appId] = {


### PR DESCRIPTION
For convenience if using a build process like Webpack or Browserify.  Since the path to the required cloud file isn't evaluated until runtime, this allows the client to specify an "initialization" function for the cloud code.