### PR TITLE
Fixed bug with null file field

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -691,7 +691,7 @@ function untransformObject(schema, className, mongoObject) {
           throw ('bad key in untransform: ' + key);
         } else {
           var expected = schema.getExpectedType(className, key);
-          if (expected == 'file') {
+          if (expected == 'file' && mongoObject[key]) {
             restObject[key] = {
               __type: 'File',
               name: mongoObject[key]


### PR DESCRIPTION
I have a `null` value for one of my ParseFile fields.  This results in an null pointer exception [here](https://github.com/ParsePlatform/parse-server/blob/master/RestQuery.js#L518) if this remains as is.  It looks as though the current version of Parse returns `null` for this field, so that's what I've updated here.