### PR TITLE
S3Adapter: expose the object and use => for s3.upload callback

### DIFF
--- a/S3Adapter.js
+++ b/S3Adapter.js
@@ -40,7 +40,7 @@ S3Adapter.prototype.create = function(config, filename, data) {
   }
 
   return new Promise((resolve, reject) => {
-    this.s3.upload(params, function(err, data) {
+    this.s3.upload(params, (err, data) => {
       if (err !== null) return reject(err);
       resolve(data);
     });

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var batch = require('./batch'),
     DatabaseAdapter = require('./DatabaseAdapter'),
     express = require('express'),
     FilesAdapter = require('./FilesAdapter'),
+    S3Adapter = require('./S3Adapter'),
     middlewares = require('./middlewares'),
     multer = require('multer'),
     Parse = require('parse/node').Parse,
@@ -179,5 +180,6 @@ function getClassName(parseClass) {
 }
 
 module.exports = {
-  ParseServer: ParseServer
+  ParseServer: ParseServer,
+  S3Adapter: S3Adapter
 };


### PR DESCRIPTION
S3Adapter was confusion to use because it wasn't exposed at the package level and this looks like something that a lot of people would use. Expose S3Adapter directly, which means usage to import will be:

    var S3Adapter = require('parse-server').S3Adapter;

Also changed callback of s3.upload call to use ES6's => for consistency.