### PR TITLE
Allowed crossdomain for Parse.file upload with POST

### DIFF
--- a/files.js
+++ b/files.js
@@ -42,6 +42,9 @@ var processCreate = function(req, res, next) {
   var filename = rack() + '_' + req.params.filename + extension;
   FilesAdapter.getAdapter().create(req.config, filename, req.body)
   .then(() => {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Methods", "*");
+    res.header("Access-Control-Allow-Headers", "*");
     res.status(201);
     var location = FilesAdapter.getAdapter().location(req.config, req, filename);
     res.set('Location', location);
@@ -74,7 +77,6 @@ router.post('/files', function(req, res, next) {
                        'Filename not provided.'));
 });
 
-// TODO: do we need to allow crossdomain and method override?
 router.post('/files/:filename',
             bodyParser.raw({type: '*/*', limit: '20mb'}),
             middlewares.handleParseHeaders,


### PR DESCRIPTION
Fix for #118

Allowed crossdomain for the route 
POST /files/:filename

This works when uploading a file with Base64 and byte. How ever it doesn't work when uploading with Content-Type image/png

**Works** 
var base64 = "V29ya2luZyBhdCBQYXJzZSBpcyBncmVhdCE=";
var file = new Parse.File("myfile.txt", { base64: base64 });
file.save();

**Works**
var bytes = [ 0xBE, 0xEF, 0xCA, 0xFE ];
var file = new Parse.File("myfile.txt", bytes);
file.save();

**Doesn't work**
var file = new Parse.File("myfile.zzz", fileData, "image/png");
file.save();

_Reason_
When uploading an image with the Content-Type image options request is made
OPTIONS /files/:filename

<br />

_Note: I haven't used the middlewares.allowCrossDomain method. Please review my code before merge_
