### PR TITLE
Added req.auth.user to parse cloud functions

### DIFF
--- a/Auth.js
+++ b/Auth.js
@@ -64,6 +64,7 @@ var getAuthForSessionToken = function(config, sessionToken) {
     var obj = results[0]['user'];
     delete obj.password;
     obj['className'] = '_User';
+    obj['sessionToken'] = sessionToken;
     var userObject = Parse.Object.fromJSON(obj);
     cache.setUser(sessionToken, userObject);
     return new Auth(config, false, userObject);

--- a/functions.js
+++ b/functions.js
@@ -8,7 +8,6 @@ var express = require('express'),
 var router = new PromiseRouter();
 
 function handleCloudFunction(req) {
-  // TODO: set user from req.auth
   if (Parse.Cloud.Functions[req.params.functionName]) {
     return new Promise(function (resolve, reject) {
       var response = createResponseObject(resolve, reject);

--- a/functions.js
+++ b/functions.js
@@ -13,7 +13,8 @@ function handleCloudFunction(req) {
     return new Promise(function (resolve, reject) {
       var response = createResponseObject(resolve, reject);
       var request = {
-        params: req.body || {}
+        params: req.body || {},
+        user: req.auth && req.auth.user || {}
       };
       Parse.Cloud.Functions[req.params.functionName](request, response);
     });


### PR DESCRIPTION
According to the TODO [here] (https://github.com/ParsePlatform/parse-server/blob/master/functions.js#L11) the cloud code functions are missing the `req.user` parameter.  Here, I'm adding the parameter based on the `req.auth`.  Note that in order to get this to work, I had to overwrite the session token returned from the user query with the one provided in `req.info`.  Please scrutnize this closely, I have no idea why the `_User` object is even stored with a session token.  When I try to use the session token returned from the user query, my cloud functions return empty results because I have ACL permissions set up.  I did delete some of my session tokens earlier, so that might have something to do with it. 

If this update is incorrect, maybe an error should be thrown if there is an invalid session token.  If the `_User` object is stored with a session token in order to provide some kind of master validation for any requests that user might make, and that session token was removed from the database of session tokens, then there is no error thrown, and to the user it just looks like no results are showing from their query. 

Please advise, again I do not fully know the implications of doing this.