### PR TITLE
Fixed invalid facebook login sessionToken

### DIFF
--- a/classes.js
+++ b/classes.js
@@ -41,6 +41,14 @@ function handleFind(req) {
   return rest.find(req.config, req.auth,
                    req.params.className, body.where, options)
     .then((response) => {
+      if (response && response.results) {
+        for (result of response.results) {
+          if (result.sessionToken) {
+            result.sessionToken = req.info.sessionToken || result.sessionToken;
+          }
+        }
+        response.results.sessionToken
+      }
       return {response: response};
     });
 }

--- a/transform.js
+++ b/transform.js
@@ -48,7 +48,7 @@ function transformKeyValue(schema, className, restKey, restValue, options) {
     break;
   case 'expiresAt':
   case '_expiresAt':
-    key = '_expiresAt';
+    key = 'expiresAt';
     timeField = true;
     break;
   case '_rperm':

--- a/users.js
+++ b/users.js
@@ -10,13 +10,16 @@ var facebook = require('./facebook');
 var PromiseRouter = require('./PromiseRouter');
 var rest = require('./rest');
 var RestWrite = require('./RestWrite');
+var deepcopy = require('deepcopy');
 
 var router = new PromiseRouter();
 
 // Returns a promise for a {status, response, location} object.
 function handleCreate(req) {
+  var data = deepcopy(req.body);
+  data.installationId = req.info.installationId;
   return rest.create(req.config, req.auth,
-                     '_User', req.body);
+                     '_User', data);
 }
 
 // Returns a promise for a {response} object.


### PR DESCRIPTION
This is an attempt to address [this todo] (https://github.com/ParseServer/parse-server/blob/master/RestWrite.js#L274).  Please scrutinize this carefully as I am unsure of it's implications elsewhere.  

Although I am able to login with Facebook, when I try to retrieve any data, I get empty results because the session token I am passing to ParseServer is not found in my list of "SessionTokens" and because it is not created as expected.  As the TODO specifies, the original version of parse included the correct "createdWith" parameter and passed an installation ID to the "SessionToken" write operation.

Here I store the `createdWith` parameter in `this.data`, and pass along the installation id sent by the user and set in `req.info.installationId`.

It also appeared as though the `expiresAt` property was not set, so I also added that.

The `expiresAt` key is being written to the database as `_expiresAt`.  I'm not sure where this is coming from, since it looks like the original Parse implementation wrote `expiresAt` to the database (from looking directly at my mongo data).  As a side note, the Parse Dashboard throws an error if the `_expiresAt` field is set.  I'm not sure of the implications of this either.