### PR TITLE
Added MailAdapter and support for Mailgun API

### DIFF
--- a/MailAdapter.js
+++ b/MailAdapter.js
@@ -1,0 +1,73 @@
+// Mail Adapter
+//
+// Allows you to send email using a third party API such as Mailgun.
+// 
+// To send messages: 
+//   var service = MailAdapter.getMailService(appId);
+//   if(service !== null) service.sendMail('user@domain.com', 'Hello User!', 'Thanks for signing up!');
+//
+// Each adapter requires:-
+// * validateConfig(config) -> returns a set of configuration values for each service. Different services have different config requirements
+// * sendMail(to, subject, text) -> sends a message using the configured service
+
+var MailgunAdapter = require('./MailgunAdapter');
+
+var adapter = MailgunAdapter;
+var mailConfigs = {};
+var mailServices = {};
+
+function setMailServiceConfig(appId, mailApiConfig) {
+
+  // Perform a type check on mailApiConfig to ensure it's a dictionary/object
+  if(typeof mailApiConfig === 'object') {
+
+    // Ensure mailApiConfig has a least a service defined, not not — default to mailgun
+    if(typeof mailApiConfig.service === 'undefined' || mailApiConfig.service === '') {
+      console.error('Error: You need to define a `service` when configuring `mailConfig` in ParseServer.');
+      mailApiConfig.service = 'mailgun'; // use mailgun as the default adapter
+    }
+
+    // Set the mail service as configured
+    if(mailApiConfig.service === '' || mailApiConfig.service === 'mailgun') {
+      adapter = MailgunAdapter;
+      mailApiConfig = MailgunAdapter.validateConfig(mailApiConfig);
+    } else {
+      // Handle other mail adapters here... (such as mandrill, postmark, etc
+    }
+
+  } else {
+    // Unexpected type, should be an object/dictionary.
+    console.log('Error: Unexpected `mailApiConfig` in MailAdapter.');
+    mailApiConfig = MailgunAdapter.validateConfig({}); // Just get some empty values
+    return false;
+  }
+
+  mailConfigs[appId] = mailApiConfig;
+  return true;
+}
+
+function clearMailService(appId) {
+  delete mailConfigs[appId];
+  delete mailServices[appId];
+}
+
+function getMailService(appId) {
+  if (mailServices[appId]) {
+    return mailServices[appId];
+  }
+
+  if(mailConfigs[appId] != null) {
+    mailServices[appId] = new adapter(appId, mailConfigs[appId]);
+    return mailServices[appId];
+  } else {
+    return null;
+  }
+}
+
+module.exports = {
+  mailConfigs: mailConfigs,
+  mailServices: mailServices,
+  setMailServiceConfig: setMailServiceConfig,
+  getMailService: getMailService,
+  clearMailService: clearMailService
+};

--- a/MailgunAdapter.js
+++ b/MailgunAdapter.js
@@ -1,0 +1,57 @@
+// A mail adapter for the Mailgun API
+
+// options can contain:
+function MailgunAdapter(appId, mailApiConfig) {
+  this.appId = appId;
+  this.apiConfig = mailApiConfig;
+}
+
+// Connects to the database. Returns a promise that resolves when the
+// connection is successful.
+// this.db will be populated with a Mongo "Db" object when the
+// promise resolves successfully.
+MailgunAdapter.prototype.sendMail = function(to, subject, text) {
+  
+  var mailgun = require('mailgun-js')({apiKey: this.apiConfig.apiKey, domain: this.apiConfig.domain});
+
+  var data = {
+    from: this.apiConfig.fromAddress,
+    to: to,
+    subject: subject,
+    text: text
+  };
+
+  return new Promise((resolve, reject) => {
+    mailgun.messages().send(data, (err, body) => {
+      if (typeof err !== 'undefined') {
+        // console.log("Mailgun Error", err);
+        return reject(err);
+      }
+      // console.log(body);
+      resolve(body);
+    });
+  });
+};
+
+MailgunAdapter.validateConfig = function(config) {
+  var cfg = {apiKey:'', domain:'', fromAddress:''};
+  var helperMessage = "When creating an instance of ParseServer, you should have a mailConfig section like this: mailConfig: { service:'mailgun', apiKey:'MAILGUN_KEY_HERE', domain:'MAILGUN_DOMAIN_HERE', fromAddress:'MAILGUN_FROM_ADDRESS_HERE' }";
+  if(typeof config.apiKey === 'undefined' || config.apiKey === '') {
+    console.error('Error: You need to define a MailGun `apiKey` when configuring ParseServer. ' + helperMessage);
+  } else {
+    cfg.apiKey = config.apiKey;
+  }
+  if(typeof config.domain === 'undefined' || config.domain === '') {
+    console.error('Error: You need to define a MailGun `domain` when configuring ParseServer. ' + helperMessage);
+  } else {
+    cfg.domain = config.domain;
+  }
+  if(typeof config.fromAddress === 'undefined' || config.fromAddress === '') {
+    console.error('Error: You need to define a MailGun `fromAddress` when configuring ParseServer. ' + helperMessage);
+  } else {
+    cfg.fromAddress = config.fromAddress;
+  }
+  return cfg;
+};
+
+module.exports = MailgunAdapter;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var batch = require('./batch'),
     express = require('express'),
     FilesAdapter = require('./FilesAdapter'),
     S3Adapter = require('./S3Adapter'),
+    MailAdapter = require('./MailAdapter'),
     middlewares = require('./middlewares'),
     multer = require('multer'),
     Parse = require('parse/node').Parse,
@@ -27,6 +28,11 @@ addParseCloud();
 // "cloud": relative location to cloud code to require, or a function
 //          that is given an instance of Parse as a parameter.  Use this instance of Parse
 //          to register your cloud code hooks and functions.
+// "mailConfig": a dictionary of 3rd party mail service settings (such as API keys etc)
+//          currently only Mailgun is supported. So service, apiKey, domain and fromAddress
+//          are all required. Setup like mailgun: { service: 'mailgun', apiKey: 'MG_APIKEY', 
+//          domain:'MG_DOMAIN', fromAddress:'Your App <yourapp@domain.com>' }. If you do not
+//          define mailConfig, no mail service will be setup.
 // "appId": the application id to host
 // "masterKey": the master key for requests to this app
 // "facebookAppIds": an array of valid Facebook Application IDs, required
@@ -52,6 +58,10 @@ function ParseServer(args) {
   if (args.databaseURI) {
     DatabaseAdapter.setAppDatabaseURI(args.appId, args.databaseURI);
   }
+  if(args.mailConfig) {
+    MailAdapter.setMailServiceConfig(args.appId, args.mailConfig);
+  }
+
   if (args.cloud) {
     addParseCloud();
     if (typeof args.cloud === 'function') {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "deepcopy": "^0.5.0",
     "express": "~4.2.x",
     "hat": "~0.0.3",
+    "mailgun-js": "^0.7.7",
     "mime": "^1.3.4",
     "mongodb": "~2.0.33",
     "multer": "~0.1.8",


### PR DESCRIPTION
I've added initial support for sending transactional e-mail via Parse Server.  The MailAdapter can eventually be used for sending verification e-mails after a user signs up, or for sending password reset instructions #99, etc.

At the moment it only supports Mailgun — which can easily be added as an add-on with Heroku for free (300 e-mails per day), or users can sign up manually for an API key at mailgun.com for 10,000 emails free per month.

To configure, simply add `mailConfig` into the `ParseServer` constructor as follows:

```
var api = new ParseServer({
  databaseURI: databaseUri || 'mongodb://localhost:27017/dev',
  cloud: process.env.CLOUD_CODE_MAIN || __dirname + '/cloud/main.js',
  appId: process.env.APP_ID || 'myAppId',
  masterKey: process.env.MASTER_KEY || 'myMasterKey',
  mailConfig: {
  	service: 'mailgun',
  	apiKey: process.env.MAILGUN_API_KEY || 'mg-MYMAILGUNKEY',
  	domain: process.env.MAILGUN_DOMAIN || 'mymailgundomain@mailgun.org',
  	fromAddress: process.env.MAIL_FROM_ADDRESS || 'My App <myapp@domain.com>'
  }
});
```

Once configured, e-mails can be sent like this:-

```
var service = MailAdapter.getMailService('myAppId');
if(service !== null) service.sendMail('user@domain.com', 'Hello User!', 'Thanks for signing up!');
```

I haven't updated the main readme file for now as no part of Parse Server currently sends transactional e-mails and I didn't want to cause any confusion for new adopters!  Also if `mailConfig` isn't configured inside the `ParseServer` constructor, nothing should happen.

Support for Mandrill / Postmark etc should be fairly trivial as they just need hooking up to MailAdapter once implemented.