### PR TITLE
Add Travis-CI and CodeCov.io integrations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ node_js:
   - "4.2"
 env:
   - MONGODB_VERSION=3.0.8
-after_script: cat ./coverage/coverage-final.json
+after_success: ./node_modules/.bin/codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+branches:
+  only:
+    - master
+language: node_js
+node_js:
+  - "4.1"
+  - "4.2"
+env:
+  - MONGODB_VERSION=3.0.8
+after_script: cat ./coverage/coverage-final.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## parse-server
 
+[![Build Status](https://img.shields.io/travis/ParsePlatform/parse-server/master.svg?style=flat)](https://travis-ci.org/ParsePlatform/parse-server)
+[![Coverage Status](https://codecov.io/github/ParsePlatform/parse-server/coverage.svg?branch=master)](https://codecov.io/github/ParsePlatform/parse-server?branch=master)
+
 A Parse.com API compatible router package for Express
 
 Read the announcement blog post here:  http://blog.parse.com/announcements/introducing-parse-server-and-the-database-migration-tool/

--- a/package.json
+++ b/package.json
@@ -23,10 +23,13 @@
   },
   "devDependencies": {
     "istanbul": "^0.4.2",
-    "jasmine": "^2.3.2"
+    "jasmine": "^2.3.2",
+    "mongodb-runner": "^3.1.15"
   },
   "scripts": {
-    "test": "TESTING=1 ./node_modules/.bin/istanbul cover --include-all-sources ./node_modules/.bin/jasmine"
+    "pretest": "MONGODB_VERSION=${MONGODB_VERSION:=3.0.8} mongodb-runner start",
+    "test": "TESTING=1 ./node_modules/.bin/istanbul cover --include-all-sources ./node_modules/.bin/jasmine",
+    "posttest": "mongodb-runner stop"
   },
   "engines": {
     "node": ">=4.1"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "request": "^2.65.0"
   },
   "devDependencies": {
+    "codecov": "^1.0.1",
     "istanbul": "^0.4.2",
     "jasmine": "^2.3.2",
     "mongodb-runner": "^3.1.15"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "pretest": "MONGODB_VERSION=${MONGODB_VERSION:=3.0.8} mongodb-runner start",
-    "test": "TESTING=1 ./node_modules/.bin/istanbul cover --include-all-sources ./node_modules/.bin/jasmine",
+    "test": "TESTING=1 ./node_modules/.bin/istanbul cover --include-all-sources -x **/spec/** ./node_modules/.bin/jasmine",
     "posttest": "mongodb-runner stop"
   },
   "engines": {


### PR DESCRIPTION
This PR adds the following:
- Travis-CI tests on every pull request/master branch
E.g. https://travis-ci.org/nlutsenko/parse-server/builds/106656352
- Travis-CI tests run in a matrix with Node 4.1 and 4.2
- It's using the latest stable version of MongoDB 3.0 (3.0.8), but we can extend and or change that extremely easy - by simply adding another item into `env` array.
- Added Codecov.io integration via npm module - this will run only if tests succeeded.
E.g. https://codecov.io/github/nlutsenko/parse-server?branch=nlutsenko.travis
- Added `mongodb-runner` npm module, which starts a mongo on pretest/posttest, so we can ensure mongo is always there locally whenever tests are run.

Few benchmarks:
- Average test run is ~1.5min on Travis-CI
https://travis-ci.org/nlutsenko/parse-server/jobs/106656353
- Average full integration is ~3min on Travis-CI
https://travis-ci.org/nlutsenko/parse-server/builds/106656352

The only flow change here is that to run tests - we enforce running mongo via `mongodb-runner`, which I still feel is absolutely fine and the best thing we could do, since it's somewhat a best practice.
Please keep in mind - that this runner is never used in a non-dev environment, but is only installed and used when developing per `devDependencies` section of package.json.

This superseeds and closes #30.