### PR TITLE
Fixed Cloud functions/triggers async rejection crashing server.

### DIFF
--- a/cloud/main.js
+++ b/cloud/main.js
@@ -4,8 +4,17 @@ Parse.Cloud.define('hello', function(req, res) {
   res.success('Hello world!');
 });
 
-Parse.Cloud.beforeSave('BeforeSaveFailure', function(req, res) {
+Parse.Cloud.beforeSave('BeforeSaveFail', function(req, res) {
   res.error('You shall not pass!');
+});
+
+Parse.Cloud.beforeSave('BeforeSaveFailWithPromise', function (req, res) {
+  var query = new Parse.Query('Yolo');
+  query.find().then(() => {
+   res.error('Nope');
+  }, () => {
+    res.success();
+  });
 });
 
 Parse.Cloud.beforeSave('BeforeSaveUnchanged', function(req, res) {
@@ -25,6 +34,15 @@ Parse.Cloud.afterSave('AfterSaveTest', function(req) {
 
 Parse.Cloud.beforeDelete('BeforeDeleteFail', function(req, res) {
   res.error('Nope');
+});
+
+Parse.Cloud.beforeSave('BeforeDeleteFailWithPromise', function (req, res) {
+  var query = new Parse.Query('Yolo');
+  query.find().then(() => {
+    res.error('Nope');
+  }, () => {
+    res.success();
+  });
 });
 
 Parse.Cloud.beforeDelete('BeforeDeleteTest', function(req, res) {

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -153,12 +153,26 @@ describe('miscellaneous', function() {
   });
 
   it('basic beforeSave rejection', function(done) {
-    var obj = new Parse.Object('BeforeSaveFailure');
+    var obj = new Parse.Object('BeforeSaveFail');
+    obj.set('foo', 'bar');
+    obj.save().then(() => {
+      fail('Should not have been able to save BeforeSaveFailure class.');
+      done();
+    }, () => {
+      done();
+    })
+  });
+
+  it('basic beforeSave rejection via promise', function(done) {
+    var obj = new Parse.Object('BeforeSaveFailWithPromise');
     obj.set('foo', 'bar');
     obj.save().then(function() {
       fail('Should not have been able to save BeforeSaveFailure class.');
       done();
     }, function(error) {
+      expect(error.code).toEqual(Parse.Error.SCRIPT_FAILED);
+      expect(error.message).toEqual('Nope');
+
       done();
     })
   });
@@ -250,6 +264,20 @@ describe('miscellaneous', function() {
       // We should have been able to fetch the object again
       fail(error);
     });
+  })
+
+  it('basic beforeDelete rejection via promise', function(done) {
+    var obj = new Parse.Object('BeforeDeleteFailWithPromise');
+    obj.set('foo', 'bar');
+    obj.save().then(function() {
+      fail('Should not have been able to save BeforeSaveFailure class.');
+      done();
+    }, function(error) {
+      expect(error.code).toEqual(Parse.Error.SCRIPT_FAILED);
+      expect(error.message).toEqual('Nope');
+
+      done();
+    })
   });
 
   it('test beforeDelete success', function(done) {

--- a/triggers.js
+++ b/triggers.js
@@ -57,7 +57,8 @@ var getResponseObject = function(request, resolve, reject) {
       return resolve(response);
     },
     error: function(error) {
-      throw new Parse.Error(Parse.Error.SCRIPT_FAILED, error);
+      var scriptError = new Parse.Error(Parse.Error.SCRIPT_FAILED, error);
+      return reject(scriptError);
     }
   }
 };


### PR DESCRIPTION
Reject a promise instead of throwing an error, which doesn't quite work with promises and crashes the server. Fixes asynchronously rejected beforeSave/beforeDelete and Cloud Functions.
Fixes #163 
