### PR TITLE
Add Mongo 2.6.11 to Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ node_js:
   - "4.1"
   - "4.2"
 env:
+  - MONGODB_VERSION=2.6.11
   - MONGODB_VERSION=3.0.8
 after_success: ./node_modules/.bin/codecov


### PR DESCRIPTION
Since we officially support it - we might as well add it to tests.