### PR TITLE
Added master option to cloud code functions

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -13,7 +13,8 @@ function handleCloudFunction(req) {
       var response = createResponseObject(resolve, reject);
       var request = {
         params: req.body || {},
-        user: req.auth && req.auth.user || {}
+        master: req.auth && req.auth.isMaster,
+        user: req.auth && req.auth.user,
       };
       Parse.Cloud.Functions[req.params.functionName](request, response);
     });


### PR DESCRIPTION
The original cloud code guide specified that the `master` parameter in `req` would be set to true if the master key was used.  Adding that here. [see here.] (https://parse.com/docs/cloudcode/guide#cloud-code-advanced-cloud-function-webhooks)

Also removed the default `{}` for `req.user`, per [this] (https://parse.com/docs/cloudcode/guide#cloud-code-cloud-functions) specification it will be unset if the user is not logged in.