### PR TITLE
Adding validation functions to Cloud Functions

### DIFF
--- a/facebook.js
+++ b/facebook.js
@@ -24,7 +24,7 @@ function validateAppId(appIds, access_token) {
   }
   return graphRequest('app?access_token=' + access_token)
     .then((data) => {
-      if (data && appIds.contains(data.id)) {
+      if (data && appIds.indexOf(data.id) != -1) {
         return;
       }
       throw new Parse.Error(

--- a/functions.js
+++ b/functions.js
@@ -10,6 +10,14 @@ var router = new PromiseRouter();
 function handleCloudFunction(req) {
   // TODO: set user from req.auth
   if (Parse.Cloud.Functions[req.params.functionName]) {
+    // Run the validator for this function first
+    if (Parse.Cloud.Validators[req.params.functionName]) {
+      var result = Parse.Cloud.Validators[req.params.functionName](req.body);
+      if (!result) {
+        throw new Parse.Error(Parse.Error.SCRIPT_FAILED, 'Validation failed.');
+      }
+    }
+
     return new Promise(function (resolve, reject) {
       var response = createResponseObject(resolve, reject);
       var request = {

--- a/index.js
+++ b/index.js
@@ -113,14 +113,17 @@ function ParseServer(args) {
 
 function addParseCloud() {
   Parse.Cloud.Functions = {};
+  Parse.Cloud.Validators = {};
   Parse.Cloud.Triggers = {
     beforeSave: {},
     beforeDelete: {},
     afterSave: {},
     afterDelete: {}
   };
-  Parse.Cloud.define = function(functionName, handler) {
+  
+  Parse.Cloud.define = function(functionName, handler, validationHandler) {
     Parse.Cloud.Functions[functionName] = handler;
+    Parse.Cloud.Validators[functionName] = validationHandler;
   };
   Parse.Cloud.beforeSave = function(parseClass, handler) {
     var className = getClassName(parseClass);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-server",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "An express module providing a Parse-compatible API server",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
If your Cloud Functions have required parameters, you can do this today:

```
Parse.Cloud.define("foobar", function(req, res) {
  if (req.params.myRequiredParam != 'foobar') {
      res.error();
  }
 // ... do something else ...
});
```

OR

```
function isValidRequest(req) {
   return req.params.myRequiredParam;
}

Parse.Cloud.define("foobar", function(req, res) {
  if (!isValidRequest(req)) {
     res.error();
  }

  // ... do something else ...
});
```

Depending on the approach you use you might end up duplicating code or writing more if-not-valid-return-error kind of code all over the place.

This PR introduces the option to provide a Validator function for a Cloud Function which runs before the actual Cloud Function runs and validates the input parameters of the request. If the validation fails, it will return an error or executes the Cloud Function if the validation succeeds.

**Example**
```
Parse.Cloud.define("foobar", function(req, res) {
  res.success();
}, function(params) {
  return params.myRequiredParam;
});
```

OR for multiple functions that share a validator

```
var requireMyAwesomeParameter = function(params) {
  return params.myRequiredParam; 
}

Parse.Cloud.define("foobar1", function(req, res) {
  res.success();
}, requireMyAwesomeParameter);

Parse.Cloud.define("foobar2", function(req, res) {
  res.success();
}, requireMyAwesomeParameter);
```

This PR is just a foundation for other work that can be done around here, for example multiple validators per function, global validators that are only registered once by calling something like `Parse.Cloud.validate(...)` etc.

I added two test in `ParseAPI.spec.js:L547`