### PR TITLE
Fixed storage of GeoPoints in nested arrays/maps.

### DIFF
--- a/spec/ParseGeoPoint.spec.js
+++ b/spec/ParseGeoPoint.spec.js
@@ -287,4 +287,47 @@ describe('Parse.GeoPoint testing', () => {
       done();
     });
   });
+
+  it('supports a sub-object with a geo point', done => {
+    var point = new Parse.GeoPoint(44.0, -11.0);
+    var obj = new TestObject();
+    obj.set('subobject', { location: point });
+    obj.save(null, {
+      success: function() {
+        var query = new Parse.Query(TestObject);
+        query.find({
+          success: function(results) {
+            equal(results.length, 1);
+            var pointAgain = results[0].get('subobject')['location'];
+            ok(pointAgain);
+            equal(pointAgain.latitude, 44.0);
+            equal(pointAgain.longitude, -11.0);
+            done();
+          }
+        });
+      }
+    });
+  });
+
+  it('supports array of geo points', done => {
+    var point1 = new Parse.GeoPoint(44.0, -11.0);
+    var point2 = new Parse.GeoPoint(22.0, -55.0);
+    var obj = new TestObject();
+    obj.set('locations', [ point1, point2 ]);
+    obj.save(null, {
+      success: function() {
+        var query = new Parse.Query(TestObject);
+        query.find({
+          success: function(results) {
+            equal(results.length, 1);
+            var locations = results[0].get('locations');
+            expect(locations.length).toEqual(2);
+            expect(locations[0]).toEqual(point1);
+            expect(locations[1]).toEqual(point2);
+            done();
+          }
+        });
+      }
+    });
+  });
 });

--- a/spec/transform.spec.js
+++ b/spec/transform.spec.js
@@ -61,6 +61,29 @@ describe('transformCreate', () => {
     // This just checks that it doesn't crash, but it should check format.
     done();
   });
+
+  describe('GeoPoints', () => {
+    it('plain', (done) => {
+      var geoPoint = {__type: 'GeoPoint', longitude: 180, latitude: -180};
+      var out = transform.transformCreate(dummySchema, null, {location: geoPoint});
+      expect(out.location).toEqual([180, -180]);
+      done();
+    });
+
+    it('in array', (done) => {
+      var geoPoint = {__type: 'GeoPoint', longitude: 180, latitude: -180};
+      var out = transform.transformCreate(dummySchema, null, {locations: [geoPoint, geoPoint]});
+      expect(out.locations).toEqual([geoPoint, geoPoint]);
+      done();
+    });
+
+    it('in sub-object', (done) => {
+      var geoPoint = {__type: 'GeoPoint', longitude: 180, latitude: -180};
+      var out = transform.transformCreate(dummySchema, null, { locations: { start: geoPoint }});
+      expect(out).toEqual({ locations: { start: geoPoint } });
+      done();
+    });
+  });
 });
 
 describe('transformWhere', () => {

--- a/transform.js
+++ b/transform.js
@@ -367,7 +367,10 @@ function transformAtom(atom, force, options) {
       return new Date(atom.iso);
     }
     if (atom.__type == 'GeoPoint') {
-      return [atom.longitude, atom.latitude];
+      if (!inArray && !inObject) {
+        return [atom.longitude, atom.latitude];
+      }
+      return atom;
     }
     if (atom.__type == 'Bytes') {
       return new mongodb.Binary(new Buffer(atom.base64, 'base64'));


### PR DESCRIPTION
We were using the same logic for storing GeoPoints in nested arrays/maps as for root-level keys, which actually changes the entire schema and will break a lot of clients.
This PR contains a fix for the whole thing, as well as tests both unit and integration tests to validate that everything is good now.