### PR TITLE
Split basic type conversions from other logic in transform.js.

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -363,23 +363,17 @@ function transformAtom(atom, force, options) {
         objectId: atom.objectId
       };
     }
-    if (atom.__type == 'Date') {
-      return new Date(atom.iso);
+    if (DateCoder.isValidJSON(atom)) {
+      return DateCoder.JSONToDatabase(atom);
     }
-    if (atom.__type == 'GeoPoint') {
-      if (!inArray && !inObject) {
-        return [atom.longitude, atom.latitude];
-      }
-      return atom;
+    if (BytesCoder.isValidJSON(atom)) {
+      return BytesCoder.JSONToDatabase(atom);
     }
-    if (atom.__type == 'Bytes') {
-      return new mongodb.Binary(new Buffer(atom.base64, 'base64'));
+    if (GeoPointCoder.isValidJSON(atom)) {
+      return (inArray || inObject ? atom : GeoPointCoder.JSONToDatabase(atom));
     }
-    if (atom.__type == 'File') {
-      if (!inArray && !inObject) {
-        return atom.name;
-      }
-      return atom;
+    if (FileCoder.isValidJSON(atom)) {
+      return (inArray || inObject ? atom : FileCoder.JSONToDatabase(atom));
     }
 
     if (force) {
@@ -620,11 +614,8 @@ function untransformObject(schema, className, mongoObject) {
       return Parse._encode(mongoObject);
     }
 
-    if (mongoObject instanceof mongodb.Binary) {
-      return {
-        __type: 'Bytes',
-        base64: mongoObject.buffer.toString('base64')
-      };
+    if (BytesCoder.isValidDatabaseObject(mongoObject)) {
+      return BytesCoder.databaseToJSON(mongoObject);
     }
 
     var restObject = untransformACL(mongoObject);
@@ -699,20 +690,14 @@ function untransformObject(schema, className, mongoObject) {
         //} else if (mongoObject[key] === null) {
           //break;
         } else {
-          var expected = schema.getExpectedType(className, key);
-          if (expected == 'file' && mongoObject[key]) {
-            restObject[key] = {
-              __type: 'File',
-              name: mongoObject[key]
-            };
+          var expectedType = schema.getExpectedType(className, key);
+          var value = mongoObject[key];
+          if (expectedType === 'file' && FileCoder.isValidDatabaseObject(value)) {
+            restObject[key] = FileCoder.databaseToJSON(value);
             break;
           }
-          if (expected == 'geopoint') {
-            restObject[key] = {
-              __type: 'GeoPoint',
-              latitude: mongoObject[key][1],
-              longitude: mongoObject[key][0]
-            };
+          if (expectedType === 'geopoint' && GeoPointCoder.isValidDatabaseObject(value)) {
+            restObject[key] = GeoPointCoder.databaseToJSON(value);
             break;
           }
         }
@@ -725,6 +710,94 @@ function untransformObject(schema, className, mongoObject) {
     throw 'unknown js type';
   }
 }
+
+var DateCoder = {
+  JSONToDatabase(json) {
+    return new Date(json.iso);
+  },
+
+  isValidJSON(value) {
+    return (typeof value === 'object' &&
+      value !== null &&
+      value.__type === 'Date'
+    );
+  }
+};
+
+var BytesCoder = {
+  databaseToJSON(object) {
+    return {
+      __type: 'Bytes',
+      base64: object.buffer.toString('base64')
+    };
+  },
+
+  isValidDatabaseObject(object) {
+    return (object instanceof mongodb.Binary);
+  },
+
+  JSONToDatabase(json) {
+    return new mongodb.Binary(new Buffer(json.base64, 'base64'));
+  },
+
+  isValidJSON(value) {
+    return (typeof value === 'object' &&
+      value !== null &&
+      value.__type === 'Bytes'
+    );
+  }
+};
+
+var GeoPointCoder = {
+  databaseToJSON(object) {
+    return {
+      __type: 'GeoPoint',
+      latitude: object[1],
+      longitude: object[0]
+    }
+  },
+
+  isValidDatabaseObject(object) {
+    return (object instanceof Array &&
+      object.length == 2
+    );
+  },
+
+  JSONToDatabase(json) {
+    return [ json.longitude, json.latitude ];
+  },
+
+  isValidJSON(value) {
+    return (typeof value === 'object' &&
+      value !== null &&
+      value.__type === 'GeoPoint'
+    );
+  }
+};
+
+var FileCoder = {
+  databaseToJSON(object) {
+    return {
+      __type: 'File',
+      name: object
+    }
+  },
+
+  isValidDatabaseObject(object) {
+    return (typeof object === 'string');
+  },
+
+  JSONToDatabase(json) {
+    return json.name;
+  },
+
+  isValidJSON(value) {
+    return (typeof value === 'object' &&
+      value !== null &&
+      value.__type === 'File'
+    );
+  }
+};
 
 module.exports = {
   transformKey: transformKey,


### PR DESCRIPTION
Should help with type safety here, as well as can uncover a lot of nasty things.