### PR TITLE
Update express app to use 'mountPath' instead of /

### DIFF
--- a/bin/parse-server
+++ b/bin/parse-server
@@ -35,7 +35,7 @@ if (process.env.PARSE_SERVER_OPTIONS) {
 
 var mountPath = process.env.PARSE_SERVER_MOUNT_PATH || "/";
 var api = new ParseServer(options);
-app.use('/', api);
+app.use(mountPath, api);
 
 var port = process.env.PORT || 1337;
 app.listen(port, function() {


### PR DESCRIPTION
Typo fix. Express app uses '/' instead of mountPath, but logs later that it is listening on the mountPath anyways. This sets up the express app to use mountPath instead of '/'