### PR TITLE
Adds generic support additional OAuth providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,61 @@ The client keys used with Parse are no longer necessary with parse-server.  If y
 * restAPIKey
 * dotNetKey
 
+#### OAuth Support
+
+parse-server supports 3rd party authentication with
+
+* Twitter
+* Meetup
+* Linkedin
+* Google
+* Instagram
+* Facebook
+
+
+Configuration options for these 3rd-party modules is done with the oauth option passed to ParseServer:
+
+```
+{
+  oauth: {
+   twitter: {
+     consumer_key: "", // REQUIRED
+     consumer_secret: "" // REQUIRED
+   },
+   facebook: {
+     appIds: "FACEBOOK APP ID"
+   }
+  }
+
+}
+```
+
+#### Custom Authentication
+
+It is possible to leverage the OAuth support with any 3rd party authentication that you bring in.
+
+```
+{
+
+  oauth: {
+   my_custom_auth: {
+     module: "PATH_TO_MODULE" // OR object, 
+     option1: "",
+     option2: "",
+   }
+  }
+}
+```
+
+On this module, you need to implement and export those two functions `validateAuthData(authData, options) {} ` and `validateAppId(appIds, authData) {}`.
+
+For more informations about custom auth please see the examples:
+
+- [facebook OAuth](https://github.com/ParsePlatform/parse-server/blob/master/src/oauth/facebook.js)
+- [twitter OAuth](https://github.com/ParsePlatform/parse-server/blob/master/src/oauth/twitter.js)
+- [instagram OAuth](https://github.com/ParsePlatform/parse-server/blob/master/src/oauth/instagram.js)
+
+
 #### Advanced options:
 
 * filesAdapter - The default behavior (GridStore) can be changed by creating an adapter class (see [`FilesAdapter.js`](https://github.com/ParsePlatform/parse-server/blob/master/src/Adapters/Files/FilesAdapter.js))

--- a/bin/parse-server
+++ b/bin/parse-server
@@ -30,6 +30,11 @@ if (process.env.PARSE_SERVER_OPTIONS) {
 		facebookAppIds = facebookAppIds.split(",");
 		options.facebookAppIds = facebookAppIds;
 	}
+
+	var oauth = process.env.PARSE_SERVER_OAUTH_PROVIDERS;
+	if (oauth) {
+		options.oauth = JSON.parse(oauth);
+	};
 }
 
 var mountPath = process.env.PARSE_SERVER_MOUNT_PATH || "/";

--- a/spec/OAuth.spec.js
+++ b/spec/OAuth.spec.js
@@ -1,0 +1,307 @@
+var OAuth = require("../src/oauth/OAuth1Client");
+var request = require('request');
+
+describe('OAuth', function() {
+
+  it("Nonce should have right length", (done) => {
+    jequal(OAuth.nonce().length, 30);
+    done();
+  });
+
+  it("Should properly build parameter string", (done) => {
+    var string = OAuth.buildParameterString({c:1, a:2, b:3})
+    jequal(string, "a=2&b=3&c=1");
+    done();
+  });
+
+  it("Should properly build empty parameter string", (done) => {
+    var string = OAuth.buildParameterString()
+    jequal(string, "");
+    done();
+  });
+
+  it("Should properly build signature string", (done) => {
+    var string = OAuth.buildSignatureString("get", "http://dummy.com", "");
+    jequal(string, "GET&http%3A%2F%2Fdummy.com&");
+    done();
+  });
+
+  it("Should properly generate request signature", (done) => {
+    var request = {
+      host: "dummy.com", 
+      path: "path"
+    };
+
+    var oauth_params = {
+      oauth_timestamp: 123450000,
+      oauth_nonce: "AAAAAAAAAAAAAAAAA",
+      oauth_consumer_key: "hello",
+      oauth_token: "token"
+    };
+
+    var consumer_secret = "world";
+    var auth_token_secret = "secret";
+    request = OAuth.signRequest(request, oauth_params, consumer_secret, auth_token_secret);
+    jequal(request.headers['Authorization'], 'OAuth oauth_consumer_key="hello", oauth_nonce="AAAAAAAAAAAAAAAAA", oauth_signature="8K95bpQcDi9Nd2GkhumTVcw4%2BXw%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="123450000", oauth_token="token", oauth_version="1.0"');
+    done();
+  });
+
+  it("Should properly build request", (done) => {
+    var options = {
+      host: "dummy.com", 
+      consumer_key: "hello",
+      consumer_secret: "world",
+      auth_token: "token",
+      auth_token_secret: "secret",
+      // Custom oauth params for tests
+      oauth_params: {
+        oauth_timestamp: 123450000,
+        oauth_nonce: "AAAAAAAAAAAAAAAAA"
+      }
+    };
+    var path = "path";
+    var method = "get";
+
+    var oauthClient = new OAuth(options);
+    var req = oauthClient.buildRequest(method, path, {"query": "param"});
+
+    jequal(req.host, options.host);
+    jequal(req.path, "/"+path+"?query=param");
+    jequal(req.method, "GET");
+    jequal(req.headers['Content-Type'], 'application/x-www-form-urlencoded');
+    jequal(req.headers['Authorization'], 'OAuth oauth_consumer_key="hello", oauth_nonce="AAAAAAAAAAAAAAAAA", oauth_signature="wNkyEkDE%2F0JZ2idmqyrgHdvC0rs%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="123450000", oauth_token="token", oauth_version="1.0"')
+    done();
+  });
+
+
+  function validateCannotAuthenticateError(data, done) {
+    jequal(typeof data, "object");
+    jequal(typeof data.errors, "object");
+    var errors = data.errors;
+    jequal(typeof errors[0], "object");
+    // Cannot authenticate error
+    jequal(errors[0].code, 32);
+    done();
+  }
+
+  it("Should fail a GET request", (done) => {
+    var options = {
+      host: "api.twitter.com", 
+      consumer_key: "XXXXXXXXXXXXXXXXXXXXXXXXX",
+      consumer_secret: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    };
+    var path = "/1.1/help/configuration.json";
+    var params = {"lang": "en"};
+    var oauthClient = new OAuth(options);
+    oauthClient.get(path, params).then(function(data){
+      validateCannotAuthenticateError(data, done);
+    })
+  });
+
+  it("Should fail a POST request", (done) => {
+    var options = {
+      host: "api.twitter.com", 
+      consumer_key: "XXXXXXXXXXXXXXXXXXXXXXXXX",
+      consumer_secret: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    };
+    var body = {
+      lang: "en"
+    };
+    var path = "/1.1/account/settings.json";
+
+    var oauthClient = new OAuth(options);
+    oauthClient.post(path, null, body).then(function(data){
+      validateCannotAuthenticateError(data, done);
+    })
+  });
+
+  it("Should fail a request", (done) => {
+    var options = {
+      host: "localhost", 
+      consumer_key: "XXXXXXXXXXXXXXXXXXXXXXXXX",
+      consumer_secret: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    };
+    var body = {
+      lang: "en"
+    };
+    var path = "/";
+
+    var oauthClient = new OAuth(options);
+    oauthClient.post(path, null, body).then(function(data){
+      jequal(false, true);
+      done();
+    }).catch(function(){
+      jequal(true, true);
+      done();
+    })
+  });
+
+  ["facebook", "github", "instagram", "google", "linkedin", "meetup", "twitter"].map(function(providerName){
+    it("Should validate structure of "+providerName, (done) => {
+      var provider = require("../src/oauth/"+providerName);
+      jequal(typeof provider.validateAuthData, "function");
+      jequal(typeof provider.validateAppId, "function");
+      jequal(provider.validateAuthData({}, {}).constructor, Promise.prototype.constructor); 
+      jequal(provider.validateAppId("app", "key", {}).constructor, Promise.prototype.constructor); 
+      done();
+    });
+  });
+
+  var getMockMyOauthProvider = function() {
+    return {
+      authData: {
+        id: "12345",
+        access_token: "12345",
+        expiration_date: new Date().toJSON(),
+      },
+      shouldError: false,
+      loggedOut: false,
+      synchronizedUserId: null,
+      synchronizedAuthToken: null,
+      synchronizedExpiration: null,
+
+      authenticate: function(options) {
+        if (this.shouldError) {
+          options.error(this, "An error occurred");
+        } else if (this.shouldCancel) {
+          options.error(this, null);
+        } else {
+          options.success(this, this.authData);
+        }
+      },
+      restoreAuthentication: function(authData) {
+        if (!authData) {
+          this.synchronizedUserId = null;
+          this.synchronizedAuthToken = null;
+          this.synchronizedExpiration = null;
+          return true;
+        }
+        this.synchronizedUserId = authData.id;
+        this.synchronizedAuthToken = authData.access_token;
+        this.synchronizedExpiration = authData.expiration_date;
+        return true;
+      },
+      getAuthType: function() {
+        return "myoauth";
+      },
+      deauthenticate: function() {
+        this.loggedOut = true;
+        this.restoreAuthentication(null);
+      }
+    };
+  };
+
+  var ExtendedUser = Parse.User.extend({
+    extended: function() {
+      return true;
+    }
+  });
+
+  var createOAuthUser = function(callback) {
+    var jsonBody = {
+      authData: {
+        myoauth: getMockMyOauthProvider().authData
+      }
+    };
+    var headers = {'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest', 
+          'Content-Type': 'application/json' }
+
+    var options = {
+        headers: {'X-Parse-Application-Id': 'test',
+          'X-Parse-REST-API-Key': 'rest', 
+          'Content-Type': 'application/json' },
+        url: 'http://localhost:8378/1/users',
+        body: JSON.stringify(jsonBody)
+      };
+
+    return request.post(options, callback);
+  }
+
+  it("should create user with REST API", (done) => {
+
+    createOAuthUser((error, response, body) => {
+        expect(error).toBe(null);
+        var b = JSON.parse(body);
+        expect(b.objectId).not.toBeNull();
+        expect(b.objectId).not.toBeUndefined();
+        done();
+      });
+
+  });
+
+  it("should only create a single user with REST API", (done) => {
+    var objectId;
+    createOAuthUser((error, response, body) => {
+        expect(error).toBe(null);
+        var b = JSON.parse(body);
+        expect(b.objectId).not.toBeNull();
+        expect(b.objectId).not.toBeUndefined();
+        objectId = b.objectId;
+
+        createOAuthUser((error, response, body) => {
+          expect(error).toBe(null);
+          var b = JSON.parse(body);
+          expect(b.objectId).not.toBeNull();
+          expect(b.objectId).not.toBeUndefined();
+          expect(b.objectId).toBe(objectId);
+          done();
+        });
+      });
+    
+  });
+
+  it("unlink and link with custom provider", (done) => {
+    var provider = getMockMyOauthProvider();
+    Parse.User._registerAuthenticationProvider(provider);
+    Parse.User._logInWith("myoauth", {
+      success: function(model) {
+        ok(model instanceof Parse.User, "Model should be a Parse.User");
+        strictEqual(Parse.User.current(), model);
+        ok(model.extended(), "Should have used the subclass.");
+        strictEqual(provider.authData.id, provider.synchronizedUserId);
+        strictEqual(provider.authData.access_token, provider.synchronizedAuthToken);
+        strictEqual(provider.authData.expiration_date, provider.synchronizedExpiration);
+        ok(model._isLinked("myoauth"), "User should be linked to myoauth");
+
+        model._unlinkFrom("myoauth", {
+          success: function(model) {
+            ok(!model._isLinked("myoauth"),
+               "User should not be linked to myoauth");
+            ok(!provider.synchronizedUserId, "User id should be cleared");
+            ok(!provider.synchronizedAuthToken, "Auth token should be cleared");
+            ok(!provider.synchronizedExpiration,
+               "Expiration should be cleared");
+
+            model._linkWith("myoauth", {
+              success: function(model) {
+                ok(provider.synchronizedUserId, "User id should have a value");
+                ok(provider.synchronizedAuthToken,
+                   "Auth token should have a value");
+                ok(provider.synchronizedExpiration,
+                   "Expiration should have a value");
+                ok(model._isLinked("myoauth"),
+                   "User should be linked to myoauth");
+                done();
+              },
+              error: function(model, error) {
+                ok(false, "linking again should succeed");
+                done();
+              }
+            });
+          },
+          error: function(model, error) {
+            ok(false, "unlinking should succeed");
+            done();
+          }
+        });
+      },
+      error: function(model, error) {
+        ok(false, "linking should have worked");
+        done();
+      }
+    });
+  });
+
+
+})

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -831,9 +831,11 @@ describe('Parse.User testing', () => {
   // server-side.
   var getMockFacebookProvider = function() {
     return {
-      userId: "8675309",
-      authToken: "jenny",
-      expiration: new Date().toJSON(),
+      authData: {
+        id: "8675309",
+        access_token: "jenny",
+        expiration_date: new Date().toJSON(),
+      },
       shouldError: false,
       loggedOut: false,
       synchronizedUserId: null,
@@ -846,11 +848,7 @@ describe('Parse.User testing', () => {
         } else if (this.shouldCancel) {
           options.error(this, null);
         } else {
-          options.success(this, {
-            id: this.userId,
-            access_token: this.authToken,
-            expiration_date: this.expiration
-          });
+          options.success(this, this.authData);
         }
       },
       restoreAuthentication: function(authData) {
@@ -889,13 +887,14 @@ describe('Parse.User testing', () => {
         ok(model instanceof Parse.User, "Model should be a Parse.User");
         strictEqual(Parse.User.current(), model);
         ok(model.extended(), "Should have used subclass.");
-        strictEqual(provider.userId, provider.synchronizedUserId);
-        strictEqual(provider.authToken, provider.synchronizedAuthToken);
-        strictEqual(provider.expiration, provider.synchronizedExpiration);
+        strictEqual(provider.authData.id, provider.synchronizedUserId);
+        strictEqual(provider.authData.access_token, provider.synchronizedAuthToken);
+        strictEqual(provider.authData.expiration_date, provider.synchronizedExpiration);
         ok(model._isLinked("facebook"), "User should be linked to facebook");
         done();
       },
       error: function(model, error) {
+        console.error(model, error);
         ok(false, "linking should have worked");
         done();
       }
@@ -910,9 +909,9 @@ describe('Parse.User testing', () => {
         ok(model instanceof Parse.User, "Model should be a Parse.User");
         strictEqual(Parse.User.current(), model);
         ok(model.extended(), "Should have used the subclass.");
-        strictEqual(provider.userId, provider.synchronizedUserId);
-        strictEqual(provider.authToken, provider.synchronizedAuthToken);
-        strictEqual(provider.expiration, provider.synchronizedExpiration);
+        strictEqual(provider.authData.id, provider.synchronizedUserId);
+        strictEqual(provider.authData.access_token, provider.synchronizedAuthToken);
+        strictEqual(provider.authData.expiration_date, provider.synchronizedExpiration);
         ok(model._isLinked("facebook"), "User should be linked to facebook");
 
         Parse.User.logOut();
@@ -925,20 +924,22 @@ describe('Parse.User testing', () => {
                "Model should be a Parse.User");
             ok(innerModel === Parse.User.current(),
                "Returned model should be the current user");
-            ok(provider.userId === provider.synchronizedUserId);
-            ok(provider.authToken === provider.synchronizedAuthToken);
+            ok(provider.authData.id === provider.synchronizedUserId);
+            ok(provider.authData.access_token === provider.synchronizedAuthToken);
             ok(innerModel._isLinked("facebook"),
                "User should be linked to facebook");
             ok(innerModel.existed(), "User should not be newly-created");
             done();
           },
           error: function(model, error) {
+            fail(error);
             ok(false, "LogIn should have worked");
             done();
           }
         });
       },
       error: function(model, error) {
+        console.error(model, error);
         ok(false, "LogIn should have worked");
         done();
       }
@@ -987,9 +988,9 @@ describe('Parse.User testing', () => {
           success: function(model) {
             ok(model instanceof Parse.User, "Model should be a Parse.User");
             strictEqual(Parse.User.current(), model);
-            strictEqual(provider.userId, provider.synchronizedUserId);
-            strictEqual(provider.authToken, provider.synchronizedAuthToken);
-            strictEqual(provider.expiration, provider.synchronizedExpiration);
+            strictEqual(provider.authData.id, provider.synchronizedUserId);
+            strictEqual(provider.authData.access_token, provider.synchronizedAuthToken);
+            strictEqual(provider.authData.expiration_date, provider.synchronizedExpiration);
             ok(model._isLinked("facebook"), "User should be linked");
             done();
           },
@@ -1020,9 +1021,9 @@ describe('Parse.User testing', () => {
           success: function(model) {
             ok(model instanceof Parse.User, "Model should be a Parse.User");
             strictEqual(Parse.User.current(), model);
-            strictEqual(provider.userId, provider.synchronizedUserId);
-            strictEqual(provider.authToken, provider.synchronizedAuthToken);
-            strictEqual(provider.expiration, provider.synchronizedExpiration);
+            strictEqual(provider.authData.id, provider.synchronizedUserId);
+            strictEqual(provider.authData.access_token, provider.synchronizedAuthToken);
+            strictEqual(provider.authData.expiration_date, provider.synchronizedExpiration);
             ok(model._isLinked("facebook"), "User should be linked.");
             var user2 = new Parse.User();
             user2.set("username", "testLinkWithProviderToAlreadyLinkedUser2");
@@ -1123,9 +1124,9 @@ describe('Parse.User testing', () => {
         ok(model instanceof Parse.User, "Model should be a Parse.User.");
         strictEqual(Parse.User.current(), model);
         ok(model.extended(), "Should have used the subclass.");
-        strictEqual(provider.userId, provider.synchronizedUserId);
-        strictEqual(provider.authToken, provider.synchronizedAuthToken);
-        strictEqual(provider.expiration, provider.synchronizedExpiration);
+        strictEqual(provider.authData.id, provider.synchronizedUserId);
+        strictEqual(provider.authData.access_token, provider.synchronizedAuthToken);
+        strictEqual(provider.authData.expiration_date, provider.synchronizedExpiration);
         ok(model._isLinked("facebook"), "User should be linked to facebook.");
 
         model._unlinkFrom("facebook", {
@@ -1159,9 +1160,9 @@ describe('Parse.User testing', () => {
         ok(model instanceof Parse.User, "Model should be a Parse.User");
         strictEqual(Parse.User.current(), model);
         ok(model.extended(), "Should have used the subclass.");
-        strictEqual(provider.userId, provider.synchronizedUserId);
-        strictEqual(provider.authToken, provider.synchronizedAuthToken);
-        strictEqual(provider.expiration, provider.synchronizedExpiration);
+        strictEqual(provider.authData.id, provider.synchronizedUserId);
+        strictEqual(provider.authData.access_token, provider.synchronizedAuthToken);
+        strictEqual(provider.authData.expiration_date, provider.synchronizedExpiration);
         ok(model._isLinked("facebook"), "User should be linked to facebook");
 
         model._unlinkFrom("facebook", {

--- a/spec/myoauth.js
+++ b/spec/myoauth.js
@@ -1,0 +1,17 @@
+// Custom oauth provider by module
+
+// Returns a promise that fulfills iff this user id is valid.
+function validateAuthData(authData) {
+  if (authData.id == "12345" && authData.access_token == "12345") {
+    return Promise.resolve();
+  }
+  return Promise.reject();
+}
+function validateAppId() {
+  return Promise.resolve();
+}
+
+module.exports = {
+  validateAppId: validateAppId,
+  validateAuthData: validateAuthData
+};

--- a/src/Config.js
+++ b/src/Config.js
@@ -25,6 +25,7 @@ function Config(applicationId, mount) {
   this.database = DatabaseAdapter.getDatabaseConnection(applicationId);
   this.filesController = cacheInfo.filesController;
 
+  this.oauth = cacheInfo.oauth;
   this.mount = mount;
 }
 

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -9,7 +9,7 @@ var cache = require('./cache');
 var Config = require('./Config');
 var cryptoUtils = require('./cryptoUtils');
 var passwordCrypto = require('./password');
-var facebook = require('./facebook');
+var oauth = require("./oauth");
 var Parse = require('parse/node');
 var triggers = require('./triggers');
 
@@ -147,19 +147,26 @@ RestWrite.prototype.validateAuthData = function() {
     return;
   }
 
-  var facebookData = this.data.authData.facebook;
+  var authData = this.data.authData;
   var anonData = this.data.authData.anonymous;
-
+  
   if (this.config.enableAnonymousUsers === true && (anonData === null ||
     (anonData && anonData.id))) {
     return this.handleAnonymousAuthData();
-  } else if (facebookData === null ||
-    (facebookData && facebookData.id && facebookData.access_token)) {
-    return this.handleFacebookAuthData();
-  } else {
-    throw new Parse.Error(Parse.Error.UNSUPPORTED_SERVICE,
-                          'This authentication method is unsupported.');
+  } 
+
+  // Not anon, try other providers
+  var providers = Object.keys(authData);
+  if (!anonData && providers.length == 1) {
+    var provider = providers[0];
+    var providerAuthData = authData[provider];
+    var hasToken = (providerAuthData && providerAuthData.id);
+    if (providerAuthData === null || hasToken) {
+      return this.handleOAuthAuthData(provider);
+    }
   }
+  throw new Parse.Error(Parse.Error.UNSUPPORTED_SERVICE,
+                          'This authentication method is unsupported.');
 };
 
 RestWrite.prototype.handleAnonymousAuthData = function() {
@@ -208,27 +215,71 @@ RestWrite.prototype.handleAnonymousAuthData = function() {
 
 };
 
-RestWrite.prototype.handleFacebookAuthData = function() {
-  var facebookData = this.data.authData.facebook;
-  if (facebookData === null && this.query) {
-    // We are unlinking from Facebook.
-    this.data._auth_data_facebook = null;
+RestWrite.prototype.handleOAuthAuthData = function(provider) {
+  var authData = this.data.authData[provider];
+
+  if (authData === null && this.query) {
+    // We are unlinking from the provider.
+    this.data["_auth_data_" + provider ] = null;
     return;
   }
 
-  return facebook.validateUserId(facebookData.id,
-                                 facebookData.access_token)
+  var appIds;
+  var oauthOptions = this.config.oauth[provider];
+  if (oauthOptions) {
+    appIds = oauthOptions.appIds;
+  } else if (provider == "facebook") {
+    appIds = this.config.facebookAppIds;
+  }
+
+  var validateAuthData;
+  var validateAppId;
+
+
+  if (oauth[provider]) {
+    validateAuthData = oauth[provider].validateAuthData;
+    validateAppId = oauth[provider].validateAppId;
+  }
+
+  // Try the configuration methods
+  if (oauthOptions) {
+    if (oauthOptions.module) {
+      validateAuthData = require(oauthOptions.module).validateAuthData;
+      validateAppId = require(oauthOptions.module).validateAppId;
+    };
+
+    if (oauthOptions.validateAuthData) {
+      validateAuthData = oauthOptions.validateAuthData;
+    }
+    if (oauthOptions.validateAppId) {
+      validateAppId = oauthOptions.validateAppId;
+    }
+  }
+  // try the custom provider first, fallback on the oauth implementation
+
+  if (!validateAuthData || !validateAppId) {
+    return false;
+  };
+
+  return validateAuthData(authData, oauthOptions)
     .then(() => {
-      return facebook.validateAppId(this.config.facebookAppIds,
-                                    facebookData.access_token);
+      if (appIds && typeof validateAppId === "function") {
+        return validateAppId(appIds, authData, oauthOptions);
+      }
+
+      // No validation required by the developer
+      return Promise.resolve();
+
     }).then(() => {
       // Check if this user already exists
       // TODO: does this handle re-linking correctly?
+      var query = {};
+      query['authData.' + provider + '.id'] = authData.id;
       return this.config.database.find(
         this.className,
-        {'authData.facebook.id': facebookData.id}, {});
+        query, {});
     }).then((results) => {
-      this.storage['authProvider'] = "facebook";
+      this.storage['authProvider'] = provider;
       if (results.length > 0) {
         if (!this.query) {
           // We're signing up, but this user already exists. Short-circuit
@@ -247,7 +298,7 @@ RestWrite.prototype.handleFacebookAuthData = function() {
           delete this.data.authData;
           return;
         }
-        // We're trying to create a duplicate FB auth. Forbid it
+        // We're trying to create a duplicate oauth auth. Forbid it
         throw new Parse.Error(Parse.Error.ACCOUNT_ALREADY_LINKED,
                               'this auth is already used');
       } else {
@@ -256,12 +307,12 @@ RestWrite.prototype.handleFacebookAuthData = function() {
 
       // This FB auth does not already exist, so transform it to a
       // saveable format
-      this.data._auth_data_facebook = facebookData;
+      this.data["_auth_data_" + provider ] = authData;
 
       // Delete the rest format key before saving
       delete this.data.authData;
     });
-};
+}
 
 // The non-third-party parts of User transformation
 RestWrite.prototype.transformUser = function() {

--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,8 @@ function ParseServer(args) {
     fileKey: args.fileKey || 'invalid-file-key',
     facebookAppIds: args.facebookAppIds || [],
     filesController: filesController,
-    enableAnonymousUsers: args.enableAnonymousUsers || true
+    enableAnonymousUsers: args.enableAnonymousUsers || true,
+    oauth: args.oauth || {},
   };
 
   // To maintain compatibility. TODO: Remove in v2.1

--- a/src/oauth/OAuth1Client.js
+++ b/src/oauth/OAuth1Client.js
@@ -1,0 +1,226 @@
+var https = require('https'),
+  crypto = require('crypto');
+
+var OAuth = function(options) {
+  this.consumer_key = options.consumer_key;
+  this.consumer_secret = options.consumer_secret;
+  this.auth_token = options.auth_token;
+  this.auth_token_secret = options.auth_token_secret;
+  this.host = options.host;
+  this.oauth_params = options.oauth_params || {};
+};
+
+OAuth.prototype.send = function(method, path, params, body){
+
+  var request = this.buildRequest(method, path, params, body);
+  // Encode the body properly, the current Parse Implementation don't do it properly
+  return new Promise(function(resolve, reject) {
+    var httpRequest = https.request(request, function(res) {
+      var data = '';
+      res.on('data', function(chunk) {
+        data += chunk;
+      });
+      res.on('end', function() {
+        data = JSON.parse(data);
+        resolve(data);
+      });
+    }).on('error', function(e) {
+      reject('Failed to make an OAuth request');
+    });
+    if (request.body) {
+    	httpRequest.write(request.body);
+    }
+    httpRequest.end();
+  });
+};
+
+OAuth.prototype.buildRequest = function(method, path, params, body) {
+  if (path.indexOf("/") != 0) {
+    path = "/"+path;
+  }
+  if (params && Object.keys(params).length > 0) {
+    path += "?" + OAuth.buildParameterString(params);
+  }
+
+  var request = {
+    host:   this.host,
+    path: 	path,
+    method: method.toUpperCase()
+  };
+
+  var oauth_params = this.oauth_params || {};
+  oauth_params.oauth_consumer_key = this.consumer_key;
+  if(this.auth_token){
+    oauth_params["oauth_token"] = this.auth_token;
+  }
+
+  request = OAuth.signRequest(request, oauth_params, this.consumer_secret,  this.auth_token_secret);
+
+  if (body && Object.keys(body).length > 0) {
+    request.body = OAuth.buildParameterString(body);
+  }
+  return request;
+}
+
+OAuth.prototype.get = function(path, params) {
+	return this.send("GET", path, params);
+}
+
+OAuth.prototype.post = function(path, params, body) {
+	return this.send("POST", path, params, body);
+}
+
+/*
+	Proper string %escape encoding
+*/
+OAuth.encode = function(str) {
+  //       discuss at: http://phpjs.org/functions/rawurlencode/
+  //      original by: Brett Zamir (http://brett-zamir.me)
+  //         input by: travc
+  //         input by: Brett Zamir (http://brett-zamir.me)
+  //         input by: Michael Grier
+  //         input by: Ratheous
+  //      bugfixed by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
+  //      bugfixed by: Brett Zamir (http://brett-zamir.me)
+  //      bugfixed by: Joris
+  // reimplemented by: Brett Zamir (http://brett-zamir.me)
+  // reimplemented by: Brett Zamir (http://brett-zamir.me)
+  //             note: This reflects PHP 5.3/6.0+ behavior
+  //             note: Please be aware that this function expects to encode into UTF-8 encoded strings, as found on
+  //             note: pages served as UTF-8
+  //        example 1: rawurlencode('Kevin van Zonneveld!');
+  //        returns 1: 'Kevin%20van%20Zonneveld%21'
+  //        example 2: rawurlencode('http://kevin.vanzonneveld.net/');
+  //        returns 2: 'http%3A%2F%2Fkevin.vanzonneveld.net%2F'
+  //        example 3: rawurlencode('http://www.google.nl/search?q=php.js&ie=utf-8&oe=utf-8&aq=t&rls=com.ubuntu:en-US:unofficial&client=firefox-a');
+  //        returns 3: 'http%3A%2F%2Fwww.google.nl%2Fsearch%3Fq%3Dphp.js%26ie%3Dutf-8%26oe%3Dutf-8%26aq%3Dt%26rls%3Dcom.ubuntu%3Aen-US%3Aunofficial%26client%3Dfirefox-a'
+
+  str = (str + '')
+    .toString();
+
+  // Tilde should be allowed unescaped in future versions of PHP (as reflected below), but if you want to reflect current
+  // PHP behavior, you would need to add ".replace(/~/g, '%7E');" to the following.
+  return encodeURIComponent(str)
+    .replace(/!/g, '%21')
+    .replace(/'/g, '%27')
+    .replace(/\(/g, '%28')
+    .replace(/\)/g, '%29')
+    .replace(/\*/g, '%2A');
+}
+
+OAuth.signatureMethod = "HMAC-SHA1";
+OAuth.version = "1.0";
+
+/*
+	Generate a nonce
+*/
+OAuth.nonce = function(){
+    var text = "";
+    var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    for( var i=0; i < 30; i++ )
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+
+    return text;
+}
+
+OAuth.buildParameterString = function(obj){
+	var result = {};
+
+	// Sort keys and encode values
+	if (obj) {
+		var keys = Object.keys(obj).sort();
+
+		// Map key=value, join them by &
+		return keys.map(function(key){
+			return key + "=" + OAuth.encode(obj[key]);
+		}).join("&");
+	}
+
+	return "";
+}
+
+/*
+	Build the signature string from the object
+*/
+
+OAuth.buildSignatureString = function(method, url, parameters){
+	return [method.toUpperCase(), OAuth.encode(url), OAuth.encode(parameters)].join("&");
+}
+
+/*
+	Retuns encoded HMAC-SHA1 from key and text
+*/
+OAuth.signature = function(text, key){
+	crypto = require("crypto");
+	return OAuth.encode(crypto.createHmac('sha1', key).update(text).digest('base64'));
+}
+
+OAuth.signRequest = function(request, oauth_parameters, consumer_secret, auth_token_secret){
+	oauth_parameters = oauth_parameters || {};
+
+	// Set default values
+	if (!oauth_parameters.oauth_nonce) {
+		oauth_parameters.oauth_nonce = OAuth.nonce();
+	}
+	if (!oauth_parameters.oauth_timestamp) {
+		oauth_parameters.oauth_timestamp = Math.floor(new Date().getTime()/1000);
+	}
+	if (!oauth_parameters.oauth_signature_method) {
+		oauth_parameters.oauth_signature_method = OAuth.signatureMethod;
+	}
+	if (!oauth_parameters.oauth_version) {
+		oauth_parameters.oauth_version = OAuth.version;
+	}
+
+	if(!auth_token_secret){
+		auth_token_secret="";
+	}
+	// Force GET method if unset
+	if (!request.method) {
+		request.method = "GET"
+	}
+
+	// Collect  all the parameters in one signatureParameters object
+	var signatureParams = {};
+	var parametersToMerge = [request.params, request.body, oauth_parameters];
+	for(var i in parametersToMerge) {
+		var parameters = parametersToMerge[i];
+		for(var k in parameters) {
+			signatureParams[k] = parameters[k];
+		}
+	}
+
+	// Create a string based on the parameters
+	var parameterString = OAuth.buildParameterString(signatureParams);
+
+	// Build the signature string
+	var url = "https://"+request.host+""+request.path;
+
+	var signatureString = OAuth.buildSignatureString(request.method, url, parameterString);
+	// Hash the signature string
+	var signatureKey = [OAuth.encode(consumer_secret), OAuth.encode(auth_token_secret)].join("&");
+
+	var signature = OAuth.signature(signatureString, signatureKey);
+
+	// Set the signature in the params
+	oauth_parameters.oauth_signature = signature;
+	if(!request.headers){
+		request.headers = {};
+	}
+
+	// Set the authorization header
+	var signature = Object.keys(oauth_parameters).sort().map(function(key){
+		var value = oauth_parameters[key];
+		return key+'="'+value+'"';
+	}).join(", ")
+
+	request.headers.Authorization = 'OAuth ' + signature;
+
+	// Set the content type header
+	request.headers["Content-Type"] = "application/x-www-form-urlencoded";
+	return request;
+
+}
+
+module.exports = OAuth;

--- a/src/oauth/facebook.js
+++ b/src/oauth/facebook.js
@@ -16,8 +16,7 @@ function validateAuthData(authData) {
 }
 
 // Returns a promise that fulfills iff this app id is valid.
-function validateAppId(appIds, authData) {
-  var access_token = authData.access_token;
+function validateAppId(appIds, access_token) {
   if (!appIds.length) {
     throw new Parse.Error(
       Parse.Error.OBJECT_NOT_FOUND,

--- a/src/oauth/github.js
+++ b/src/oauth/github.js
@@ -1,0 +1,51 @@
+// Helper functions for accessing the github API.
+var https = require('https');
+var Parse = require('parse/node').Parse;
+
+// Returns a promise that fulfills iff this user id is valid.
+function validateAuthData(authData) {
+  return request('user', authData.access_token)
+    .then((data) => {
+      if (data && data.id == authData.id) {
+        return;
+      }
+      throw new Parse.Error(
+        Parse.Error.OBJECT_NOT_FOUND,
+        'Github auth is invalid for this user.');
+    });
+}
+
+// Returns a promise that fulfills iff this app id is valid.
+function validateAppId() {
+  return Promise.resolve();
+}
+
+// A promisey wrapper for api requests
+function request(path, access_token) {
+  return new Promise(function(resolve, reject) {
+    https.get({
+      host: 'api.github.com',
+      path: '/' + path,
+      headers: {
+        'Authorization': 'bearer '+access_token,
+        'User-Agent': 'parse-server'
+      }
+    }, function(res) {
+      var data = '';
+      res.on('data', function(chunk) {
+        data += chunk;
+      });
+      res.on('end', function() {
+        data = JSON.parse(data);
+        resolve(data);
+      });
+    }).on('error', function(e) {
+      reject('Failed to validate this access token with Github.');
+    });
+  });
+}
+
+module.exports = {
+  validateAppId: validateAppId,
+  validateAuthData: validateAuthData
+};

--- a/src/oauth/google.js
+++ b/src/oauth/google.js
@@ -1,0 +1,44 @@
+// Helper functions for accessing the google API.
+var https = require('https');
+var Parse = require('parse/node').Parse;
+
+// Returns a promise that fulfills iff this user id is valid.
+function validateAuthData(authData) {
+  return request("tokeninfo?access_token="+authData.access_token)
+    .then((response) => {
+      if (response && response.user_id == authData.id) {
+        return;
+      }
+      throw new Parse.Error(
+        Parse.Error.OBJECT_NOT_FOUND,
+        'Google auth is invalid for this user.');
+    });
+}
+
+// Returns a promise that fulfills iff this app id is valid.
+function validateAppId() {
+  return Promise.resolve();
+}
+
+// A promisey wrapper for api requests
+function request(path) {
+  return new Promise(function(resolve, reject) {
+    https.get("https://www.googleapis.com/oauth2/v1/" + path, function(res) {
+      var data = '';
+      res.on('data', function(chunk) {
+        data += chunk;
+      });
+      res.on('end', function() {
+        data = JSON.parse(data);
+        resolve(data);
+      });
+    }).on('error', function(e) {
+      reject('Failed to validate this access token with Google.');
+    });
+  });
+}
+
+module.exports = {
+  validateAppId: validateAppId,
+  validateAuthData: validateAuthData
+};

--- a/src/oauth/index.js
+++ b/src/oauth/index.js
@@ -1,0 +1,17 @@
+var facebook = require('./facebook');
+var instagram = require("./instagram");
+var linkedin = require("./linkedin");
+var meetup = require("./meetup");
+var google = require("./google");
+var github = require("./github");
+var twitter = require("./twitter");
+
+module.exports = {
+	facebook: facebook,
+	github: github,
+	google: google,
+	instagram: instagram,
+	linkedin: linkedin, 
+	meetup: meetup,
+	twitter: twitter
+}

--- a/src/oauth/instagram.js
+++ b/src/oauth/instagram.js
@@ -1,0 +1,44 @@
+// Helper functions for accessing the instagram API.
+var https = require('https');
+var Parse = require('parse/node').Parse;
+
+// Returns a promise that fulfills iff this user id is valid.
+function validateAuthData(authData) {
+  return request("users/self/?access_token="+authData.access_token)
+    .then((response) => {
+      if (response && response.data && response.data.id == authData.id) {
+        return;
+      }
+      throw new Parse.Error(
+        Parse.Error.OBJECT_NOT_FOUND,
+        'Instagram auth is invalid for this user.');
+    });
+}
+
+// Returns a promise that fulfills iff this app id is valid.
+function validateAppId() {
+  return Promise.resolve();
+}
+
+// A promisey wrapper for api requests
+function request(path) {
+  return new Promise(function(resolve, reject) {
+    https.get("https://api.instagram.com/v1/" + path, function(res) {
+      var data = '';
+      res.on('data', function(chunk) {
+        data += chunk;
+      });
+      res.on('end', function() {
+        data = JSON.parse(data);
+        resolve(data);
+      });
+    }).on('error', function(e) {
+      reject('Failed to validate this access token with Instagram.');
+    });
+  });
+}
+
+module.exports = {
+  validateAppId: validateAppId,
+  validateAuthData: validateAuthData
+};

--- a/src/oauth/linkedin.js
+++ b/src/oauth/linkedin.js
@@ -1,0 +1,51 @@
+// Helper functions for accessing the linkedin API.
+var https = require('https');
+var Parse = require('parse/node').Parse;
+
+// Returns a promise that fulfills iff this user id is valid.
+function validateAuthData(authData) {
+  return request('people/~:(id)', authData.access_token)
+    .then((data) => {
+      if (data && data.id == authData.id) {
+        return;
+      }
+      throw new Parse.Error(
+        Parse.Error.OBJECT_NOT_FOUND,
+        'Meetup auth is invalid for this user.');
+    });
+}
+
+// Returns a promise that fulfills iff this app id is valid.
+function validateAppId() {
+  return Promise.resolve();
+}
+
+// A promisey wrapper for api requests
+function request(path, access_token) {
+  return new Promise(function(resolve, reject) {
+    https.get({
+      host: 'api.linkedin.com',
+      path: '/v1/' + path,
+      headers: {
+        'Authorization': 'Bearer '+access_token,
+        'x-li-format': 'json'
+      }
+    }, function(res) {
+      var data = '';
+      res.on('data', function(chunk) {
+        data += chunk;
+      });
+      res.on('end', function() {
+        data = JSON.parse(data);
+        resolve(data);
+      });
+    }).on('error', function(e) {
+      reject('Failed to validate this access token with Linkedin.');
+    });
+  });
+}
+
+module.exports = {
+  validateAppId: validateAppId,
+  validateAuthData: validateAuthData
+};

--- a/src/oauth/meetup.js
+++ b/src/oauth/meetup.js
@@ -1,0 +1,50 @@
+// Helper functions for accessing the meetup API.
+var https = require('https');
+var Parse = require('parse/node').Parse;
+
+// Returns a promise that fulfills iff this user id is valid.
+function validateAuthData(authData) {
+  return request('member/self', authData.access_token)
+    .then((data) => {
+      if (data && data.id == authData.id) {
+        return;
+      }
+      throw new Parse.Error(
+        Parse.Error.OBJECT_NOT_FOUND,
+        'Meetup auth is invalid for this user.');
+    });
+}
+
+// Returns a promise that fulfills iff this app id is valid.
+function validateAppId() {
+  return Promise.resolve();
+}
+
+// A promisey wrapper for api requests
+function request(path, access_token) {
+  return new Promise(function(resolve, reject) {
+    https.get({
+      host: 'api.meetup.com',
+      path: '/2/' + path,
+      headers: {
+        'Authorization': 'bearer '+access_token
+      }
+    }, function(res) {
+      var data = '';
+      res.on('data', function(chunk) {
+        data += chunk;
+      });
+      res.on('end', function() {
+        data = JSON.parse(data);
+        resolve(data);
+      });
+    }).on('error', function(e) {
+      reject('Failed to validate this access token with Meetup.');
+    });
+  });
+}
+
+module.exports = {
+  validateAppId: validateAppId,
+  validateAuthData: validateAuthData
+};

--- a/src/oauth/twitter.js
+++ b/src/oauth/twitter.js
@@ -1,0 +1,30 @@
+// Helper functions for accessing the meetup API.
+var OAuth = require('./OAuth1Client');
+var Parse = require('parse/node').Parse;
+
+// Returns a promise that fulfills iff this user id is valid.
+function validateAuthData(authData, options) {
+  var client = new OAuth(options);
+  client.host = "api.twitter.com";
+  client.auth_token = authData.auth_token;
+  client.auth_token_secret = authData.auth_token_secret;
+  
+  return client.get("/1.1/account/verify_credentials.json").then((data) => {
+    if (data && data.id == authData.id) {
+      return;
+    }
+    throw new Parse.Error(
+      Parse.Error.OBJECT_NOT_FOUND,
+      'Twitter auth is invalid for this user.');
+  });
+}
+
+// Returns a promise that fulfills iff this app id is valid.
+function validateAppId() {
+  return Promise.resolve();
+}
+
+module.exports = {
+  validateAppId: validateAppId,
+  validateAuthData: validateAuthData
+};

--- a/src/transform.js
+++ b/src/transform.js
@@ -55,21 +55,6 @@ export function transformKeyValue(schema, className, restKey, restValue, options
   case '_wperm':
     return {key: key, value: restValue};
     break;
-  // case 'authData.anonymous.id':
-  //   if (options.query) {
-  //     return {key: '_auth_data_anonymous.id', value: restValue};
-  //   }
-  //   throw new Parse.Error(Parse.Error.INVALID_KEY_NAME,
-  //                         'can only query on ' + key);
-  //   break;
-  // case 'authData.facebook.id':
-  //   if (options.query) {
-  //     // Special-case auth data.
-  //     return {key: '_auth_data_facebook.id', value: restValue};
-  //   }
-  //   throw new Parse.Error(Parse.Error.INVALID_KEY_NAME,
-  //                         'can only query on ' + key);
-  //   break;
   case '$or':
     if (!options.query) {
       throw new Parse.Error(Parse.Error.INVALID_KEY_NAME,

--- a/src/transform.js
+++ b/src/transform.js
@@ -55,21 +55,21 @@ export function transformKeyValue(schema, className, restKey, restValue, options
   case '_wperm':
     return {key: key, value: restValue};
     break;
-  case 'authData.anonymous.id':
-    if (options.query) {
-      return {key: '_auth_data_anonymous.id', value: restValue};
-    }
-    throw new Parse.Error(Parse.Error.INVALID_KEY_NAME,
-                          'can only query on ' + key);
-    break;
-  case 'authData.facebook.id':
-    if (options.query) {
-      // Special-case auth data.
-      return {key: '_auth_data_facebook.id', value: restValue};
-    }
-    throw new Parse.Error(Parse.Error.INVALID_KEY_NAME,
-                          'can only query on ' + key);
-    break;
+  // case 'authData.anonymous.id':
+  //   if (options.query) {
+  //     return {key: '_auth_data_anonymous.id', value: restValue};
+  //   }
+  //   throw new Parse.Error(Parse.Error.INVALID_KEY_NAME,
+  //                         'can only query on ' + key);
+  //   break;
+  // case 'authData.facebook.id':
+  //   if (options.query) {
+  //     // Special-case auth data.
+  //     return {key: '_auth_data_facebook.id', value: restValue};
+  //   }
+  //   throw new Parse.Error(Parse.Error.INVALID_KEY_NAME,
+  //                         'can only query on ' + key);
+  //   break;
   case '$or':
     if (!options.query) {
       throw new Parse.Error(Parse.Error.INVALID_KEY_NAME,
@@ -97,6 +97,18 @@ export function transformKeyValue(schema, className, restKey, restValue, options
     });
     return {key: '$and', value: mongoSubqueries};
   default:
+    // Other auth data
+    var authDataMatch = key.match(/^authData\.([a-zA-Z0-9_]+)\.id$/);
+    if (authDataMatch) {
+      if (options.query) {
+        var provider = authDataMatch[1];
+        // Special-case auth data.
+        return {key: '_auth_data_'+provider+'.id', value: restValue};
+      }
+      throw new Parse.Error(Parse.Error.INVALID_KEY_NAME,
+                            'can only query on ' + key);
+      break;
+    };
     if (options.validate && !key.match(/^[a-zA-Z][a-zA-Z0-9_\.]*$/)) {
       throw new Parse.Error(Parse.Error.INVALID_KEY_NAME,
                             'invalid key name: ' + key);
@@ -646,15 +658,16 @@ function untransformObject(schema, className, mongoObject) {
       case '_expiresAt':
         restObject['expiresAt'] = Parse._encode(new Date(mongoObject[key])).iso;
         break;
-      case '_auth_data_anonymous':
-        restObject['authData'] = restObject['authData'] || {};
-        restObject['authData']['anonymous'] = mongoObject[key];
-        break;
-      case '_auth_data_facebook':
-        restObject['authData'] = restObject['authData'] || {};
-        restObject['authData']['facebook'] = mongoObject[key];
-        break;
       default:
+        // Check other auth data keys
+        var authDataMatch = key.match(/^_auth_data_([a-zA-Z0-9_]+)$/);
+        if (authDataMatch) {
+          var provider = authDataMatch[1];
+          restObject['authData'] = restObject['authData'] || {};
+          restObject['authData'][provider] = mongoObject[key];
+          break;
+        }
+        
         if (key.indexOf('_p_') == 0) {
           var newKey = key.substring(3);
           var expected;


### PR DESCRIPTION
Proposed fix for #241  and #40 
 
Adds additional OAuth providers, may need a refactor to reduct the boilerplate request code.

No coverage of the network request, needs to be tested against real keys and tokens unfortunately.

Because Facebook auth validation is refactored, the methodology should work for all other providers.