### PR TITLE
Correct Could Functions response encoding

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -28,7 +28,7 @@ function createResponseObject(resolve, reject) {
     success: function(result) {
       resolve({
         response: {
-          result: result
+          result: Parse._encode(result)
         }
       });
     },


### PR DESCRIPTION
This will encode all ParseObject on the correct way so they can be translated into PFObject by the IOS SDK.

this resolve this bug:
https://github.com/ParsePlatform/parse-server/issues/112