### PR TITLE
Schemas endpoint: ignore '_metadata' key, convert 'map' type to Object

### DIFF
--- a/schemas.js
+++ b/schemas.js
@@ -23,6 +23,7 @@ function mongoFieldTypeToApiResponseType(type) {
     case 'string':   return {type: 'String'};
     case 'boolean':  return {type: 'Boolean'};
     case 'date':     return {type: 'Date'};
+    case 'map':
     case 'object':   return {type: 'Object'};
     case 'array':    return {type: 'Array'};
     case 'geopoint': return {type: 'GeoPoint'};
@@ -31,7 +32,7 @@ function mongoFieldTypeToApiResponseType(type) {
 }
 
 function mongoSchemaAPIResponseFields(schema) {
-  fieldNames = Object.keys(schema).filter(key => key !== '_id');
+  fieldNames = Object.keys(schema).filter(key => key !== '_id' && key !== '_metadata');
   response = {};
   fieldNames.forEach(fieldName => {
     response[fieldName] = mongoFieldTypeToApiResponseType(schema[fieldName]);


### PR DESCRIPTION
Thanks to everyone working so hard on parse-server!

Legacy Parse platform databases may have additional fields that aren't supported in the current
database-to-api-response conversion. This PR accounts for some discrepancies that appear in schemas created on the Parse platform, and newer schemas created with parse-server. For example, here's a _Role schema created on legacy Parse:

```
{
    "_id": "_Role",
    "_metadata": {
        "class_permissions": {
            "get": {
                "*": true
            },
            "find": {
                "*": true
            },
            "update": {
                "*": true
            },
            "create": {
                "*": true
            },
            "delete": {
                "*": true
            },
            "addField": {
                "*": true
            },
            "readUserFields": [],
            "writeUserFields": []
        }
    },
    "name": "string",
    "roles": "relation<_Role>",
    "users": "relation<_User>"
}
```

and here's one created with parse-server:

```
{
  "_id": "_Role",
  "ACL": "object",
  "createdAt": "string",
  "name": "string",
  "id": "string",
  "updatedAt": "string",
  "objectId": "string",
  "roles": "relation<_Role>",
  "users": "relation<_User>"
}
```

- the `_metadata` field doesn't appear in the api-response version
  of Schema. Its value (an object), crashes [the conversion function](https://github.com/ParsePlatform/parse-server/blob/master/schemas.js#L15),
  because it isn't a string, so it doesn't have a `startsWith` function.
- the 'map' type (not shown in the _Role schema) appears in legacy database representations, and seems to be the equivalent of the current `object` type. It was added to Schema in #87, but it isn't incorporated into the conversion.

There may be more exceptions that these, and it may make sense to make the conversion more robust to unexpected values, rather than just adding an exception for `_metadata`. But this seems like a sensible place to start.

No tests, because existing tests create objects using parse-server, and those objects don't have the problematic keys. I'd love to add some, but not sure what would be the best approach.