### PR TITLE
Adding link to parse-server-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Read the migration guide here: https://parse.com/docs/server/guide#migrating
 
 There is a development wiki here on GitHub: https://github.com/ParsePlatform/parse-server/wiki
 
+We also have an [example project](https://github.com/ParsePlatform/parse-server-example) using the parse-server module on Express.
+
 ---
 
 #### Basic options:


### PR DESCRIPTION
Thought it would be helpful to expose the example. It feels hidden in the docs right now.