### PR TITLE
WIP: Fix failing travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,7 @@ node_js:
 env:
   - MONGODB_VERSION=2.6.11
   - MONGODB_VERSION=3.0.8
+cache:
+  directories:
+    - $HOME/.mongodb/versions/downloads
 after_success: ./node_modules/.bin/codecov


### PR DESCRIPTION
After investigation, it seems that the small builds are not related to the downloads but the mongod subprocess failling to start at all.

Adds cached directory for faster builds.