### PR TITLE
Add support for running tests on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,14 +32,15 @@
     "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.5.1",
     "codecov": "^1.0.1",
+    "cross-env": "^1.0.7",
     "deep-diff": "^0.3.3",
     "jasmine": "^2.3.2",
     "mongodb-runner": "^3.1.15"
   },
   "scripts": {
     "build": "./node_modules/.bin/babel src/ -d lib/",
-    "pretest": "MONGODB_VERSION=${MONGODB_VERSION:=3.0.8} mongodb-runner start",
-    "test": "NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover -x **/spec/** ./node_modules/.bin/jasmine",
+    "pretest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.0.8} ./node_modules/.bin/mongodb-runner start",
+    "test": "cross-env NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover -x **/spec/** ./node_modules/.bin/jasmine",
     "posttest": "mongodb-runner stop",
     "start": "./bin/parse-server",
     "prepublish": "npm run build"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "./node_modules/.bin/babel src/ -d lib/",
     "pretest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.0.8} ./node_modules/.bin/mongodb-runner start",
-    "test": "cross-env NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node ./node_modules/babel-istanbul/lib/cli.js cover -x **/spec/** node_modules/jasmine/bin/jasmine.js",
+    "test": "cross-env NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node ./node_modules/babel-istanbul/lib/cli.js cover -x **/spec/** ./node_modules/jasmine/bin/jasmine.js",
     "posttest": "mongodb-runner stop",
     "start": "./bin/parse-server",
     "prepublish": "npm run build"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "./node_modules/.bin/babel src/ -d lib/",
     "pretest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.0.8} ./node_modules/.bin/mongodb-runner start",
-    "test": "cross-env NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover -x **/spec/** ./node_modules/.bin/jasmine",
+    "test": "cross-env NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node ./node_modules/babel-istanbul/lib/cli.js cover -x **/spec/** node_modules/jasmine/bin/jasmine.js",
     "posttest": "mongodb-runner stop",
     "start": "./bin/parse-server",
     "prepublish": "npm run build"

--- a/spec/RestCreate.spec.js
+++ b/spec/RestCreate.spec.js
@@ -57,6 +57,23 @@ describe('rest create', () => {
       });
   });
 
+	it('handles anonymous user signup', (done) => {
+		var data = {
+			authData: {
+				anonymous: {
+					id: '00000000-0000-0000-0000-000000000000'
+				}
+			}
+		};
+		rest.create(config, auth.nobody(config), '_User', data)
+			.then((r) => {
+				expect(typeof r.response.objectId).toEqual('string');
+				expect(typeof r.response.createdAt).toEqual('string');
+				expect(typeof r.response.sessionToken).toEqual('string');
+        done();
+      });
+	});
+
   it('test facebook signup and login', (done) => {
     var data = {
       authData: {

--- a/spec/RestCreate.spec.js
+++ b/spec/RestCreate.spec.js
@@ -57,23 +57,6 @@ describe('rest create', () => {
       });
   });
 
-	it('handles anonymous user signup', (done) => {
-		var data = {
-			authData: {
-				anonymous: {
-					id: '00000000-0000-0000-0000-000000000000'
-				}
-			}
-		};
-		rest.create(config, auth.nobody(config), '_User', data)
-			.then((r) => {
-				expect(typeof r.response.objectId).toEqual('string');
-				expect(typeof r.response.createdAt).toEqual('string');
-				expect(typeof r.response.sessionToken).toEqual('string');
-        done();
-      });
-	});
-
   it('test facebook signup and login', (done) => {
     var data = {
       authData: {


### PR DESCRIPTION
cross-env or similar is required for setting environment variables
js paths instead of cmd paths required on Windows

I'm not sure if we need ./node_modules/.bin/babel-node as babel-istanbul includes babel? Would like to remove if not required to simplify and slim the package down.