### PR TITLE
Force node 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ branches:
     - master
 language: node_js
 node_js:
-  - "4.1"
-  - "4.2"
+  - "4.3"
 env:
   - MONGODB_VERSION=2.6.11
   - MONGODB_VERSION=3.0.8

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prepublish": "npm run build"
   },
   "engines": {
-    "node": ">=4.1"
+    "node": ">=4.3"
   },
   "bin": {
     "parse-server": "./bin/parse-server"


### PR DESCRIPTION
Node 4.1 has a security vulnerability. Lets update our Node.

https://nodejs.org/en/blog/vulnerability/february-2016-security-releases/