### PR TITLE
Limit 100 records as default

### DIFF
--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -129,6 +129,22 @@ describe('miscellaneous', function() {
     });
   });
 
+  it('query without limit get default 100 records', function(done) {
+    var objects = [];
+    for (var i = 0; i < 150; i++) {
+      objects.push(new TestObject({name: 'name' + i}));
+    }
+    Parse.Object.saveAll(objects).then(() => {
+      return new Parse.Query(TestObject).find();
+    }).then((results) => {
+      expect(results.length).toEqual(100);
+    done();
+    }, (error) => {
+      fail(error);
+      done();
+    });
+  });
+
   it('basic saveAll', function(done) {
     var alpha = new TestObject({ letter: 'alpha' });
     var beta = new TestObject({ letter: 'beta' });

--- a/src/Routers/ClassesRouter.js
+++ b/src/Routers/ClassesRouter.js
@@ -12,6 +12,8 @@ export class ClassesRouter {
     }
     if (body.limit) {
       options.limit = Number(body.limit);
+    } else {
+      options.limit = Number(100);
     }
     if (body.order) {
       options.order = String(body.order);


### PR DESCRIPTION
Current parse platform set the default `limit` 100. 
https://parse.com/docs/rest/guide#queries-relational-queries