### PR TITLE
Support job on cloudcode

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "node-gcm": "^0.14.0",
     "parse": "^1.7.0",
     "request": "^2.65.0",
-    "winston": "^2.1.1"
+    "winston": "^2.1.1",
+    "cron": "1.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",

--- a/src/CloudCode.js
+++ b/src/CloudCode.js
@@ -1,0 +1,33 @@
+"use strict"
+var Parse = require('parse/node').Parse;
+var Cron = require('./Cron');
+var Job = require('./Job');
+
+class CloudCode {
+
+  constructor(timezone){
+    this.cron = new Cron(timezone);
+    this.job = new Job();
+  }
+	
+  putJob(name, req){
+    this.job.put(name, req);
+    return this;
+  }
+
+  addCron(name, timeFormat){
+    this.cron.addJob(timeFormat, this.job.get(name));
+    return this;
+  }
+
+  start(){
+    this.cron.on();
+  }
+
+  stop(){
+    this.cron.off();
+  }
+
+}
+
+module.exports = CloudCode;

--- a/src/Cron.js
+++ b/src/Cron.js
@@ -1,0 +1,35 @@
+"use strict"
+class Cron {
+
+  constructor(timezone){
+    this.cronJob = require('cron').CronJob;
+	  this.jobs = [];
+	  this.timezone = timezone;
+  }
+	
+  addJob(timeFormat, func){
+    var job = new this.cronJob(timeFormat, func, null, false, this.timezone);
+    this.jobs.push(job);
+    return this;
+  }
+  
+  on(){
+    for(let job of this.jobs){
+      job.start(); 
+    }
+    console.log("cron on");
+  }
+
+  off(){
+    for(let job of this.jobs){
+      job.stop(); 
+    }
+    console.log("cron off");
+  }
+
+  static getTimeFormat(min, hour, day, month, weekday){
+    return [min, hour, day, month, weekday].join(" ");
+  }
+}
+
+module.exports = Cron;

--- a/src/Job.js
+++ b/src/Job.js
@@ -1,0 +1,26 @@
+"use strict"
+var Parse = require('parse/node').Parse;
+
+class Job {
+
+  constructor(){
+    require('./cloud/main.js');
+    this.jobs = {};
+  }
+
+  put(name, req){
+    var res = {
+      success: (message) => {console.log(message)},
+      error: (message) => {console.error(message)}
+    }
+    this.jobs[name] = function(){Parse.Cloud.Functions[name](req, res);};
+    return this;
+  }
+
+  get(name){
+    return this.jobs[name];
+  }
+	
+}
+
+module.exports = Job;


### PR DESCRIPTION
Parse.com supported the cloud code as cron or job scheduler but parse-servier does not implement this feather.
https://parse.com/docs/server/guide#migrating

This patch makes parse-server support cron job.

If you has this job on cloud code

```javascript
Parse.Cloud.define('hello', function(req, res) {
  res.success('Hello world!');
});
```

write

```javascript
var CloudCode = require("../lib/CloudCode");
var cloud = new CloudCode(yourTimezone);
cloud.putJob("hello", null);
cloud.addCron("hello", "1 * * * *");
cloud.start();
```

on parse-server.
