### PR TITLE
Throw when query is encoded incorrectly

### DIFF
--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -4,6 +4,9 @@ var cache = require('../src/cache');
 var Config = require('../src/Config');
 var rest = require('../src/rest');
 
+var querystring = require('querystring');
+var request = require('request');
+
 var config = new Config('test');
 var nobody = auth.nobody(config);
 
@@ -90,6 +93,51 @@ describe('rest query', () => {
       expect(typeof results[0].fromUser.username).toEqual('string');
       done();
     }).catch((error) => { console.log(error); });
+  });
+
+  it('query with wrongly encoded parameter', (done) => {
+    rest.create(config, nobody, 'TestParameterEncode', {foo: 'bar'}
+    ).then(() => {
+      return rest.create(config, nobody,
+                         'TestParameterEncode', {foo: 'baz'});
+    }).then(() => {
+      var headers = {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest'
+      };
+      request.get({
+        headers: headers,
+        url: 'http://localhost:8378/1/classes/TestParameterEncode?'
+                         + querystring.stringify({
+                             where: '{"foo":{"$ne": "baz"}}',
+                             limit: 1
+                         }).replace('=', '%3D'),
+      }, (error, response, body) => {
+        expect(error).toBe(null);
+        var b = JSON.parse(body);
+        expect(b.code).toEqual(Parse.Error.INVALID_QUERY);
+        expect(b.error).toEqual('Improper encode of parameter');
+        done();
+      });
+    }).then(() => {
+      var headers = {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest'
+      };
+      request.get({
+        headers: headers,
+        url: 'http://localhost:8378/1/classes/TestParameterEncode?'
+                         + querystring.stringify({
+                             limit: 1
+                         }).replace('=', '%3D'),
+      }, (error, response, body) => {
+        expect(error).toBe(null);
+        var b = JSON.parse(body);
+        expect(b.code).toEqual(Parse.Error.INVALID_QUERY);
+        expect(b.error).toEqual('Improper encode of parameter');
+        done();
+      });
+    });
   });
 
 });

--- a/src/Routers/ClassesRouter.js
+++ b/src/Routers/ClassesRouter.js
@@ -2,11 +2,22 @@
 import PromiseRouter from '../PromiseRouter';
 import rest from '../rest';
 
+import url from 'url';
+
 export class ClassesRouter {
   // Returns a promise that resolves to a {response} object.
   handleFind(req) {
     let body = Object.assign(req.body, req.query);
     let options = {};
+    let allowConstraints = ['skip', 'limit', 'order', 'count', 'keys',
+      'include', 'redirectClassNameForKey', 'where'];
+
+    for (var key in body) {
+      if (allowConstraints.indexOf(key) === -1) {
+        throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Improper encode of parameter');
+      }
+    }
+
     if (body.skip) {
       options.skip = Number(body.skip);
     }


### PR DESCRIPTION
Fix for #101 #211
Since the original `req.query` did not decode correctly, curl with --data-urlencode will fail.