### PR TITLE
Fixes Parse.User.become / clears session on password change

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1607,8 +1607,29 @@ describe('Parse.User testing', () => {
       fail('Session should have been invalidated');
       done();
     }, function(err) {
-      expect(err.code).toBe(209);
+      expect(err.code).toBe(Parse.Error.INVALID_SESSION_TOKEN);
       expect(err.message).toBe('invalid session token');
+      done();
+    });
+  });
+  
+  it('test parse user become', (done) => {
+    var sessionToken = null;
+    Parse.Promise.as().then(function() {
+      return Parse.User.signUp("flessard", "folo",{'foo':1});
+    }).then(function(newUser) {
+      equal(Parse.User.current(), newUser);
+      sessionToken = newUser.getSessionToken();
+      ok(sessionToken);
+      newUser.set('foo',2);
+      return newUser.save();
+    }).then(function() {
+      return Parse.User.become(sessionToken);
+    }).then(function(newUser) {
+      equal(newUser.get('foo'), 2);
+      done();
+    }, function(e) {
+      fail('The session should still be valid');
       done();
     });
   });

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1606,7 +1606,9 @@ describe('Parse.User testing', () => {
     }).then(function(newUser) {
       fail('Session should have been invalidated');
       done();
-    }, function() {
+    }, function(err) {
+      expect(err.code).toBe(209);
+      expect(err.message).toBe('invalid session token');
       done();
     });
   });

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -306,7 +306,7 @@ RestWrite.prototype.transformUser = function() {
     if (!this.data.password) {
       return;
     }
-    if (this.query) {
+    if (this.query && !this.auth.isMaster ) {
       this.storage['clearSessions'] = true;
     }
     return passwordCrypto.hash(this.data.password).then((hashedPassword) => {

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -41,8 +41,7 @@ export class UsersRouter extends ClassesRouter {
 
   handleMe(req) {
     if (!req.info || !req.info.sessionToken) {
-      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND,
-        'Object not found.');
+      throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'invalid session token');
     }
     return rest.find(req.config, Auth.master(req.config), '_Session',
       { _session_token: req.info.sessionToken },
@@ -51,8 +50,7 @@ export class UsersRouter extends ClassesRouter {
         if (!response.results ||
           response.results.length == 0 ||
           !response.results[0].user) {
-          throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND,
-            'Object not found.');
+          throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'invalid session token');
         } else {
           let user = response.results[0].user;
           return { response: user };
@@ -145,10 +143,10 @@ export class UsersRouter extends ClassesRouter {
     let router = new PromiseRouter();
     router.route('GET', '/users', req => { return this.handleFind(req); });
     router.route('POST', '/users', req => { return this.handleCreate(req); });
+    router.route('GET', '/users/me', req => { return this.handleMe(req); });
     router.route('GET', '/users/:objectId', req => { return this.handleGet(req); });
     router.route('PUT', '/users/:objectId', req => { return this.handleUpdate(req); });
     router.route('DELETE', '/users/:objectId', req => { return this.handleDelete(req); });
-    router.route('GET', '/users/me', req => { return this.handleMe(req); });
     router.route('GET', '/login', req => { return this.handleLogIn(req); });
     router.route('POST', '/logout', req => { return this.handleLogOut(req); });
     router.route('POST', '/requestPasswordReset', () => {


### PR DESCRIPTION
- Fixes Parse.User.become not using the /users/me path
- Fixes /users/me path not being called
- Fixes error type when passing an invalid session token (Parse.Error.INVALID_SESSION_TOKEN)

Superseds #403 