### PR TITLE
Adds ability to disable anonymous users

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The client keys used with Parse are no longer necessary with parse-server.  If y
 * filesAdapter - The default behavior (GridStore) can be changed by creating an adapter class (see [`FilesAdapter.js`](https://github.com/ParsePlatform/parse-server/blob/master/src/Adapters/Files/FilesAdapter.js))
 * databaseAdapter (unfinished) - The backing store can be changed by creating an adapter class (see `DatabaseAdapter.js`)
 * loggerAdapter - The default behavior/transport (File) can be changed by creating an adapter class (see [`LoggerAdapter.js`](https://github.com/ParsePlatform/parse-server/blob/master/src/Adapters/Logger/LoggerAdapter.js))
-
+* enableAnonymousUsers - Defaults to true. Set to false to disable anonymous users.
 ---
 
 ### Usage

--- a/spec/RestCreate.spec.js
+++ b/spec/RestCreate.spec.js
@@ -100,6 +100,25 @@ describe('rest create', () => {
         done();
       });
   });
+  
+  it('handles no anonymous users config', (done) => {
+     var NoAnnonConfig = Object.assign({}, config, {enableAnonymousUsers: false});
+     var data1 = {
+      authData: {
+        anonymous: {
+          id: '00000000-0000-0000-0000-000000000001'
+        }
+      }
+    };
+    rest.create(NoAnnonConfig, auth.nobody(NoAnnonConfig), '_User', data1).then(() => {
+      fail("Should throw an error");
+      done();
+    }, (err) => {
+      expect(err.code).toEqual(Parse.Error.UNSUPPORTED_SERVICE);
+      expect(err.message).toEqual('This authentication method is unsupported.');
+      done();
+    })
+  });
 
   it('test facebook signup and login', (done) => {
     var data = {

--- a/src/Config.js
+++ b/src/Config.js
@@ -20,6 +20,7 @@ function Config(applicationId, mount) {
   this.restAPIKey = cacheInfo.restAPIKey;
   this.fileKey = cacheInfo.fileKey;
   this.facebookAppIds = cacheInfo.facebookAppIds;
+  this.enableAnonymousUsers = cacheInfo.enableAnonymousUsers;
 
   this.database = DatabaseAdapter.getDatabaseConnection(applicationId);
   this.filesController = cacheInfo.filesController;

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -150,8 +150,8 @@ RestWrite.prototype.validateAuthData = function() {
   var facebookData = this.data.authData.facebook;
   var anonData = this.data.authData.anonymous;
 
-  if (anonData === null ||
-    (anonData && anonData.id)) {
+  if (this.config.enableAnonymousUsers === true && (anonData === null ||
+    (anonData && anonData.id))) {
     return this.handleAnonymousAuthData();
   } else if (facebookData === null ||
     (facebookData && facebookData.id && facebookData.access_token)) {

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,8 @@ function ParseServer(args) {
     restAPIKey: args.restAPIKey || '',
     fileKey: args.fileKey || 'invalid-file-key',
     facebookAppIds: args.facebookAppIds || [],
-    filesController: filesController
+    filesController: filesController,
+    enableAnonymousUsers: args.enableAnonymousUsers || true
   };
 
   // To maintain compatibility. TODO: Remove in v2.1


### PR DESCRIPTION
Proposed fix for #327 

- Adds enableAnonymousUsers to the config.
- Marks the service unsupported when enableAnonymousUsers !== true.
- Adds according tests.