### PR TITLE
Removes installationId from _User

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1367,7 +1367,7 @@ describe('Parse.User testing', () => {
         var b = JSON.parse(body);
         expect(b.results.length).toEqual(1);
         var user = b.results[0];
-        expect(Object.keys(user).length).toEqual(7);
+        expect(Object.keys(user).length).toEqual(6);
         done();
       });
     });

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -23,7 +23,6 @@ export class UsersRouter extends ClassesRouter {
 
   handleCreate(req) {
     let data = deepcopy(req.body);
-    data.installationId = req.info.installationId;
     req.body = data;
     req.params.className = '_User';
     return super.handleCreate(req);


### PR DESCRIPTION
Fix for #449.

A  _User can have many _Installation.