### PR TITLE
Don't use https://api.parse.com/1 as default serverURL

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,9 +115,7 @@ function ParseServer(args) {
 
   // Initialize the node client SDK automatically
   Parse.initialize(args.appId, args.javascriptKey || '', args.masterKey);
-  if(args.serverURL) {
-    Parse.serverURL = args.serverURL;
-  }
+  Parse.serverURL = args.serverURL || '';
 
   // This app serves the Parse API directly.
   // It's the equivalent of https://api.parse.com/1 in the hosted Parse API.


### PR DESCRIPTION
The parse js sdk uses https://api.parse.com/1 as default serverURL for obvious reasons. However I can't think of a common use case for it in Parse Server and it might be confusing #356 #407 #477. This pull request simply overwrites the default url with en empty string if the user does not specify it.

When using queries in cloud code and forgetting to change the serverURL you currently get a `ParseError { code: undefined, message: 'unauthorized' }`. With this change you instead get a `ParseError {code: 100, message: 'XMLHttpRequest failed: "Unable to connect to the Parse API"' }`. This might only be a slight improvement, but it makes it possible to add a custom error message in the parse js sdk when no serverURL is found.

It might also be desirable to make serverURL a required property or adding a warning when it is not set?