### PR TITLE
Fix passing parameters via URL query when querying for objects.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "apn": "^1.7.5",
     "aws-sdk": "~2.2.33",
+    "babel-polyfill": "^6.5.0",
     "babel-runtime": "^6.5.0",
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "^1.14.2",

--- a/src/Routers/ClassesRouter.js
+++ b/src/Routers/ClassesRouter.js
@@ -7,12 +7,12 @@ import url from 'url';
 export class ClassesRouter extends PromiseRouter {
   
   handleFind(req) {
-    let body = Object.assign(req.body, req.query);
+    let body = Object.assign(req.body, ClassesRouter.JSONFromQuery(req.query));
     let options = {};
     let allowConstraints = ['skip', 'limit', 'order', 'count', 'keys',
       'include', 'redirectClassNameForKey', 'where'];
 
-    for (var key in body) {
+    for (let key of Object.keys(body)) {
       if (allowConstraints.indexOf(key) === -1) {
         throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Improper encode of parameter');
       }
@@ -96,6 +96,18 @@ export class ClassesRouter extends PromiseRouter {
       .then(() => {
         return {response: {}};
       });
+  }
+
+  static JSONFromQuery(query) {
+    let json = {};
+    for (let [key, value] of Object.entries(query)) {
+      try {
+        json[key] = JSON.parse(value);
+      } catch (e) {
+        json[key] = value;
+      }
+    }
+    return json
   }
   
   mountRoutes() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 // ParseServer - open-source compatible API Server for Parse apps
 
+import 'babel-polyfill';
+
 var batch = require('./batch'),
     bodyParser = require('body-parser'),
     cache = require('./cache'),
@@ -17,7 +19,6 @@ import { FilesController }     from './Controllers/FilesController';
 
 import ParsePushAdapter        from './Adapters/Push/ParsePushAdapter';
 import { PushController }      from './Controllers/PushController';
-
 
 import { ClassesRouter }       from './Routers/ClassesRouter';
 import { InstallationsRouter } from './Routers/InstallationsRouter';


### PR DESCRIPTION
Parse query parameters into proper JSON body if they are supplied.
Also added babel-polyfill at the entry point of our stuff to allow fancy ES6 iterator syntax.
Fixes #211, #101 