### PR TITLE
Accept subdocuments keys ("object.subobject"), to allow atomic updates of an object field.

### DIFF
--- a/spec/RestCreate.spec.js
+++ b/spec/RestCreate.spec.js
@@ -1,4 +1,4 @@
-// These tests check the "create" functionality of the REST API.
+// These tests check the "create" / "update" functionality of the REST API.
 var auth = require('../src/Auth');
 var cache = require('../src/cache');
 var Config = require('../src/Config');
@@ -38,6 +38,38 @@ describe('rest create', () => {
       expect(typeof mob.object).toBe('object');
       expect(mob.date instanceof Date).toBe(true);
       done();
+    });
+  });
+
+  it('handles object and subdocument', (done) => {
+    var obj = {
+      subdoc: {foo: 'bar', wu: 'tan'},
+    };
+    rest.create(config, auth.nobody(config), 'MyClass', obj).then(() => {
+      return database.mongoFind('MyClass', {}, {});
+    }).then((results) => {
+      expect(results.length).toEqual(1);
+      var mob = results[0];
+      expect(typeof mob.subdoc).toBe('object');
+      expect(mob.subdoc.foo).toBe('bar');
+      expect(mob.subdoc.wu).toBe('tan');
+      expect(typeof mob._id).toEqual('string');
+
+      var obj = {
+        'subdoc.wu': 'clan',
+      };
+
+      rest.update(config, auth.nobody(config), 'MyClass', mob._id, obj).then(() => {
+        return database.mongoFind('MyClass', {}, {});
+      }).then((results) => {
+        expect(results.length).toEqual(1);
+        var mob = results[0];
+        expect(typeof mob.subdoc).toBe('object');
+        expect(mob.subdoc.foo).toBe('bar');
+        expect(mob.subdoc.wu).toBe('clan');
+        done();
+      });
+
     });
   });
 

--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -32,6 +32,17 @@ describe('Schema', () => {
     });
   });
 
+  it('can validate one object with dot notation', (done) => {
+    config.database.loadSchema().then((schema) => {
+      return schema.validateObject('TestObjectWithSubDoc', {x: false, y: 'YY', z: 1, 'aObject.k1': 'newValue'});
+    }).then((schema) => {
+      done();
+    }, (error) => {
+      fail(error);
+      done();
+    });
+  });
+
   it('can validate two objects in a row', (done) => {
     config.database.loadSchema().then((schema) => {
       return schema.validateObject('Foo', {x: true, y: 'yyy', z: 0});

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -426,6 +426,12 @@ Schema.prototype.validateField = function(className, key, type, freeze) {
   // Just to check that the key is valid
   transform.transformKey(this, className, key);
 
+  if( key.indexOf(".") > 0 ) {
+      // subdocument key (x.y) => ok if x is of type 'object'    
+      key = key.split(".")[ 0 ];
+      type = 'object';
+  }
+
   var expected = this.data[className][key];
   if (expected) {
     expected = (expected === 'map' ? 'object' : expected);

--- a/src/index.js
+++ b/src/index.js
@@ -188,6 +188,17 @@ function ParseServer({
 
   api.use(middlewares.handleParseErrors);
 
+
+  process.on('uncaughtException', (err) => {
+    if( err.code === "EADDRINUSE" ) { // user-friendly message for this common error
+      console.log(`Unable to listen on port ${err.port}. The port is already in use.`);
+      process.exit(0);
+    }
+    else {
+      throw err;
+    }
+  });  
+
   return api;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -188,17 +188,6 @@ function ParseServer({
 
   api.use(middlewares.handleParseErrors);
 
-
-  process.on('uncaughtException', (err) => {
-    if( err.code === "EADDRINUSE" ) { // user-friendly message for this common error
-      console.log(`Unable to listen on port ${err.port}. The port is already in use.`);
-      process.exit(0);
-    }
-    else {
-      throw err;
-    }
-  });  
-
   return api;
 }
 


### PR DESCRIPTION
The  validateField  function checks the key/type against the schema.
For objects fields, it's valid to set subdocuments with the dot notation syntax.

This patch changes the  validateField  test to allow this syntax.