### PR TITLE
Allow uploading files without Content-Type.

### DIFF
--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -10,25 +10,49 @@ for (var i = 0; i < str.length; i++) {
 }
 
 describe('Parse.File testing', () => {
-  it('works with REST API', done => {
-    var headers = {
-      'Content-Type': 'application/octet-stream',
-      'X-Parse-Application-Id': 'test',
-      'X-Parse-REST-API-Key': 'rest'
-    };
-    request.post({
-      headers: headers,
-      url: 'http://localhost:8378/1/files/file.txt',
-      body: 'argle bargle',
-    }, (error, response, body) => {
-      expect(error).toBe(null);
-      var b = JSON.parse(body);
-      expect(b.name).toMatch(/_file.txt$/);
-      expect(b.url).toMatch(/^http:\/\/localhost:8378\/1\/files\/test\/.*file.txt$/);
-      request.get(b.url, (error, response, body) => {
+  describe('creating files', () => {
+    it('works with Content-Type', done => {
+      var headers = {
+        'Content-Type': 'application/octet-stream',
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest'
+      };
+      request.post({
+        headers: headers,
+        url: 'http://localhost:8378/1/files/file.txt',
+        body: 'argle bargle',
+      }, (error, response, body) => {
         expect(error).toBe(null);
-        expect(body).toEqual('argle bargle');
-        done();
+        var b = JSON.parse(body);
+        expect(b.name).toMatch(/_file.txt$/);
+        expect(b.url).toMatch(/^http:\/\/localhost:8378\/1\/files\/test\/.*file.txt$/);
+        request.get(b.url, (error, response, body) => {
+          expect(error).toBe(null);
+          expect(body).toEqual('argle bargle');
+          done();
+        });
+      });
+    });
+
+    it('works without Content-Type', done => {
+      var headers = {
+        'X-Parse-Application-Id': 'test',
+        'X-Parse-REST-API-Key': 'rest'
+      };
+      request.post({
+        headers: headers,
+        url: 'http://localhost:8378/1/files/file.txt',
+        body: 'argle bargle',
+      }, (error, response, body) => {
+        expect(error).toBe(null);
+        var b = JSON.parse(body);
+        expect(b.name).toMatch(/_file.txt$/);
+        expect(b.url).toMatch(/^http:\/\/localhost:8378\/1\/files\/test\/.*file.txt$/);
+        request.get(b.url, (error, response, body) => {
+          expect(error).toBe(null);
+          expect(body).toEqual('argle bargle');
+          done();
+        });
       });
     });
   });

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -19,7 +19,7 @@ export class FilesController extends AdaptableController {
         name: filename
       });
     });
-  } 
+  }
 
   deleteFile(config, filename) {
     return this.adapter.deleteFile(config, filename);
@@ -30,7 +30,7 @@ export class FilesController extends AdaptableController {
    * with the current mount point and app id.
    * Object may be a single object or list of REST-format objects.
    */
-   expandFilesInObject(config, object) {
+  expandFilesInObject(config, object) {
     if (object instanceof Array) {
       object.map((obj) => this.expandFilesInObject(config, obj));
       return;
@@ -53,7 +53,7 @@ export class FilesController extends AdaptableController {
       }
     }
   }
-  
+
   expectedAdapterType() {
     return FilesAdapter;
   }


### PR DESCRIPTION
Looks like our SDKs might be uploading files without `Content-Type` header, which is valid, since we want the server to automatically pick a content type for us.
Remove the restriction by using function instead of a string for body parser type validation (any other ideas on how to remove content-type restriction there are very very welcome).
Also added test that validates that this works now.

Fixes #136 