### PR TITLE
Improve beforeSave triggers for newly created objects.

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -111,6 +111,11 @@ RestWrite.prototype.validateSchema = function() {
 // Runs any beforeSave triggers against this operation.
 // Any change leads to our data being mutated.
 RestWrite.prototype.runBeforeTrigger = function() {
+  // Avoid doing any setup for triggers if there is no 'beforeSave' trigger for this class.
+  if (!triggers.triggerExists(this.className, triggers.Types.beforeSave)) {
+    return Promise.resolve();
+  }
+
   // Cloud code gets a bit of extra data for its objects
   var extraData = {className: this.className};
   if (this.query && this.query.objectId) {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -123,17 +123,12 @@ RestWrite.prototype.runBeforeTrigger = function() {
   }
 
   let originalObject = null;
-  let updatedObject = null;
+  let updatedObject = triggers.inflate(extraData, this.originalData);
   if (this.query && this.query.objectId) {
     // This is an update for existing object.
     originalObject = triggers.inflate(extraData, this.originalData);
-    updatedObject = triggers.inflate(extraData, this.originalData);
-    updatedObject.set(Parse._decode(undefined, this.data));
-  } else {
-    // This is create of an object, so no original object exists.
-    // TODO: (nlutsenko) Use the same flow as for creation, when _Session triggers support is removed.
-    updatedObject = triggers.inflate(extraData, this.data);
   }
+  updatedObject.set(Parse._decode(undefined, this.data));
 
   return Promise.resolve().then(() => {
     return triggers.maybeRunTrigger(

--- a/src/index.js
+++ b/src/index.js
@@ -211,24 +211,35 @@ function addParseCloud() {
     afterDelete: {}
   };
 
+  function validateClassNameForTriggers(className) {
+    const restrictedClassNames = [ '_Session' ];
+    if (restrictedClassNames.indexOf(className) != -1) {
+      throw `Triggers are not supported for ${className} class.`;
+    }
+  }
+
   Parse.Cloud.define = function(functionName, handler, validationHandler) {
     Parse.Cloud.Functions[functionName] = handler;
     Parse.Cloud.Validators[functionName] = validationHandler;
   };
   Parse.Cloud.beforeSave = function(parseClass, handler) {
-    var className = getClassName(parseClass);
+    let className = getClassName(parseClass);
+    validateClassNameForTriggers(className);
     Parse.Cloud.Triggers.beforeSave[className] = handler;
   };
   Parse.Cloud.beforeDelete = function(parseClass, handler) {
-    var className = getClassName(parseClass);
+    let className = getClassName(parseClass);
+    validateClassNameForTriggers(className);
     Parse.Cloud.Triggers.beforeDelete[className] = handler;
   };
   Parse.Cloud.afterSave = function(parseClass, handler) {
-    var className = getClassName(parseClass);
+    let className = getClassName(parseClass);
+    validateClassNameForTriggers(className);
     Parse.Cloud.Triggers.afterSave[className] = handler;
   };
   Parse.Cloud.afterDelete = function(parseClass, handler) {
-    var className = getClassName(parseClass);
+    let className = getClassName(parseClass);
+    validateClassNameForTriggers(className);
     Parse.Cloud.Triggers.afterDelete[className] = handler;
   };
   Parse.Cloud.httpRequest = httpRequest;

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -18,6 +18,10 @@ var getTrigger = function(className, triggerType) {
   return undefined;
 };
 
+function triggerExists(className: string, type: string): boolean {
+  return (getTrigger(className, type) != undefined);
+}
+
 var getRequestObject = function(triggerType, auth, parseObject, originalParseObject) {
   var request = {
     triggerName: triggerType,
@@ -96,5 +100,6 @@ module.exports = {
   getRequestObject: getRequestObject,
   inflate: inflate,
   maybeRunTrigger: maybeRunTrigger,
+  triggerExists: triggerExists,
   Types: Types
 };

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -56,7 +56,7 @@ var getResponseObject = function(request, resolve, reject) {
     success: function() {
       var response = {};
       if (request.triggerName === Types.beforeSave) {
-        response['object'] = request.object.toJSON();
+        response['object'] = request.object._getSaveJSON();
       }
       return resolve(response);
     },


### PR DESCRIPTION
This Pull Request does a lot of things, but is setup in this way to showcase the full story on why we need these:

This fixes the following issues:
- No `dirtyKeys()` in `beforeSave` hook for newly created objects
- Crazy bug that happens due to mutation of any pointer in a `beforeSave` hook for the root object.

Improvements:
- We no longer attempt to run Cloud Code triggers on beforeSave hooks that were never registered, thus making it somewhat cheaper, as we don't need to create one (2 for updates) objects/decode/inflate and do magic.
- We don't inflate the full JSON for the object back for an Update, but only the changes that were applied to the object, which is explicitly inline with what we do on a v8server in Classic CC. (literally - the same function).

Changes:
- Any kind of trigger on `_Session` class is no longer supported, and actually shouldn't be, since it's quite scary for security, easy to mess up as well as this is not something new and it was explicitly was never supported (Parsers - D9140 for reference on the initial restriction).
- This is not a breaking change, since it was never supported in any deployment of Cloud Code, and only was supported here for less than a month (27 days to be precise at this moment).

Fixes #589 

Outside of obvious improvements - here is the broader explanation on why we need to remove support for _Session, at least for now:
- We need to basically re-apply the changes to the Parse.Object to get it into the same state as people expect: `dirtyKeys()`, `isNew()` and friends.
- The only way we can do it is by using a mutating `set()` on a Parse.Object instance, as this is what the API allows us.
- All of this is great so far outside of a single limitation - Parse.Session explicitly catches any mutation to it's state for read-only keys. This is done to protect everyone from shooting themselves in the face and is guaranteed on all platforms.
- Since _Session class is one of the most commonly triggered operations when using Parse.User - we end up constructing it a lot of times and neither of those can actually succeed, since the setters are enforced to be read-only.
- Adding support for mutating Parse.Session via a private method is a good option, but at the same time - this exposes a security hole, since no function in JS is private.

We can plan to support triggers on sessions, but I think they shouldn't be allowed, since they introduce a lot of hidden complexity in the first place and could be a giant failure point for any application, if anything goes wrong in them.

cc @gfosco 