### PR TITLE
Don't trigger beforeSave on login

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -66,11 +66,11 @@ RestWrite.prototype.execute = function() {
   }).then(() => {
     return this.handleSession();
   }).then(() => {
+    return this.validateAuthData();
+  }).then(() => {
     return this.runBeforeTrigger();
   }).then(() => {
     return this.setRequiredFieldsIfNeeded();
-  }).then(() => {
-    return this.validateAuthData();
   }).then(() => {
     return this.transformUser();
   }).then(() => {
@@ -111,6 +111,10 @@ RestWrite.prototype.validateSchema = function() {
 // Runs any beforeSave triggers against this operation.
 // Any change leads to our data being mutated.
 RestWrite.prototype.runBeforeTrigger = function() {
+  if (this.response) {
+    return;
+  }
+
   // Cloud code gets a bit of extra data for its objects
   var extraData = {className: this.className};
   if (this.query && this.query.objectId) {


### PR DESCRIPTION
The Parse iOS SDK (and maybe others?) sends a "create user request" even though the user already exists. Basically using a create request to login. It is handled in parse-server right now by short circuiting the request:

```js
// RestWrite.js::321
if (!this.query) {
  // We're signing up, but this user already exists. Short-circuit
  delete results[0].password;
  this.response = {
    response: results[0],
    location: this.location()
  };
  return;
}
```

The problem is that this check happens after the beforeSave is triggered which means it will be triggered for every login. This PR fixes that and short circuits before the beforeSave is called.

One side effect of this PR is that the beforeSave is not triggered when authData, username or password is invalid. I thought this made sense, but it might be up for discussion.

This PR brings `parse-server` closer to `parse.com` as beforeSave was not called on login there.