### PR TITLE
Send a sessionToken back on /users/me.

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -5,6 +5,8 @@
 // Tests that involve revocable sessions.
 // Tests that involve sending password reset emails.
 
+"use strict";
+
 var request = require('request');
 var passwordCrypto = require('../src/password');
 
@@ -92,6 +94,33 @@ describe('Parse.User testing', () => {
       ok(fileAgain.name());
       ok(fileAgain.url());
       done();
+    });
+  });
+
+  describe('become', () => {
+    it('sends token back', done => {
+      let user = null;
+      var sessionToken = null;
+
+      Parse.User.signUp('Jason', 'Parse', { 'code': 'red' }).then(newUser => {
+        user = newUser;
+        expect(user.get('code'), 'red');
+
+        sessionToken = newUser.getSessionToken();
+        expect(sessionToken).toBeDefined();
+
+        return Parse.User.become(sessionToken);
+      }).then(newUser => {
+        expect(newUser.id).toEqual(user.id);
+        expect(newUser.get('username'), 'Jason');
+        expect(newUser.get('code'), 'red');
+        expect(newUser.getSessionToken()).toEqual(sessionToken);
+      }).then(() => {
+        done();
+      }, error => {
+        fail(error);
+        done();
+      });
     });
   });
 

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -42,8 +42,9 @@ export class UsersRouter extends ClassesRouter {
     if (!req.info || !req.info.sessionToken) {
       throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'invalid session token');
     }
+    let sessionToken = req.info.sessionToken;
     return rest.find(req.config, Auth.master(req.config), '_Session',
-      { _session_token: req.info.sessionToken },
+      { _session_token: sessionToken },
       { include: 'user' })
       .then((response) => {
         if (!response.results ||
@@ -52,6 +53,8 @@ export class UsersRouter extends ClassesRouter {
           throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'invalid session token');
         } else {
           let user = response.results[0].user;
+          // Send token back on the login, because SDKs expect that.
+          user.sessionToken = sessionToken;
           return { response: user };
         }
       });


### PR DESCRIPTION
Looks like we were not sending a token back on `/users/me`, but all SDKs expect that we do - so send it.
No security implications, since the token was already sent to us and we validated it.

Fixes #624 