### PR TITLE
Fix missing file URL for short-circuited _User in RestWrite.

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -82,8 +82,6 @@ describe('Parse.User testing', () => {
   });
 
   it("user login with files", (done) => {
-    "use strict";
-
     let file = new Parse.File("yolo.txt", [1,2,3], "text/plain");
     file.save().then((file) => {
       return Parse.User.signUp("asdf", "zxcv", { "file" : file });
@@ -927,6 +925,29 @@ describe('Parse.User testing', () => {
         ok(false, "linking should have worked");
         done();
       }
+    });
+  });
+
+  it('log in with provider with files', done => {
+    let provider = getMockFacebookProvider();
+    Parse.User._registerAuthenticationProvider(provider);
+    let file = new Parse.File("yolo.txt", [1, 2, 3], "text/plain");
+    file.save().then(file => {
+      let user = new Parse.User();
+      user.set('file', file);
+      return user._linkWith('facebook', {});
+    }).then(user => {
+      expect(user._isLinked("facebook")).toBeTruthy();
+      return Parse.User._logInWith('facebook', {});
+    }).then(user => {
+      let fileAgain = user.get('file');
+      expect(fileAgain.name()).toMatch(/yolo.txt$/);
+      expect(fileAgain.url()).toMatch(/yolo.txt$/);
+    }).then(() => {
+      done();
+    }, error => {
+      fail(error);
+      done();
     });
   });
 

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -74,6 +74,8 @@ RestWrite.prototype.execute = function() {
   }).then(() => {
     return this.transformUser();
   }).then(() => {
+    return this.expandFilesForExistingObjects();
+  }).then(() => {
     return this.runDatabaseOperation();
   }).then(() => {
     return this.handleFollowup();
@@ -702,6 +704,16 @@ RestWrite.prototype.handleInstallation = function() {
     // TODO: Validate ops (add/remove on channels, $inc on badge, etc.)
   });
   return promise;
+};
+
+// If we short-circuted the object response - then we need to make sure we expand all the files,
+// since this might not have a query, meaning it won't return the full result back.
+// TODO: (nlutsenko) This should die when we move to per-class based controllers on _Session/_User
+RestWrite.prototype.expandFilesForExistingObjects = function() {
+  // Check whether we have a short-circuited response - only then run expansion.
+  if (this.response && this.response.response) {
+    this.config.filesController.expandFilesInObject(this.config, this.response.response);
+  }
 };
 
 RestWrite.prototype.runDatabaseOperation = function() {


### PR DESCRIPTION
We short-circuit RestWrite on auth providers login/anonymous login - where those don't go through RestQuery, meaning they won't get expanded files.
This fixes missing URLs on _Session/_User if you are logging in with authData of any sort.

This will eventually somewhat change, so I placed a todo to remind us to clean this up.
Fixes #616