### PR TITLE
Remove 'url' as a required field on Files when they are stored on object.

### DIFF
--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -1,6 +1,8 @@
 // This is a port of the test suite:
 // hungry/js/test/parse_file_test.js
 
+"use strict";
+
 var request = require('request');
 
 var str = "Hello World!";
@@ -482,7 +484,22 @@ describe('Parse.File testing', () => {
       );
       done();
     });
-
   });
 
+  it('supports files in objects without urls', done => {
+    var file = {
+      __type: 'File',
+      name: '123.txt'
+    };
+    var obj = new Parse.Object('FileTest');
+    obj.set('file', file);
+    obj.save().then(() => {
+      var query = new Parse.Query('FileTest');
+      return query.first();
+    }).then(result => {
+      let fileAgain = result.get('file');
+      expect(fileAgain.url()).toMatch(/123.txt$/);
+      done();
+    });
+  });
 });

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -728,7 +728,7 @@ function getObjectType(obj) {
   if (obj.__type === 'Pointer' && obj.className) {
     return '*' + obj.className;
   }
-  if (obj.__type === 'File' && obj.url && obj.name) {
+  if (obj.__type === 'File' && obj.name) {
     return 'file';
   }
   if (obj.__type === 'Date' && obj.iso) {


### PR DESCRIPTION
api.parse.com doesn't require it, as well as we can safely reconstruct it back when we need to.
Also added test that checks this behavior.

Fixes #660