### PR TITLE
Use constants instead of magic strings for trigger names.

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -133,8 +133,7 @@ RestWrite.prototype.runBeforeTrigger = function() {
   updatedObject.set(Parse._decode(undefined, this.data));
 
   return Promise.resolve().then(() => {
-    return triggers.maybeRunTrigger(
-      'beforeSave', this.auth, updatedObject, originalObject, this.config.applicationId);
+    return triggers.maybeRunTrigger(triggers.Types.beforeSave, this.auth, updatedObject, originalObject, this.config.applicationId);
   }).then((response) => {
     if (response && response.object) {
       this.data = response.object;
@@ -789,7 +788,7 @@ RestWrite.prototype.runAfterTrigger = function() {
     originalObject = triggers.inflate(extraData, this.originalData);
   }
 
-  triggers.maybeRunTrigger('afterSave', this.auth, inflatedObject, originalObject, this.config.applicationId);
+  triggers.maybeRunTrigger(triggers.Types.afterSave, this.auth, inflatedObject, originalObject, this.config.applicationId);
 };
 
 // A helper to figure out what location this operation happens at.

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -1,5 +1,5 @@
-var Parse = require("parse/node");
-var triggers = require("../triggers");
+import { Parse } from 'parse/node';
+import * as triggers from '../triggers';
 
 function validateClassNameForTriggers(className) {
   const restrictedClassNames = [ '_Session' ];
@@ -23,22 +23,22 @@ ParseCloud.define = function(functionName, handler, validationHandler) {
 
 ParseCloud.beforeSave = function(parseClass, handler) {
   var className = getClassName(parseClass);
-  triggers.addTrigger('beforeSave', className, handler, Parse.applicationId);
+  triggers.addTrigger(triggers.Types.beforeSave, className, handler, Parse.applicationId);
 };
 
 ParseCloud.beforeDelete = function(parseClass, handler) {
   var className = getClassName(parseClass);
-  triggers.addTrigger('beforeDelete', className, handler, Parse.applicationId);
+  triggers.addTrigger(triggers.Types.beforeDelete, className, handler, Parse.applicationId);
 };
 
 ParseCloud.afterSave = function(parseClass, handler) {
   var className = getClassName(parseClass);
-  triggers.addTrigger('afterSave', className, handler, Parse.applicationId);
+  triggers.addTrigger(triggers.Types.afterSave, className, handler, Parse.applicationId);
 };
 
 ParseCloud.afterDelete = function(parseClass, handler) {
   var className = getClassName(parseClass);
-  triggers.addTrigger('afterDelete', className, handler, Parse.applicationId);
+  triggers.addTrigger(triggers.Types.afterDelete, className, handler, Parse.applicationId);
 };
   
 ParseCloud._removeHook = function(category, name, type, applicationId) {

--- a/src/rest.js
+++ b/src/rest.js
@@ -39,8 +39,8 @@ function del(config, auth, className, objectId) {
   var inflatedObject;
 
   return Promise.resolve().then(() => {
-    if (triggers.getTrigger(className, 'beforeDelete', config.applicationId) ||
-        triggers.getTrigger(className, 'afterDelete', config.applicationId) ||
+    if (triggers.getTrigger(className, triggers.Types.beforeDelete, config.applicationId) ||
+        triggers.getTrigger(className, triggers.Types.afterDelete, config.applicationId) ||
         className == '_Session') {
       return find(config, auth, className, {objectId: objectId})
       .then((response) => {
@@ -48,8 +48,7 @@ function del(config, auth, className, objectId) {
           response.results[0].className = className;
           cache.clearUser(response.results[0].sessionToken);
           inflatedObject = Parse.Object.fromJSON(response.results[0]);
-          return triggers.maybeRunTrigger('beforeDelete',
-                                          auth, inflatedObject, null,  config.applicationId);
+          return triggers.maybeRunTrigger(triggers.Types.beforeDelete, auth, inflatedObject, null,  config.applicationId);
         }
         throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND,
                               'Object not found for delete.');
@@ -76,7 +75,7 @@ function del(config, auth, className, objectId) {
       objectId: objectId
     }, options);
   }).then(() => {
-    triggers.maybeRunTrigger('afterDelete', auth, inflatedObject, null, config.applicationId);
+    triggers.maybeRunTrigger(triggers.Types.afterDelete, auth, inflatedObject, null, config.applicationId);
     return Promise.resolve();
   });
 }
@@ -96,8 +95,8 @@ function update(config, auth, className, objectId, restObject) {
   enforceRoleSecurity('update', className, auth);
 
   return Promise.resolve().then(() => {
-    if (triggers.getTrigger(className, 'beforeSave', config.applicationId) ||
-        triggers.getTrigger(className, 'afterSave', config.applicationId)) {
+    if (triggers.getTrigger(className, triggers.Types.beforeSave, config.applicationId) ||
+        triggers.getTrigger(className, triggers.Types.afterSave, config.applicationId)) {
       return find(config, auth, className, {objectId: objectId});
     }
     return Promise.resolve({});

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -10,7 +10,6 @@ export const Types = {
 };
 
 const baseStore = function() {
-  
   let Validators = {};
   let Functions = {};
   let Triggers = Object.keys(Types).reduce(function(base, key){
@@ -23,7 +22,7 @@ const baseStore = function() {
     Validators,
     Triggers
   });
-}
+};
 
 const _triggerStore = {};
 
@@ -58,7 +57,6 @@ export function _unregister(a,b,c,d) {
     delete _triggerStore[a][b][c];
   }
 }
-
 
 export function getTrigger(className, triggerType, applicationId) {
   if (!applicationId) {


### PR DESCRIPTION
In all of these occurences - we are using a magic string (stirng literal created in place) instead of a constant - just use the constant, since we have `triggers.js` imported.
There are actually no more occurences of this, so we might as well continue using constants for these in future at all times.