### PR TITLE
Add the possibility to enable experimental config from ParseServer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,7 @@ function ParseServer({
   facebookAppIds = [],
   enableAnonymousUsers = true,
   oauth = {},
+  enableExperimentalConfig = false,
   serverURL = requiredParameter('You must provide a serverURL!'),
   maxUploadSize = '20mb'
 }) {
@@ -140,6 +141,7 @@ function ParseServer({
     hooksController: hooksController,
     enableAnonymousUsers: enableAnonymousUsers,
     oauth: oauth,
+    enableExperimentalConfig: enableExperimentalConfig
   };
 
   // To maintain compatibility. TODO: Remove in v2.1
@@ -180,7 +182,7 @@ function ParseServer({
     new IAPValidationRouter()
   ];
 
-  if (process.env.PARSE_EXPERIMENTAL_CONFIG_ENABLED || process.env.TESTING) {
+  if (process.env.PARSE_EXPERIMENTAL_CONFIG_ENABLED || process.env.TESTING || enableExperimentalConfig) {
     routers.push(require('./global_config'));
   }
   


### PR DESCRIPTION
Example :
```
new ParseServer({
   databaseURI: 'mongodb://localhost:27017/dev',
   [...]
   enableExperimentalConfig: true
});
```