### PR TITLE
Don't trigger beforeSave when logging in with a provider

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1026,6 +1026,32 @@ describe('Parse.User testing', () => {
     });
   });
 
+  it("login with provider should not call beforeSave trigger", (done) => {
+    var provider = getMockFacebookProvider();
+    Parse.User._registerAuthenticationProvider(provider);
+    Parse.User._logInWith("facebook", {
+      success: function(model) {
+        Parse.User.logOut();
+
+        Parse.Cloud.beforeSave(Parse.User, function(req, res) {
+          res.error("Before save shouldn't be called on login");
+        });
+
+        Parse.User._logInWith("facebook", {
+          success: function(innerModel) {
+            Parse.Cloud._removeHook('Triggers', 'beforeSave', Parse.User.className);
+            done();
+          },
+          error: function(model, error) {
+            ok(undefined, error);
+            Parse.Cloud._removeHook('Triggers', 'beforeSave', Parse.User.className);
+            done();
+          }
+        });
+      }
+    });
+  });
+
   it("link with provider", (done) => {
     var provider = getMockFacebookProvider();
     Parse.User._registerAuthenticationProvider(provider);

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -68,11 +68,11 @@ RestWrite.prototype.execute = function() {
   }).then(() => {
     return this.handleSession();
   }).then(() => {
+    return this.validateAuthData();
+  }).then(() => {
     return this.runBeforeTrigger();
   }).then(() => {
     return this.setRequiredFieldsIfNeeded();
-  }).then(() => {
-    return this.validateAuthData();
   }).then(() => {
     return this.transformUser();
   }).then(() => {
@@ -134,6 +134,10 @@ RestWrite.prototype.validateSchema = function() {
 // Runs any beforeSave triggers against this operation.
 // Any change leads to our data being mutated.
 RestWrite.prototype.runBeforeTrigger = function() {
+  if (this.response) {
+    return;
+  }
+  
   // Avoid doing any setup for triggers if there is no 'beforeSave' trigger for this class.
   if (!triggers.triggerExists(this.className, triggers.Types.beforeSave, this.config.applicationId)) {
     return Promise.resolve();


### PR DESCRIPTION
Currently beforeSave is called while logging in with a provider such as facebook which feels strange as the user is never modified. It is also a difference from `api.parse.com`. Logging in with a provider sends a create request which currently is short circuited in RestWrite.js if the user has already signed up. This PR moves that short circuiting code before the triggering of the beforeSave which means it will no longer be called on logins. More info can be found in #623. I closed that PR as I thought the issue was fixed, but turns out I was wrong. Also added a test for it in this PR.