### PR TITLE
addParseCloud in ParseServer init function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,6 @@ import { HooksController }     from './Controllers/HooksController';
 
 import requiredParameter       from './requiredParameter';
 import { randomString }        from './cryptoUtils';
-// Mutate the Parse object to add the Cloud Code handlers
-addParseCloud();
 
 // ParseServer works like a constructor of an express app.
 // The args that we understand are:
@@ -210,7 +208,8 @@ function ParseServer({
     }
   });
   hooksController.load();
-
+  // Mutate the Parse object to add the Cloud Code handlers
+  addParseCloud();
   return api;
 }
 


### PR DESCRIPTION
I try to add my function to triggers by [`ParseCloud.define`](https://github.com/ParsePlatform/parse-server/blob/master/src/cloud-code/Parse.Cloud.js#L20) but failed, because `Parse.applicationId` is null.

I think the function `addParseCloud ` should be call in `ParseServer` that is given the appId.




