### PR TITLE
Amazon SNS support

### DIFF
--- a/spec/APNS.spec.js
+++ b/spec/APNS.spec.js
@@ -1,4 +1,4 @@
-var APNS = require('../src/APNS');
+var APNS = require('../src/APNS').APNS;
 
 describe('APNS', () => {
 

--- a/spec/GCM.spec.js
+++ b/spec/GCM.spec.js
@@ -1,4 +1,4 @@
-var GCM = require('../src/GCM');
+var GCM = require('../src/GCM').GCM;
 
 describe('GCM', () => {
   it('can initialize', (done) => {

--- a/spec/ParsePushAdapter.spec.js
+++ b/spec/ParsePushAdapter.spec.js
@@ -1,5 +1,5 @@
 var ParsePushAdapter = require('../src/Adapters/Push/ParsePushAdapter');
-var APNS = require('../src/APNS');
+var APNS = require('../src/APNS').APNS;
 var GCM = require('../src/GCM').GCM;
 
 describe('ParsePushAdapter', () => {

--- a/spec/ParsePushAdapter.spec.js
+++ b/spec/ParsePushAdapter.spec.js
@@ -1,6 +1,6 @@
 var ParsePushAdapter = require('../src/Adapters/Push/ParsePushAdapter');
 var APNS = require('../src/APNS');
-var GCM = require('../src/GCM');
+var GCM = require('../src/GCM').GCM;
 
 describe('ParsePushAdapter', () => {
   it('can be initialized', (done) => {

--- a/spec/SNSPushAdapter.spec.js
+++ b/spec/SNSPushAdapter.spec.js
@@ -115,18 +115,16 @@ describe('SNSPushAdapter', () => {
 
     it('can generate the right Android payload', (done) => {
         var data = {"action": "com.example.UPDATE_STATUS"};
-        var pushId = '123';
         var timeStamp = 1456728000;
 
-        var returnedData = SNSPushAdapter.generateAndroidPayload(data, pushId, timeStamp);
-        var expectedData = {GCM: '{"priority":"normal","data":{"time":"1970-01-17T20:38:48.000Z","push_id":"123"}}'};
+        var returnedData = SNSPushAdapter.generateAndroidPayload(data, timeStamp);
+        var expectedData = {GCM: '{"priority":"normal","data":{"time":"1970-01-17T20:38:48.000Z"}}'};
         expect(returnedData).toEqual(expectedData)
         done();
     });
 
     it('can generate the right iOS payload', (done) => {
         var data = {data : {"alert": "Check out these awesome deals!"}};
-        var pushId = '123';
         var timeStamp = 1456728000;
 
         var returnedData = SNSPushAdapter.generateiOSPayload(data, true);

--- a/spec/SNSPushAdapter.spec.js
+++ b/spec/SNSPushAdapter.spec.js
@@ -194,6 +194,18 @@ describe('SNSPushAdapter', () => {
         });
     });
 
+    it('errors sending SNS Payload to Android and iOS', (done) => {
+        // Mock out Amazon SNS token exchange
+        var snsSender = jasmine.createSpyObj('sns', ['publish', 'createPlatformEndpoint']);
+
+        snsSender.createPlatformEndpoint.and.callFake(function (object, callback) {
+            callback("error", {});
+        });
+
+        var promise = snsSender.getPlatformArn(makeDevice("android"), "android", function(err, data));
+        done();
+    });
+
     it('can send SNS Payload to Android and iOS', (done) => {
         // Mock out Amazon SNS token exchange
         var snsSender = jasmine.createSpyObj('sns', ['publish', 'createPlatformEndpoint']);
@@ -222,7 +234,6 @@ describe('SNSPushAdapter', () => {
 
         var promise = snsPushAdapter.send({"test": "hello"}, installations);
 
-        var callback = jasmine.createSpy();
         promise.then(function () {
             expect(snsSender.publish).toHaveBeenCalled();
             expect(snsSender.publish.calls.count()).toEqual(2);

--- a/spec/SNSPushAdapter.spec.js
+++ b/spec/SNSPushAdapter.spec.js
@@ -1,0 +1,240 @@
+var SNSPushAdapter = require('../src/Adapters/Push/SNSPushAdapter');
+describe('SNSPushAdapter', () => {
+
+    var pushConfig;
+    var snsPushAdapter;
+
+    beforeEach(function() {
+        pushConfig = {
+            pushTypes: {
+                ios: "APNS_ID",
+                android: "GCM_ID"
+            },
+            accessKey: "accessKey",
+            secretKey: "secretKey",
+            region: "region"
+        };
+        snsPushAdapter = new SNSPushAdapter(pushConfig);
+    });
+
+    it('can be initialized', (done) => {
+        // Make mock config
+        var arnMap = snsPushAdapter.arnMap;
+
+        expect(arnMap.ios).toEqual("APNS_ID");
+        expect(arnMap.android).toEqual("GCM_ID");
+
+        done();
+    });
+
+    it('can get valid push types', (done) => {
+        expect(snsPushAdapter.getValidPushTypes()).toEqual(['ios', 'android']);
+        done();
+    });
+
+    it('can classify installation', (done) => {
+        // Mock installations
+        var validPushTypes = ['ios', 'android'];
+        var installations = [
+            {
+                deviceType: 'android',
+                deviceToken: 'androidToken'
+            },
+            {
+                deviceType: 'ios',
+                deviceToken: 'iosToken'
+            },
+            {
+                deviceType: 'win',
+                deviceToken: 'winToken'
+            },
+            {
+                deviceType: 'android',
+                deviceToken: undefined
+            }
+        ];
+        var deviceMap = SNSPushAdapter.classifyInstallations(installations, validPushTypes);
+        expect(deviceMap['android']).toEqual([makeDevice('androidToken')]);
+        expect(deviceMap['ios']).toEqual([makeDevice('iosToken')]);
+        expect(deviceMap['win']).toBe(undefined);
+        done();
+    });
+
+    it('can send push notifications', (done) => {
+        // Mock SNS sender
+        var snsSender = jasmine.createSpyObj('sns', ['createPlatformEndpoint', 'publish']);
+        snsPushAdapter.sns = snsSender;
+
+        // Mock android ios senders
+        var androidSender = jasmine.createSpy('send')
+        var iosSender = jasmine.createSpy('send')
+
+        var senderMap = {
+            ios: iosSender,
+            android: androidSender
+        };
+        snsPushAdapter.senderMap = senderMap;
+
+        // Mock installations
+        var installations = [
+            {
+                deviceType: 'android',
+                deviceToken: 'androidToken'
+            },
+            {
+                deviceType: 'ios',
+                deviceToken: 'iosToken'
+            },
+            {
+                deviceType: 'win',
+                deviceToken: 'winToken'
+            },
+            {
+                deviceType: 'android',
+                deviceToken: undefined
+            }
+        ];
+        var data = {};
+
+        snsPushAdapter.send(data, installations);
+        // Check SNS sender
+        expect(androidSender).toHaveBeenCalled();
+        var args = androidSender.calls.first().args;
+        expect(args[0]).toEqual(data);
+        expect(args[1]).toEqual([
+            makeDevice('androidToken')
+        ]);
+        // Check ios sender
+        expect(iosSender).toHaveBeenCalled();
+        args = iosSender.calls.first().args;
+        expect(args[0]).toEqual(data);
+        expect(args[1]).toEqual([
+            makeDevice('iosToken')
+        ]);
+        done();
+    });
+
+    it('can generate the right Android payload', (done) => {
+        var data = {"action": "com.example.UPDATE_STATUS"};
+        var pushId = '123';
+        var timeStamp = 1456728000;
+
+        var returnedData = SNSPushAdapter.generateAndroidPayload(data, pushId, timeStamp);
+        var expectedData = {GCM: '{"priority":"normal","data":{"time":"1970-01-17T20:38:48.000Z","push_id":"123"}}'};
+        expect(returnedData).toEqual(expectedData)
+        done();
+    });
+
+    it('can generate the right iOS payload', (done) => {
+        var data = {"aps": {"alert": "Check out these awesome deals!"}};
+        var pushId = '123';
+        var timeStamp = 1456728000;
+
+        var returnedData = SNSPushAdapter.generateiOSPayload(data);
+        var expectedData = {APNS: '{"aps":{"alert":"Check out these awesome deals!"}}'};
+        expect(returnedData).toEqual(expectedData)
+        done();
+    });
+
+    it('can exchange device tokens for an Amazon Resource Number (ARN)', (done) => {
+        // Mock out Amazon SNS token exchange
+        var snsSender = jasmine.createSpyObj('sns', ['createPlatformEndpoint']);
+        snsPushAdapter.sns = snsSender;
+
+        // Mock installations
+        var installations = [
+            {
+                deviceType: 'android',
+                deviceToken: 'androidToken'
+            }
+        ];
+
+        snsSender.createPlatformEndpoint.and.callFake(function(object, callback) {
+            callback(null, {'EndpointArn' : 'ARN'});
+        });
+
+        var promise = snsPushAdapter.exchangeTokenPromise(makeDevice("androidToken"), "android");
+
+        promise.then(function() {
+            expect(snsSender.createPlatformEndpoint).toHaveBeenCalled();
+            args = snsSender.createPlatformEndpoint.calls.first().args;
+            expect(args[0].PlatformApplicationArn).toEqual("GCM_ID");
+            expect(args[0].Token).toEqual("androidToken");
+            done();
+        });
+    });
+
+    it('can send SNS Payload', (done) => {
+        // Mock out Amazon SNS token exchange
+        var snsSender = jasmine.createSpyObj('sns', ['publish'])
+        snsSender.publish.and.callFake(function (object, callback) {
+            callback(null, '123');
+        });
+
+        snsPushAdapter.sns = snsSender;
+
+        // Mock installations
+        var installations = [
+            {
+                deviceType: 'android',
+                deviceToken: 'androidToken'
+            }
+        ];
+
+        var promise = snsPushAdapter.sendSNSPayload("123", {"test": "hello"});
+
+        var callback = jasmine.createSpy();
+        promise.then(function () {
+            expect(snsSender.publish).toHaveBeenCalled();
+            args = snsSender.publish.calls.first().args;
+            expect(args[0].MessageStructure).toEqual("json");
+            expect(args[0].TargetArn).toEqual("123");
+            expect(args[0].Message).toEqual('{"test":"hello"}');
+            done();
+        });
+    });
+
+    it('can send SNS Payload to Android and iOS', (done) => {
+        // Mock out Amazon SNS token exchange
+        var snsSender = jasmine.createSpyObj('sns', ['publish', 'createPlatformEndpoint']);
+
+        snsSender.createPlatformEndpoint.and.callFake(function (object, callback) {
+            callback(null, {'EndpointArn': 'ARN'});
+        });
+
+        snsSender.publish.and.callFake(function (object, callback) {
+            callback(null, '123');
+        });
+
+        snsPushAdapter.sns = snsSender;
+
+        // Mock installations
+        var installations = [
+            {
+                deviceType: 'android',
+                deviceToken: 'androidToken'
+            },
+            {
+                deviceType: 'ios',
+                deviceToken: 'iosToken'
+            }
+        ];
+
+        var promise = snsPushAdapter.send({"test": "hello"}, installations);
+
+        var callback = jasmine.createSpy();
+        promise.then(function () {
+            expect(snsSender.publish).toHaveBeenCalled();
+            expect(snsSender.publish.calls.count()).toEqual(2);
+            done();
+        });
+    });
+
+    function makeDevice(deviceToken, appIdentifier) {
+        return {
+            deviceToken: deviceToken,
+            appIdentifier: appIdentifier
+        };
+    }
+
+});

--- a/src/APNS.js
+++ b/src/APNS.js
@@ -16,7 +16,7 @@ const apn = require('apn');
  * @param {String} args.bundleId The bundleId for cert
  * @param {Boolean} args.production Specifies which environment to connect to: Production (if true) or Sandbox
  */
-function APNS(args) {
+export function APNS(args) {
   // Since for ios, there maybe multiple cert/key pairs,
   // typePushConfig can be an array.
   let apnsArgsList = [];
@@ -187,7 +187,7 @@ function chooseConns(conns, device) {
  * @param {Object} coreData The data field under api request body
  * @returns {Object} A apns notification
  */
-function generateNotification(coreData, expirationTime) {
+export function generateNotification(coreData, expirationTime) {
   let notification = new apn.notification();
   let payload = {};
   for (let key in coreData) {
@@ -224,4 +224,3 @@ if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
   APNS.chooseConns = chooseConns;
   APNS.handleTransmissionError = handleTransmissionError;
 }
-module.exports = APNS;

--- a/src/Adapters/Push/ParsePushAdapter.js
+++ b/src/Adapters/Push/ParsePushAdapter.js
@@ -4,7 +4,7 @@
 // for ios push.
 
 const Parse = require('parse/node').Parse;
-const GCM = require('../../GCM');
+const GCM = require('../../GCM').GCM;
 const APNS = require('../../APNS');
 import PushAdapter from './PushAdapter';
 import { classifyInstallations } from './PushAdapterUtils';

--- a/src/Adapters/Push/ParsePushAdapter.js
+++ b/src/Adapters/Push/ParsePushAdapter.js
@@ -5,7 +5,7 @@
 
 const Parse = require('parse/node').Parse;
 const GCM = require('../../GCM').GCM;
-const APNS = require('../../APNS');
+const APNS = require('../../APNS').APNS;
 import PushAdapter from './PushAdapter';
 import { classifyInstallations } from './PushAdapterUtils';
 

--- a/src/Adapters/Push/SNSPushAdapter.js
+++ b/src/Adapters/Push/SNSPushAdapter.js
@@ -1,0 +1,186 @@
+"use strict";
+// SNSAdapter
+//
+// Uses SNS for push notification
+import PushAdapter from './PushAdapter';
+
+const Parse = require('parse/node').Parse;
+const GCM = require('../../GCM');
+
+const AWS = require('aws-sdk');
+
+var DEFAULT_REGION = "us-east-1";
+import { classifyInstallations } from './PushAdapterUtils';
+
+export class SNSPushAdapter extends PushAdapter {
+
+    // Publish to an SNS endpoint
+    // Providing AWS access and secret keys is mandatory
+    // Region will use sane defaults if omitted
+    constructor(pushConfig = {}) {
+        super(pushConfig);
+        this.validPushTypes = ['ios', 'android'];
+        this.availablePushTypes = [];
+        this.arnMap = {};
+        this.senderMap = {};
+
+        if (!pushConfig.accessKey || !pushConfig.secretKey) {
+            throw new Parse.Error(Parse.Error.PUSH_MISCONFIGURED,
+                'Need to provide AWS keys');
+        }
+
+        if (pushConfig.pushTypes) {
+            let pushTypes = Object.keys(pushConfig.pushTypes);
+            for (let pushType of pushTypes) {
+                if (this.validPushTypes.indexOf(pushType) < 0) {
+                    throw new Parse.Error(Parse.Error.PUSH_MISCONFIGURED,
+                        'Push to ' + pushTypes + ' is not supported');
+                }
+                this.availablePushTypes.push(pushType);
+                switch (pushType) {
+                    case 'ios':
+                        this.senderMap[pushType] = this.sendToAPNS.bind(this);
+                        this.arnMap[pushType] = pushConfig.pushTypes[pushType];
+                        break;
+                    case 'android':
+                        this.senderMap[pushType] = this.sendToGCM.bind(this);
+                        this.arnMap[pushType] = pushConfig.pushTypes[pushType];
+                        break;
+                }
+            }
+        }
+
+        AWS.config.update({
+            accessKeyId: pushConfig.accessKey,
+            secretAccessKey: pushConfig.secretKey,
+            region: pushConfig.region || DEFAULT_REGION
+        });
+
+        // Instantiate after config is setup.
+        this.sns = new AWS.SNS();
+    }
+
+    getValidPushTypes() {
+        return this.availablePushTypes;
+    }
+
+    static classifyInstallations(installations, validTypes) {
+        return classifyInstallations(installations, validTypes)
+    }
+
+    //Generate proper json for APNS message
+    static generateiOSPayload(data) {
+        return {
+            'APNS': JSON.stringify(data)
+        };
+    }
+
+    // Generate proper json for GCM message
+    static generateAndroidPayload(data, pushId, timeStamp) {
+        var payload = GCM.generateGCMPayload(data.data, pushId, timeStamp, data.expirationTime);
+
+        // SNS is verify sensitive to the body being JSON stringified but not GCM key.
+        return {
+            'GCM': JSON.stringify(payload)
+        };
+    }
+
+    sendToAPNS(data, devices) {
+        var payload = SNSPushAdapter.generateiOSPayload(data);
+
+        return this.sendToSNS(payload, devices, 'ios');
+    }
+
+    sendToGCM(data, devices) {
+        var payload = SNSPushAdapter.generateAndroidPayload(data);
+        return this.sendToSNS(payload, devices, 'android');
+    }
+
+    sendToSNS(payload, devices, pushType) {
+        // Exchange the device token for the Amazon resource ID
+        let exchangePromises = devices.map((device) => {
+            return this.exchangeTokenPromise(device, pushType);
+        });
+
+        // Publish off to SNS!
+        // Bulk publishing is not yet supported on Amazon SNS.
+        let promises = Parse.Promise.when(exchangePromises).then(arns => {
+            arns.map((arn) => {
+                return this.sendSNSPayload(arn, payload);
+            });
+        });
+
+        return promises;
+    }
+
+
+    /**
+     * Request a Amazon Resource Identifier if one is not set.
+     */
+    getPlatformArn(device, pushType, callback) {
+        var params = {
+            PlatformApplicationArn: this.arnMap[pushType],
+            Token: device.deviceToken
+        };
+
+        this.sns.createPlatformEndpoint(params, callback);
+    }
+
+    /**
+     * Exchange the device token for an ARN
+     */
+    exchangeTokenPromise(device, pushType) {
+        return new Parse.Promise((resolve, reject) => {
+            this.getPlatformArn(device, pushType, (err, data) => {
+                if (data.EndpointArn) {
+                    resolve(data.EndpointArn);
+                } else {
+                    console.error(err);
+                    reject(err);
+                }
+            });
+        });
+    }
+
+    /**
+     * Send the Message, MessageStructure, and Target Amazon Resource Number (ARN) to SNS
+     * @param arn Amazon Resource ID
+     * @param payload JSON-encoded message
+     * @returns {Parse.Promise}
+     */
+    sendSNSPayload(arn, payload) {
+
+        var object = {
+            Message: JSON.stringify(payload),
+            MessageStructure: 'json',
+            TargetArn: arn
+        };
+
+        return new Parse.Promise((resolve, reject) => {
+            this.sns.publish(object, (err, data) => {
+                if (err != null) {
+                    console.error("Error sending push " + err);
+                    return reject(err);
+                }
+                resolve(object);
+            });
+        });
+    }
+
+    // For a given config object, endpoint and payload, publish via SNS
+    // Returns a promise containing the SNS object publish response
+    send(data, installations) {
+        let deviceMap = classifyInstallations(installations, this.availablePushTypes);
+
+        let sendPromises = Object.keys(deviceMap).forEach((pushType) => {
+            var devices = deviceMap[pushType];
+            var sender = this.senderMap[pushType];
+            return sender(data, devices);
+        });
+
+        return Parse.Promise.when(sendPromises);
+    }
+}
+
+export default SNSPushAdapter;
+module.exports = SNSPushAdapter;


### PR DESCRIPTION
TODOS:

- [x] GCM payload code is shared with GCM.js.  To instantiate though you need to supply a GCM key.  For Amazon SNS, we don't need to do it.

- [x] Modify Promise chain to grab all the Amazon ARN's per device token (right now it is looping 1 to 1)

- [x] Chunking the GCM token delivery (may reuse the GCM .js code if possible) - Amazon SNS doesn't look like it allows bulk deliveries.

- [X] Test coverage

- [x] Document how this works:

```javascript
if (process.env.SNS_ENABLE) {

    pushConfig =  { pushTypes : { android: {ARN : YOUR-ANDROID_ARN-HERE},
                                 ios: {ARN: YOUR-IOS_ARN-HERE}, production: false, bundleId: "beta.parseplatform.yourappname"}
                                 },
                   accessKey: process.env.SNS_ACCESS_KEY,
                   secretKey: process.env.SNS_SECRET_ACCESS_KEY,
                   region: "us-west-2"
                 };

    var SNSPushAdapter = require('parse-server/lib/Adapters/Push/SNSPushAdapter');
    var snsPushAdapter = new SNSPushAdapter(pushConfig);
    pushConfig['adapter'] = snsPushAdapter;
}
```

a. Adding Platform endpoints to AWS console
b. Add IAM roles for platform
c. CloudSearch logs debugging

The worst part of adding was figuring out AWS SNS JSON encoding:

http://bit.ly/215rLnq