### PR TITLE
Refactor GCM so it can be reused

### DIFF
--- a/src/Adapters/Push/ParsePushAdapter.js
+++ b/src/Adapters/Push/ParsePushAdapter.js
@@ -4,7 +4,7 @@
 // for ios push.
 
 const Parse = require('parse/node').Parse;
-const GCM = require('../../GCM');
+const GCM = require('../../GCM').GCM;
 const APNS = require('../../APNS');
 import PushAdapter from './PushAdapter';
 import { classifyInstallations } from './PushAdapterUtils';


### PR DESCRIPTION
Trying to use the GCM module to use with Amazon SNS: https://github.com/ParsePlatform/parse-server/pull/711