### PR TITLE
FileSystemAdapter for saving files to the server's file system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ lib/
 
 # Mac DS_Store files
 .DS_Store
+
+# Folder created by FileSystemAdapter
+/files

--- a/spec/FilesController.spec.js
+++ b/spec/FilesController.spec.js
@@ -2,6 +2,7 @@ var FilesController = require('../src/Controllers/FilesController').FilesControl
 var GridStoreAdapter = require("../src/Adapters/Files/GridStoreAdapter").GridStoreAdapter;
 var S3Adapter = require("../src/Adapters/Files/S3Adapter").S3Adapter;
 var GCSAdapter = require("../src/Adapters/Files/GCSAdapter").GCSAdapter;
+var FileSystemAdapter = require("../src/Adapters/Files/FileSystemAdapter").FileSystemAdapter;
 var Config = require("../src/Config");
 
 var FCTestFactory = require("./FilesControllerTestFactory");
@@ -48,5 +49,16 @@ describe("FilesController",()=>{
 
   } else if (!process.env.TRAVIS) {
     console.log("set GCP_PROJECT_ID, GCP_KEYFILE_PATH, and GCS_BUCKET to test GCSAdapter")
+  }
+
+  try {
+    // Test the file system adapter
+    var fsAdapter = new FileSystemAdapter({
+      filesSubDirectory: 'sub1/sub2'
+    });
+
+    FCTestFactory.testAdapter("FileSystemAdapter", fsAdapter);
+  } catch (e) {
+    console.log("Give write access to the file system to test the FileSystemAdapter. Error: " + e);
   }
 });

--- a/src/Adapters/Files/FileSystemAdapter.js
+++ b/src/Adapters/Files/FileSystemAdapter.js
@@ -15,6 +15,9 @@ export class FileSystemAdapter extends FilesAdapter {
 
     this._filesDir = filesSubDirectory;
     this._mkdir(this._getApplicationDir());
+    if (!this._applicationDirExist()) {
+      throw "Files directory doesn't exist.";
+    }
   }
 
   // For a given config object, filename, and data, store a file
@@ -100,7 +103,6 @@ export class FileSystemAdapter extends FilesAdapter {
           console.error("");
           console.error(colors.red("ERROR: In order to use the FileSystemAdapter, write access to the server's file system is required"));
           console.error("");
-          process.exit(1);
       }
       //dir wasn't made, something went wrong
       if(!fs.statSync(root).isDirectory()) throw new Error(e);

--- a/src/Adapters/Files/FileSystemAdapter.js
+++ b/src/Adapters/Files/FileSystemAdapter.js
@@ -14,7 +14,7 @@ export class FileSystemAdapter extends FilesAdapter {
     super();
 
     this._filesDir = filesSubDirectory;
-    this._mkdir(filesSubDirectory);
+    this._mkdir(this._getApplicationDir());
   }
 
   // For a given config object, filename, and data, store a file
@@ -68,10 +68,20 @@ export class FileSystemAdapter extends FilesAdapter {
   /*
     Helpers
    --------------- */
+   _getApplicationDir() {
+    if (this._filesDir) {
+      return 'files/' + this._filesDir;
+    } else {
+      return 'files';
+    }
+   }
+
+  _applicationDirExist() {
+    return fs.existsSync(this._getApplicationDir());
+  }
 
   _getLocalFilePath(filename) {
-    let filesDir = 'files';
-    let applicationDir = filesDir + '/' + this._filesDir;
+    let applicationDir = this._getApplicationDir();
     if (!fs.existsSync(applicationDir)) {
       this._mkdir(applicationDir);
     }

--- a/src/Adapters/Files/FileSystemAdapter.js
+++ b/src/Adapters/Files/FileSystemAdapter.js
@@ -21,7 +21,7 @@ export class FileSystemAdapter extends FilesAdapter {
   // Returns a promise
   createFile(config, filename, data) {
     return new Promise((resolve, reject) => {
-      let filepath = this._getLocalFilePath(config, filename);
+      let filepath = this._getLocalFilePath(filename);
       fs.writeFile(filepath, data, (err) => {
         if(err !== null) {
           return reject(err);
@@ -33,7 +33,7 @@ export class FileSystemAdapter extends FilesAdapter {
 
   deleteFile(config, filename) {
     return new Promise((resolve, reject) => {
-      let filepath = this._getLocalFilePath(config, filename);
+      let filepath = this._getLocalFilePath(filename);
       fs.readFile( filepath , function (err, data) {
         if(err !== null) {
           return reject(err);
@@ -51,7 +51,7 @@ export class FileSystemAdapter extends FilesAdapter {
 
   getFileData(config, filename) {
     return new Promise((resolve, reject) => {
-      let filepath = this._getLocalFilePath(config, filename);
+      let filepath = this._getLocalFilePath(filename);
       fs.readFile( filepath , function (err, data) {
         if(err !== null) {
           return reject(err);
@@ -62,14 +62,14 @@ export class FileSystemAdapter extends FilesAdapter {
   }
 
   getFileLocation(config, filename) {
-    return (config.mount + '/' + this._getLocalFilePath(config, filename));
+    return (config.mount + '/' + this._getLocalFilePath(filename));
   }
 
   /*
     Helpers
    --------------- */
 
-  _getLocalFilePath(config, filename) {
+  _getLocalFilePath(filename) {
     let filesDir = 'files';
     let applicationDir = filesDir + '/' + this._filesDir;
     if (!fs.existsSync(applicationDir)) {

--- a/src/Adapters/Files/FileSystemAdapter.js
+++ b/src/Adapters/Files/FileSystemAdapter.js
@@ -1,0 +1,72 @@
+// FileSystemAdapter
+//
+// Stores files in local file system
+// Requires write access to the server's file system.
+
+import { FilesAdapter } from './FilesAdapter';
+var fs = require('fs');
+
+export class FileSystemAdapter extends FilesAdapter {
+  // For a given config object, filename, and data, store a file
+  // Returns a promise
+  createFile(config, filename, data) {
+    return new Promise((resolve, reject) => {
+      let filepath = this._getLocalFilePath(config, filename);
+      fs.writeFile(filepath, data, (err) => {
+        if(err !== null) {
+          return reject(err);
+        }
+        resolve(data);
+      });
+    });
+  }
+
+  deleteFile(config, filename) {
+    return new Promise((resolve, reject) => {
+      let filepath = this._getLocalFilePath(config, filename);
+      fs.readFile( filepath , function (err, data) {
+        if(err !== null) {
+          return reject(err);
+        }
+        fs.unlink(filepath, (unlinkErr) => {
+        if(err !== null) {
+            return reject(unlinkErr);
+          }
+          resolve(data);
+        });
+      });
+
+    });
+  }
+
+  getFileData(config, filename) {
+    return new Promise((resolve, reject) => {
+      let filepath = this._getLocalFilePath(config, filename);
+      fs.readFile( filepath , function (err, data) {
+        if(err !== null) {
+          return reject(err);
+        }
+        resolve(data);
+      });
+    });
+  }
+
+  getFileLocation(config, filename) {
+    return (config.mount + '/' + this._getLocalFilePath(config, filename));
+  }
+
+  _getLocalFilePath(config, filename) {
+    let filesDir = 'files';
+    if (!fs.existsSync(filesDir)) {
+      fs.mkdirSync(filesDir);
+    }
+
+    let applicationDir = filesDir + '/' + config.applicationId;
+    if (!fs.existsSync(applicationDir)) {
+      fs.mkdirSync(applicationDir);
+    }
+    return (applicationDir + '/' + encodeURIComponent(filename));
+  }
+}
+
+export default FileSystemAdapter;

--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -40,14 +40,6 @@ if (program.args.length > 0 ) {
   jsonPath = path.resolve(jsonPath);
   options = require(jsonPath);
   console.log(`Configuation loaded from ${jsonPath}`)
-} 
-
-if (!program.appId || !program.masterKey || !program.serverURL) {
-  program.outputHelp();
-  console.error("");
-  console.error(colors.red("ERROR: appId, masterKey and serverURL are required"));
-  console.error("");
-  process.exit(1);
 }
 
 options = Object.keys(definitions).reduce(function (options, key) {
@@ -59,6 +51,14 @@ options = Object.keys(definitions).reduce(function (options, key) {
 
 if (!options.serverURL) {
   options.serverURL = `http://localhost:${options.port}${options.mountPath}`;
+}
+
+if (!program.appId || !program.masterKey || !program.serverURL) {
+  program.outputHelp();
+  console.error("");
+  console.error(colors.red("ERROR: appId, masterKey and serverURL are required"));
+  console.error("");
+  process.exit(1);
 }
 
 const app = express();
@@ -77,3 +77,12 @@ app.listen(options.port, function() {
   console.log('');
   console.log('parse-server running on '+options.serverURL);
 });
+
+var handleShutdown = function() {
+  console.log('Termination signal received. Shutting down.');
+  server.close(function () {
+    process.exit(0);
+  });
+};
+process.on('SIGTERM', handleShutdown);
+process.on('SIGINT', handleShutdown);

--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -4,7 +4,6 @@ import { ParseServer } from '../index';
 import definitions from './cli-definitions';
 import program from './utils/commander';
 import colors from 'colors';
-import { FileSystemAdapter } from '../Adapters/Files/FileSystemAdapter';
 
 program.loadDefinitions(definitions);
 
@@ -60,21 +59,6 @@ options = Object.keys(definitions).reduce(function (options, key) {
 
 if (!options.serverURL) {
   options.serverURL = `http://localhost:${options.port}${options.mountPath}`;
-}
-
-if (options.filesAdapter instanceof FileSystemAdapter) {
-  var fs = require('fs');
-
-  try {
-    fs.mkdirSync('files');
-  } catch(e) {
-    if ( e.code == 'EACCES' ) {
-        console.error("");
-        console.error(colors.red("ERROR: In order to use the FileSystemAdapter, write access to the server's file system is required"));
-        console.error("");
-        process.exit(1);
-    }
-  }
 }
 
 const app = express();

--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -4,6 +4,7 @@ import { ParseServer } from '../index';
 import definitions from './cli-definitions';
 import program from './utils/commander';
 import colors from 'colors';
+import { FileSystemAdapter } from '../Adapters/Files/FileSystemAdapter';
 
 program.loadDefinitions(definitions);
 

--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -4,7 +4,6 @@ import { ParseServer } from '../index';
 import definitions from './cli-definitions';
 import program from './utils/commander';
 import colors from 'colors';
-import { FileSystemAdapter } from '../Adapters/Files/FileSystemAdapter';
 
 program.loadDefinitions(definitions);
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,6 @@ import { AnalyticsRouter }     from './Routers/AnalyticsRouter';
 import { ClassesRouter }       from './Routers/ClassesRouter';
 import { FeaturesRouter }      from './Routers/FeaturesRouter';
 import { FileLoggerAdapter }   from './Adapters/Logger/FileLoggerAdapter';
-import { FilesController }     from './Controllers/FilesController';
 import { FilesRouter }         from './Routers/FilesRouter';
 import { FunctionsRouter }     from './Routers/FunctionsRouter';
 import { GCSAdapter }          from './Adapters/Files/GCSAdapter';

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ import { SessionsRouter }      from './Routers/SessionsRouter';
 import { setFeature }          from './features';
 import { UserController }      from './Controllers/UserController';
 import { UsersRouter }         from './Routers/UsersRouter';
+import { FilesController }     from './Controllers/FilesController';
 
 // Mutate the Parse object to add the Cloud Code handlers
 addParseCloud();
@@ -265,5 +266,6 @@ function addParseCloud() {
 module.exports = {
   ParseServer: ParseServer,
   S3Adapter: S3Adapter,
-  GCSAdapter: GCSAdapter
+  GCSAdapter: GCSAdapter,
+  FileSystemAdapter: FileSystemAdapter
 };

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ import { setFeature }          from './features';
 import { UserController }      from './Controllers/UserController';
 import { UsersRouter }         from './Routers/UsersRouter';
 import { FilesController }     from './Controllers/FilesController';
+import { FileSystemAdapter }   from './Adapters/Files/FileSystemAdapter';
 
 // Mutate the Parse object to add the Cloud Code handlers
 addParseCloud();


### PR DESCRIPTION
Can be used while starting the parse-server

```
var api = new ParseServer({
  databaseURI: 'mongodb://localhost:52853/dev',
  appId: 'appId',
  masterKey: "masterKey",
  serverURL: "http://localhost:1337/parse",
  filesAdapter: new FileSystemAdapter({
    filesSubDirectory: 'path/under/files/directory'
  })
});
```
