### PR TITLE
Make GridStoreAdapter persist it's own connection and don't talk to config.database.

### DIFF
--- a/src/DatabaseAdapter.js
+++ b/src/DatabaseAdapter.js
@@ -18,10 +18,12 @@
 import DatabaseController from './Controllers/DatabaseController';
 import MongoStorageAdapter from './Adapters/Storage/Mongo/MongoStorageAdapter';
 
+const DefaultDatabaseURI = 'mongodb://localhost:27017/parse';
+
 let adapter = MongoStorageAdapter;
-var dbConnections = {};
-var databaseURI = 'mongodb://localhost:27017/parse';
-var appDatabaseURIs = {};
+let dbConnections = {};
+let databaseURI = DefaultDatabaseURI;
+let appDatabaseURIs = {};
 
 function setAdapter(databaseAdapter) {
   adapter = databaseAdapter;
@@ -61,5 +63,6 @@ module.exports = {
   setAdapter: setAdapter,
   setDatabaseURI: setDatabaseURI,
   setAppDatabaseURI: setAppDatabaseURI,
-  clearDatabaseURIs: clearDatabaseURIs
+  clearDatabaseURIs: clearDatabaseURIs,
+  defaultDatabaseURI: databaseURI
 };

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ function ParseServer({
   filesAdapter,
   push,
   loggerAdapter,
-  databaseURI,
+  databaseURI = DatabaseAdapter.defaultDatabaseURI,
   cloud,
   collectionPrefix = '',
   clientKey,
@@ -129,7 +129,9 @@ function ParseServer({
     }
   }
 
-  const filesControllerAdapter = loadAdapter(filesAdapter, GridStoreAdapter);
+  const filesControllerAdapter = loadAdapter(filesAdapter, () => {
+    return new GridStoreAdapter(databaseURI);
+  });
   const pushControllerAdapter = loadAdapter(push, ParsePushAdapter);
   const loggerControllerAdapter = loadAdapter(loggerAdapter, FileLoggerAdapter);
   const emailControllerAdapter = loadAdapter(emailAdapter);


### PR DESCRIPTION
No more direct interactions with Mongo, but rather it persists it's own connection.
`FilesAdapter`, or in our case `GridStoreAdapter` is app specific, so it can be just one.