### PR TITLE
Add MongoCollection wrapper and move few basic uses of collection to it.

### DIFF
--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -46,4 +46,8 @@ export default class MongoCollection {
   count(query, { skip, limit, sort } = {}) {
     return this._mongoCollection.count(query, { skip, limit, sort });
   }
+
+  drop() {
+    return this._mongoCollection.drop();
+  }
 }

--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -1,0 +1,49 @@
+
+let mongodb = require('mongodb');
+let Collection = mongodb.Collection;
+
+export default class MongoCollection {
+  _mongoCollection:Collection;
+
+  constructor(mongoCollection:Collection) {
+    this._mongoCollection = mongoCollection;
+  }
+
+  // Does a find with "smart indexing".
+  // Currently this just means, if it needs a geoindex and there is
+  // none, then build the geoindex.
+  // This could be improved a lot but it's not clear if that's a good
+  // idea. Or even if this behavior is a good idea.
+  find(query, { skip, limit, sort } = {}) {
+    return this._rawFind(query, { skip, limit, sort })
+      .catch(error => {
+        // Check for "no geoindex" error
+        if (error.code != 17007 ||
+          !error.message.match(/unable to find index for .geoNear/)) {
+          throw error;
+        }
+        // Figure out what key needs an index
+        let key = error.message.match(/field=([A-Za-z_0-9]+) /)[1];
+        if (!key) {
+          throw error;
+        }
+
+        var index = {};
+        index[key] = '2d';
+        //TODO: condiser moving index creation logic into Schema.js
+        return this._mongoCollection.createIndex(index)
+          // Retry, but just once.
+          .then(() => this._rawFind(query, { skip, limit, sort }));
+      });
+  }
+
+  _rawFind(query, { skip, limit, sort } = {}) {
+    return this._mongoCollection
+      .find(query, { skip, limit, sort })
+      .toArray();
+  }
+
+  count(query, { skip, limit, sort } = {}) {
+    return this._mongoCollection.count(query, { skip, limit, sort });
+  }
+}

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -1,4 +1,6 @@
 
+import MongoCollection from './MongoCollection';
+
 let mongodb = require('mongodb');
 let MongoClient = mongodb.MongoClient;
 
@@ -28,6 +30,12 @@ export class MongoStorageAdapter {
     return this.connect().then(() => {
       return this.database.collection(name);
     });
+  }
+
+  adaptiveCollection(name: string) {
+    return this.connect()
+      .then(() => this.database.collection(name))
+      .then(rawCollection => new MongoCollection(rawCollection));
   }
 
   collectionExists(name: string) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -38,6 +38,10 @@ DatabaseController.prototype.collection = function(className) {
   return this.rawCollection(className);
 };
 
+DatabaseController.prototype.adaptiveCollection = function(className) {
+  return this.adapter.adaptiveCollection(this.collectionPrefix + className);
+};
+
 DatabaseController.prototype.collectionExists = function(className) {
   return this.adapter.collectionExists(this.collectionPrefix + className);
 };
@@ -340,9 +344,8 @@ DatabaseController.prototype.create = function(className, object, options) {
 // to avoid Mongo-format dependencies.
 // Returns a promise that resolves to a list of items.
 DatabaseController.prototype.mongoFind = function(className, query, options = {}) {
-  return this.collection(className).then((coll) => {
-    return coll.find(query, options).toArray();
-  });
+  return this.adaptiveCollection(className)
+    .then(collection => collection.find(query, options));
 };
 
 // Deletes everything in the database matching the current collectionPrefix
@@ -378,23 +381,17 @@ function keysForQuery(query) {
 // Returns a promise for a list of related ids given an owning id.
 // className here is the owning className.
 DatabaseController.prototype.relatedIds = function(className, key, owningId) {
-  var joinTable = '_Join:' + key + ':' + className;
-  return this.collection(joinTable).then((coll) => {
-    return coll.find({owningId: owningId}).toArray();
-  }).then((results) => {
-    return results.map(r => r.relatedId);
-  });
+  return this.adaptiveCollection(joinTableName(className, key))
+    .then(coll => coll.find({owningId : owningId}))
+    .then(results => results.map(r => r.relatedId));
 };
 
 // Returns a promise for a list of owning ids given some related ids.
 // className here is the owning className.
 DatabaseController.prototype.owningIds = function(className, key, relatedIds) {
-  var joinTable = '_Join:' + key + ':' + className;
-  return this.collection(joinTable).then((coll) => {
-    return coll.find({relatedId: {'$in': relatedIds}}).toArray();
-  }).then((results) => {
-    return results.map(r => r.owningId);
-  });
+  return this.adaptiveCollection(joinTableName(className, key))
+    .then(coll => coll.find({ relatedId: { '$in': relatedIds } }))
+    .then(results => results.map(r => r.owningId));
 };
 
 // Modifies query so that it no longer has $in on relation fields, or
@@ -441,38 +438,6 @@ DatabaseController.prototype.reduceRelationKeys = function(className, query) {
         return this.reduceRelationKeys(className, query);
       });
   }
-};
-
-// Does a find with "smart indexing".
-// Currently this just means, if it needs a geoindex and there is
-// none, then build the geoindex.
-// This could be improved a lot but it's not clear if that's a good
-// idea. Or even if this behavior is a good idea.
-DatabaseController.prototype.smartFind = function(coll, where, options) {
-  return coll.find(where, options).toArray()
-    .then((result) => {
-      return result;
-    }, (error) => {
-      // Check for "no geoindex" error
-      if (!error.message.match(/unable to find index for .geoNear/) ||
-          error.code != 17007) {
-        throw error;
-      }
-
-      // Figure out what key needs an index
-      var key = error.message.match(/field=([A-Za-z_0-9]+) /)[1];
-      if (!key) {
-        throw error;
-      }
-
-      var index = {};
-      index[key] = '2d';
-      //TODO: condiser moving index creation logic into Schema.js
-      return coll.createIndex(index).then(() => {
-        // Retry, but just once.
-        return coll.find(where, options).toArray();
-      });
-    });
 };
 
 // Runs a query on the database.
@@ -528,8 +493,8 @@ DatabaseController.prototype.find = function(className, query, options = {}) {
   }).then(() => {
     return this.reduceInRelation(className, query, schema);
   }).then(() => {
-    return this.collection(className);
-  }).then((coll) => {
+    return this.adaptiveCollection(className);
+  }).then(collection => {
     var mongoWhere = transform.transformWhere(schema, className, query);
     if (!isMaster) {
       var orParts = [
@@ -542,9 +507,9 @@ DatabaseController.prototype.find = function(className, query, options = {}) {
       mongoWhere = {'$and': [mongoWhere, {'$or': orParts}]};
     }
     if (options.count) {
-      return coll.count(mongoWhere, mongoOptions);
+      return collection.count(mongoWhere, mongoOptions);
     } else {
-      return this.smartFind(coll, mongoWhere, mongoOptions)
+      return collection.find(mongoWhere, mongoOptions)
         .then((mongoResults) => {
           return mongoResults.map((r) => {
             return this.untransformObject(
@@ -554,5 +519,9 @@ DatabaseController.prototype.find = function(className, query, options = {}) {
     }
   });
 };
+
+function joinTableName(className, key) {
+  return `_Join:${key}:${className}`;
+}
 
 module.exports = DatabaseController;


### PR DESCRIPTION
Adds `MongoCollection` wrapper class that will be used as a replacement for direct mongo drive collection access.
Also, moved few basic things that interact with the collection directly to this new API.

As you can see - we can already move custom indexing logic into MongoCollection, since it's super specific to mongo.
The next steps:
- replace all usages of `database.collection()` to `database.adaptiveCollection()` adding the APIs where we need
- Move transformation logic for find/update/insert directly into MongoCollection
- ...
- PROFIT!