### PR TITLE
Add findOneAndDelete, findOneAndModify to MongoCollection, move most of usages to it.

### DIFF
--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -46,7 +46,19 @@ export default class MongoCollection {
   count(query, { skip, limit, sort } = {}) {
     return this._mongoCollection.count(query, { skip, limit, sort });
   }
-  
+
+  // Atomically finds and updates an object based on query.
+  // The result is the promise with an object that was in the database !AFTER! changes.
+  // Postgres Note: Translates directly to `UPDATE * SET * ... RETURNING *`, which will return data after the change is done.
+  findOneAndUpdate(query, update) {
+    // arguments: query, sort, update, options(optional)
+    // Setting `new` option to true makes it return the after document, not the before one.
+    return this._mongoCollection.findAndModify(query, [], update, { new: true }).then(document => {
+      // Value is the object where mongo returns multiple fields.
+      return document.value;
+    })
+  }
+
   // Atomically find and delete an object based on query.
   // The result is the promise with an object that was in the database before deleting.
   // Postgres Note: Translates directly to `DELETE * FROM ... RETURNING *`, which will return data after delete is done.

--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -46,6 +46,17 @@ export default class MongoCollection {
   count(query, { skip, limit, sort } = {}) {
     return this._mongoCollection.count(query, { skip, limit, sort });
   }
+  
+  // Atomically find and delete an object based on query.
+  // The result is the promise with an object that was in the database before deleting.
+  // Postgres Note: Translates directly to `DELETE * FROM ... RETURNING *`, which will return data after delete is done.
+  findOneAndDelete(query) {
+    // arguments: query, sort
+    return this._mongoCollection.findAndRemove(query, []).then(document => {
+      // Value is the object where mongo returns multiple fields.
+      return document.value;
+    });
+  }
 
   drop() {
     return this._mongoCollection.drop();

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -40,32 +40,27 @@ export class UserController extends AdaptableController {
   
   
   verifyEmail(username, token) {
-    
-    return new Promise((resolve, reject) => {
-      
+    if (!this.shouldVerifyEmails) {
       // Trying to verify email when not enabled
-      if (!this.shouldVerifyEmails) {
-        reject();
-        return;
-      }
-      
-      var database = this.config.database;
-     
-      database.collection('_User').then(coll => {
+      // TODO: Better error here.
+      return Promise.reject();
+    }
+
+    return this.config.database
+      .adaptiveCollection('_User')
+      .then(collection => {
         // Need direct database access because verification token is not a parse field
-        return coll.findAndModify({
+        return collection.findOneAndUpdate({
           username: username,
-          _email_verify_token: token,
-        }, null, {$set: {emailVerified: true}}, (err, doc) => {
-          if (err || !doc.value) {
-            reject(err);
-          } else {
-            resolve(doc.value);
-          }
-        });
+          _email_verify_token: token
+        }, {$set: {emailVerified: true}});
+      })
+      .then(document => {
+        if (!document) {
+          return Promise.reject();
+        }
+        return document;
       });
-       
-    });    
   }
   
   checkResetTokenValidity(username, token) {
@@ -129,24 +124,16 @@ export class UserController extends AdaptableController {
   }
   
   setPasswordResetToken(email) {
-    var database = this.config.database;
-    var token = randomString(25);
-    return new Promise((resolve, reject) => {
-      return database.collection('_User').then(coll => {
+    let token = randomString(25);
+    return this.config.database
+      .adaptiveCollection('_User')
+      .then(collection => {
         // Need direct database access because verification token is not a parse field
-        return coll.findAndModify({
-          email: email,
-        }, null, {$set: {_perishable_token: token}}, (err, doc) => {
-          if (err || !doc.value) {
-            console.error(err);
-            reject(err);
-          } else {
-            doc.value._perishable_token = token;
-            resolve(doc.value);
-          }
-        });
+        return collection.findOneAndUpdate(
+          { email: email}, // query
+          { $set: { _perishable_token: token } } // update
+        );
       });
-    });
   }
 
   sendPasswordResetEmail(email) {

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -69,20 +69,19 @@ export class UserController extends AdaptableController {
   }
   
   checkResetTokenValidity(username, token) {
-    return new Promise((resolve, reject) => {
-      return this.config.database.collection('_User').then(coll => {
-        return coll.findOne({
-          username: username,
-          _perishable_token: token,
-        }, (err, doc) => {
-          if (err || !doc) {
-            reject(err);
-          } else {
-            resolve(doc);
-          }
-        });
+    return this.config.database.adaptiveCollection('_User')
+      .then(collection => {
+          return collection.find({
+            username: username,
+            _perishable_token: token
+          }, { limit: 1 });
+        })
+      .then(results => {
+        if (results.length != 1) {
+          return Promise.reject();
+        }
+        return results[0];
       });
-    });
   }
   
   getUserIfNeeded(user) {

--- a/src/Routers/SchemasRouter.js
+++ b/src/Routers/SchemasRouter.js
@@ -164,14 +164,14 @@ function deleteSchema(req) {
     .then(() => {
       // We've dropped the collection now, so delete the item from _SCHEMA
       // and clear the _Join collections
-      return req.config.database.collection('_SCHEMA')
-        .then(coll => coll.findAndRemove({_id: req.params.className}, []))
-        .then(doc => {
-          if (doc.value === null) {
+      return req.config.database.adaptiveCollection('_SCHEMA')
+        .then(coll => coll.findOneAndDelete({_id: req.params.className}))
+        .then(document => {
+          if (document === null) {
             //tried to delete non-existent class
             return Promise.resolve();
           }
-          return removeJoinTables(req.config.database, doc.value);
+          return removeJoinTables(req.config.database, document);
         });
     })
     .then(() => {


### PR DESCRIPTION
- Add findOneAndDelete
Atomic find and delete if it exists, which directly translates to Postgres
- Add findOneAndModify
Atomic find and update if it exists, which also translates to Postgres.
There is a behavior difference here compared to before - it returns the object with the changes applied, but that's ok and actually simplifies our stuff by a lot.

Move everything, but the Schema.js to it (need few more changes there to support this).

cc @lacker since you are going to be probably interested in this.