### PR TITLE
Update OneSignalPushAdapter.js [Parameters support]

### DIFF
--- a/src/Adapters/Push/OneSignalPushAdapter.js
+++ b/src/Adapters/Push/OneSignalPushAdapter.js
@@ -61,7 +61,7 @@ export class OneSignalPushAdapter extends PushAdapter {
 
     data= deepcopy(data['data']);
 
-    var post = {};
+    var post = deepcopy(data['params']);
     if(data['badge']) {
       if(data['badge'] == "Increment") {
         post['ios_badgeType'] = 'Increase';
@@ -121,7 +121,7 @@ export class OneSignalPushAdapter extends PushAdapter {
   sendToGCM(data,tokens) {
     data= deepcopy(data['data']);
 
-    var post = {};
+   var post = deepcopy(data['params']);
     
     if(data['alert']) {
       post['contents'] = {en: data['alert']};


### PR DESCRIPTION
OneSignal Parameters can now be passed as described in the documentation: https://documentation.onesignal.com/v2.0/docs/notifications-create-notification