### PR TITLE
Fix an installation deduplication bug

### DIFF
--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -853,4 +853,32 @@ describe('miscellaneous', function() {
     });
   });
 
+  it('dedupes an installation properly and returns updatedAt', (done) => {
+    let headers = {
+      'Content-Type': 'application/json',
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-REST-API-Key': 'rest'
+    };
+    let data = {
+      'installationId': 'lkjsahdfkjhsdfkjhsdfkjhsdf',
+      'deviceType': 'embedded'
+    };
+    let requestOptions = {
+      headers: headers,
+      url: 'http://localhost:8378/1/installations',
+      body: JSON.stringify(data)
+    };
+    request.post(requestOptions, (error, response, body) => {
+      expect(error).toBe(null);
+      let b = JSON.parse(body);
+      expect(typeof b.objectId).toEqual('string');
+      request.post(requestOptions, (error, response, body) => {
+        expect(error).toBe(null);
+        let b = JSON.parse(body);
+        expect(typeof b.updatedAt).toEqual('string');
+        done();
+      });
+    });
+  });
+
 });

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -782,8 +782,10 @@ RestWrite.prototype.runDatabaseOperation = function() {
     // Run an update
     return this.config.database.update(
       this.className, this.query, this.data, this.runOptions).then((resp) => {
-        this.response = resp;
-        this.response.updatedAt = this.updatedAt;
+        resp.updatedAt = this.updatedAt;
+        this.response = {
+          response: resp
+        };
       });
   } else {
     // Set the default ACL for the new _User

--- a/src/Routers/ClassesRouter.js
+++ b/src/Routers/ClassesRouter.js
@@ -85,10 +85,7 @@ export class ClassesRouter extends PromiseRouter {
   }
 
   handleUpdate(req) {
-    return rest.update(req.config, req.auth, req.params.className, req.params.objectId, req.body)
-      .then((response) => {
-        return {response: response};
-      });
+    return rest.update(req.config, req.auth, req.params.className, req.params.objectId, req.body);
   }
 
   handleDelete(req) {


### PR DESCRIPTION
Posting the same installation Id to /installations would result in a broken request the second time.

