### PR TITLE
Flatten custom operations in request.object in afterSave hooks.

### DIFF
--- a/spec/OneSignalPushAdapter.spec.js
+++ b/spec/OneSignalPushAdapter.spec.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var OneSignalPushAdapter = require('../src/Adapters/Push/OneSignalPushAdapter');
 var classifyInstallations = require('../src/Adapters/Push/PushAdapterUtils').classifyInstallations;
@@ -210,7 +211,7 @@ describe('OneSignalPushAdapter', () => {
     expect(write).toHaveBeenCalled();
 
     // iOS
-    args = write.calls.first().args;
+    let args = write.calls.first().args;
     expect(args[0]).toEqual(JSON.stringify({
   		'contents': { 'en':'Example content'},
   		'content_available':true,
@@ -219,7 +220,7 @@ describe('OneSignalPushAdapter', () => {
   		'app_id':'APP ID'
   		}));
 
-	// Android
+    // Android
     args = write.calls.mostRecent().args;
     expect(args[0]).toEqual(JSON.stringify({
   		'contents': { 'en':'Example content'},

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -821,17 +821,19 @@ RestWrite.prototype.runAfterTrigger = function() {
     extraData.objectId = this.query.objectId;
   }
 
-  // Build the inflated object, different from beforeSave, originalData is not empty
-  // since developers can change data in the beforeSave.
-  var inflatedObject = triggers.inflate(extraData, this.originalData);
-  inflatedObject._finishFetch(this.data);
   // Build the original object, we only do this for a update write.
-  var originalObject;
+  let originalObject;
   if (this.query && this.query.objectId) {
     originalObject = triggers.inflate(extraData, this.originalData);
   }
 
-  triggers.maybeRunTrigger(triggers.Types.afterSave, this.auth, inflatedObject, originalObject, this.config.applicationId);
+  // Build the inflated object, different from beforeSave, originalData is not empty
+  // since developers can change data in the beforeSave.
+  let updatedObject = triggers.inflate(extraData, this.originalData);
+  updatedObject.set(Parse._decode(undefined, this.data));
+  updatedObject._handleSaveResponse(this.response.response, this.response.status || 200);
+
+  triggers.maybeRunTrigger(triggers.Types.afterSave, this.auth, updatedObject, originalObject, this.config.applicationId);
 };
 
 // A helper to figure out what location this operation happens at.

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -816,6 +816,15 @@ RestWrite.prototype.runDatabaseOperation = function() {
 
 // Returns nothing - doesn't wait for the trigger.
 RestWrite.prototype.runAfterTrigger = function() {
+  if (!this.response || !this.response.response) {
+    return;
+  }
+
+  // Avoid doing any setup for triggers if there is no 'afterSave' trigger for this class.
+  if (!triggers.triggerExists(this.className, triggers.Types.afterSave, this.config.applicationId)) {
+    return Promise.resolve();
+  }
+
   var extraData = {className: this.className};
   if (this.query && this.query.objectId) {
     extraData.objectId = this.query.objectId;


### PR DESCRIPTION
Used the same pipeline with the same data that Parse SDK is using behind the scenes.
`_handleSaveResponse` is triggered on reply via REST API - so we inject the same data there.

cc @wangmengyan95 

Fixes #743.