### PR TITLE
Fix : remove query count limit

### DIFF
--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -501,6 +501,7 @@ DatabaseController.prototype.find = function(className, query, options = {}) {
       mongoWhere = {'$and': [mongoWhere, {'$or': orParts}]};
     }
     if (options.count) {
+      delete mongoOptions.limit;
       return collection.count(mongoWhere, mongoOptions);
     } else {
       return collection.find(mongoWhere, mongoOptions)


### PR DESCRIPTION
Remove the limit on query count. By default the limit is 100. If you
try to get the count of a collection and the collection has more than
100 rows, the result is always 100.