### PR TITLE
Add fast-test script to package.json that doesn't run code-coverage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "build": "./node_modules/.bin/babel src/ -d lib/",
     "pretest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.0.8} ./node_modules/.bin/mongodb-runner start",
     "test": "cross-env NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node ./node_modules/babel-istanbul/lib/cli.js cover -x **/spec/** ./node_modules/jasmine/bin/jasmine.js",
+    "fast-test": "npm run pretest && cross-env NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node ./node_modules/jasmine/bin/jasmine.js; npm run posttest",
     "posttest": "mongodb-runner stop",
     "start": "./bin/parse-server",
     "prepublish": "npm run build"


### PR DESCRIPTION
Waaaaay faster local development.
@drew-gross @andrewimm - how can I make it work with `posttest` and have an ability to pass arguments into it?