### PR TITLE
Expires at fix

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -54,7 +54,7 @@ describe('Parse.User testing', () => {
       success: function(user) {
         Parse.User.logIn("non_existent_user", "asdf3",
                          expectError(Parse.Error.OBJECT_NOT_FOUND, done));
-      }, 
+      },
       error: function(err) {
         console.error(err);
         fail("Shit should not fail");
@@ -1763,5 +1763,22 @@ describe('Parse.User testing', () => {
     });
   });
 
+  it("session expiresAt correct format", (done) => {
+    Parse.User.signUp("asdf", "zxcv", null, {
+      success: function(user) {
+        request.get({
+          url: 'http://localhost:8378/1/classes/_Session',
+          json: true,
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-Master-Key': 'test',
+          },
+        }, (error, response, body) => {
+          expect(body.results[0].expiresAt.__type).toEqual('Date');
+          done();
+        })
+      }
+    });
+  });
 });
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -644,7 +644,7 @@ function untransformObject(schema, className, mongoObject, isNestedObject = fals
         break;
       case 'expiresAt':
       case '_expiresAt':
-        restObject['expiresAt'] = Parse._encode(new Date(mongoObject[key])).iso;
+        restObject['expiresAt'] = Parse._encode(new Date(mongoObject[key]));
         break;
       default:
         // Check other auth data keys


### PR DESCRIPTION
Parse.com returns a Date object, Parse Server returns a string. Turns out the SDKs don't care, but the Dashboard can only handle the Date object.