### PR TITLE
Propagate installationId to all Cloud Code triggers.

### DIFF
--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -749,6 +749,80 @@ describe('miscellaneous', function() {
     });
   });
 
+  it('test beforeSave/afterSave get installationId', function(done) {
+    let triggerTime = 0;
+    Parse.Cloud.beforeSave('GameScore', function(req, res) {
+      triggerTime++;
+      expect(triggerTime).toEqual(1);
+      expect(req.installationId).toEqual('yolo');
+      res.success();
+    });
+    Parse.Cloud.afterSave('GameScore', function(req) {
+      triggerTime++;
+      expect(triggerTime).toEqual(2);
+      expect(req.installationId).toEqual('yolo');
+    });
+
+    var headers = {
+      'Content-Type': 'application/json',
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-REST-API-Key': 'rest',
+      'X-Parse-Installation-Id': 'yolo'
+    };
+    request.post({
+      headers: headers,
+      url: 'http://localhost:8378/1/classes/GameScore',
+      body: JSON.stringify({ a: 'b' })
+    }, (error, response, body) => {
+      expect(error).toBe(null);
+      expect(triggerTime).toEqual(2);
+
+      Parse.Cloud._removeHook("Triggers", "beforeSave", "GameScore");
+      Parse.Cloud._removeHook("Triggers", "afterSave", "GameScore");
+      done();
+    });
+  });
+
+  it('test beforeDelete/afterDelete get installationId', function(done) {
+    let triggerTime = 0;
+    Parse.Cloud.beforeDelete('GameScore', function(req, res) {
+      triggerTime++;
+      expect(triggerTime).toEqual(1);
+      expect(req.installationId).toEqual('yolo');
+      res.success();
+    });
+    Parse.Cloud.afterDelete('GameScore', function(req) {
+      triggerTime++;
+      expect(triggerTime).toEqual(2);
+      expect(req.installationId).toEqual('yolo');
+    });
+
+    var headers = {
+      'Content-Type': 'application/json',
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-REST-API-Key': 'rest',
+      'X-Parse-Installation-Id': 'yolo'
+    };
+    request.post({
+      headers: headers,
+      url: 'http://localhost:8378/1/classes/GameScore',
+      body: JSON.stringify({ a: 'b' })
+    }, (error, response, body) => {
+      expect(error).toBe(null);
+      request.del({
+        headers: headers,
+        url: 'http://localhost:8378/1/classes/GameScore/' + JSON.parse(body).objectId
+      }, (error, response, body) => {
+        expect(error).toBe(null);
+        expect(triggerTime).toEqual(2);
+
+        Parse.Cloud._removeHook("Triggers", "beforeDelete", "GameScore");
+        Parse.Cloud._removeHook("Triggers", "afterDelete", "GameScore");
+        done();
+      });
+    });
+  });
+
   it('test cloud function query parameters', (done) => {
     Parse.Cloud.define('echoParams', (req, res) => {
       res.success(req.params);

--- a/spec/ParseRole.spec.js
+++ b/spec/ParseRole.spec.js
@@ -86,7 +86,7 @@ describe('Parse Role testing', () => {
          return createRole(rolesNames[2], anotherRole, user);
        }).then( (lastRole) => {
          roleIds[lastRole.get("name")] = lastRole.id;
-         var auth = new Auth(new Config("test") , true, user);
+         var auth = new Auth({ config: new Config("test"), isMaster: true, user: user });
          return auth._loadRoles();
        })
      }).then( (roles) => {

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -22,23 +22,22 @@ export class UserController extends AdaptableController {
     }
     super.validateAdapter(adapter);
   }
-  
+
   expectedAdapterType() {
     return MailAdapter;
   }
-  
+
   get shouldVerifyEmails() {
     return this.options.verifyUserEmails;
   }
-  
+
   setEmailVerifyToken(user) {
     if (this.shouldVerifyEmails) {
       user._email_verify_token = randomString(25);
       user.emailVerified = false;
     }
   }
-  
-  
+
   verifyEmail(username, token) {
     if (!this.shouldVerifyEmails) {
       // Trying to verify email when not enabled
@@ -62,7 +61,7 @@ export class UserController extends AdaptableController {
         return document;
       });
   }
-  
+
   checkResetTokenValidity(username, token) {
     return this.config.database.adaptiveCollection('_User')
       .then(collection => {
@@ -78,7 +77,7 @@ export class UserController extends AdaptableController {
         return results[0];
       });
   }
-  
+
   getUserIfNeeded(user) {
     if (user.username && user.email) {
       return Promise.resolve(user);
@@ -90,7 +89,7 @@ export class UserController extends AdaptableController {
     if (user.email) {
       where.email = user.email;
     }
-    
+
     var query = new RestQuery(this.config, Auth.master(this.config), '_User', where);
     return query.execute().then(function(result){
       if (result.results.length != 1) {
@@ -99,7 +98,7 @@ export class UserController extends AdaptableController {
       return result.results[0];
     })
   }
-  
+
 
   sendVerificationEmail(user) {
     if (!this.shouldVerifyEmails) {
@@ -122,7 +121,7 @@ export class UserController extends AdaptableController {
       }
     });
   }
-  
+
   setPasswordResetToken(email) {
     let token = randomString(25);
     return this.config.database
@@ -142,11 +141,11 @@ export class UserController extends AdaptableController {
       //  TODO: No adapter?
       return;
     }
-    
+
     return this.setPasswordResetToken(email).then((user) => {
 
       const token = encodeURIComponent(user._perishable_token);
-      const username = encodeURIComponent(user.username);    
+      const username = encodeURIComponent(user.username);
       let link = `${this.config.requestResetPasswordURL}?token=${token}&username=${username}`
 
       let options = {
@@ -154,7 +153,7 @@ export class UserController extends AdaptableController {
         link: link,
         user: inflate('_User', user),
       };
-      
+
       if (this.adapter.sendPasswordResetEmail) {
         this.adapter.sendPasswordResetEmail(options);
       } else {
@@ -164,13 +163,13 @@ export class UserController extends AdaptableController {
       return Promise.resolve(user);
     });
   }
-  
+
   updatePassword(username, token, password, config) {
    return this.checkResetTokenValidity(username, token).then(() => {
      return updateUserPassword(username, token, password, this.config);
    });
   }
-  
+
   defaultVerificationEmail({link, user, appName, }) {
     let text = "Hi,\n\n" +
 	      "You are being asked to confirm the e-mail address " + user.email + " with " + appName + "\n\n" +
@@ -180,9 +179,9 @@ export class UserController extends AdaptableController {
     let subject = 'Please verify your e-mail for ' + appName;
     return { text, to, subject };
   }
-  
+
   defaultResetPasswordEmail({link, user, appName, }) {
-    let text = "Hi,\n\n" + 
+    let text = "Hi,\n\n" +
         "You requested to reset your password for " + appName + ".\n\n" +
         "" +
         "Click here to reset it:\n" + link;
@@ -193,9 +192,9 @@ export class UserController extends AdaptableController {
 }
 
 // Mark this private
-function updateUserPassword(username, token, password, config) { 
+function updateUserPassword(username, token, password, config) {
     var write = new RestWrite(config, Auth.master(config), '_User', {
-            username: username, 
+            username: username,
             _perishable_token: token
           }, {password: password, _perishable_token: null }, undefined);
     return write.execute();

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -89,7 +89,7 @@ function handleParseHeaders(req, res, next) {
   var isMaster = (info.masterKey === req.config.masterKey);
 
   if (isMaster) {
-    req.auth = new auth.Auth(req.config, true);
+    req.auth = new auth.Auth({ config: req.config, installationId: info.installationId, isMaster: true });
     next();
     return;
   }
@@ -114,23 +114,23 @@ function handleParseHeaders(req, res, next) {
   }
 
   if (!info.sessionToken) {
-    req.auth = new auth.Auth(req.config, false);
+    req.auth = new auth.Auth({ config: req.config, installationId: info.installationId, isMaster: false });
     next();
     return;
   }
 
-  return auth.getAuthForSessionToken(
-    req.config, info.sessionToken).then((auth) => {
+  return auth.getAuthForSessionToken({ config: req.config, installationId: info.installationId, sessionToken: info.sessionToken })
+    .then((auth) => {
       if (auth) {
         req.auth = auth;
         next();
       }
-    }).catch((error) => {
+    })
+    .catch((error) => {
       // TODO: Determine the correct error scenario.
       console.log(error);
       throw new Parse.Error(Parse.Error.UNKNOWN_ERROR, error);
     });
-
 }
 
 var allowCrossDomain = function(req, res, next) {

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -110,12 +110,11 @@ export function getRequestObject(triggerType, auth, parseObject, originalParseOb
   if (auth.user) {
     request['user'] = auth.user;
   }
-  // TODO: Add installation to Auth?
   if (auth.installationId) {
     request['installationId'] = auth.installationId;
   }
   return request;
-};
+}
 
 // Creates the response object, and uses the request object to pass data
 // The API will call this with REST API formatted objects, this will


### PR DESCRIPTION
Turns out that `auth` never had this, so we were never propagating the installationId to any before/after hooks. Fixes #713 