### PR TITLE
Fix delete schema when actual collection does not exist

### DIFF
--- a/src/Routers/SchemasRouter.js
+++ b/src/Routers/SchemasRouter.js
@@ -151,14 +151,20 @@ function deleteSchema(req) {
     throw new Parse.Error(Parse.Error.INVALID_CLASS_NAME, Schema.invalidClassNameMessage(req.params.className));
   }
 
-  return req.config.database.adaptiveCollection(req.params.className)
-    .then(collection => {
-      return collection.count()
-        .then(count => {
-          if (count > 0) {
-            throw new Parse.Error(255, `Class ${req.params.className} is not empty, contains ${count} objects, cannot drop schema.`);
-          }
-          return collection.drop();
+  return req.config.database.collectionExists(req.params.className)
+    .then(exist => {
+      if (!exist) {
+        return Promise.resolve();
+      }
+      return req.config.database.adaptiveCollection(req.params.className)
+        .then(collection => {
+          return collection.count()
+            .then(count => {
+              if (count > 0) {
+                throw new Parse.Error(255, `Class ${req.params.className} is not empty, contains ${count} objects, cannot drop schema.`);
+              }
+              return collection.drop();
+            })
         })
     })
     .then(() => {


### PR DESCRIPTION
Fix for #789
If the collection does not exist, it will jump to the error block and skip everything else.
Check for existence before getting the collection.