### PR TITLE
Convert Schema.js to ES6 class.

### DIFF
--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -180,20 +180,18 @@ describe('Schema', () => {
 
   it('will fail to create a class if that class was already created by an object', done => {
     config.database.loadSchema()
-    .then(schema => {
-      schema.validateObject('NewClass', {foo: 7})
-      .then(() => {
-        schema.reload()
-        .then(schema => schema.addClassIfNotExists('NewClass', {
-          foo: {type: 'String'}
-        }))
-        .catch(error => {
-          expect(error.code).toEqual(Parse.Error.INVALID_CLASS_NAME);
-          expect(error.message).toEqual('Class NewClass already exists.');
-          done();
-        });
+      .then(schema => {
+        schema.validateObject('NewClass', { foo: 7 })
+          .then(() => schema.reloadData())
+          .then(() => schema.addClassIfNotExists('NewClass', {
+            foo: { type: 'String' }
+          }))
+          .catch(error => {
+            expect(error.code).toEqual(Parse.Error.INVALID_CLASS_NAME);
+            expect(error.message).toEqual('Class NewClass already exists.');
+            done();
+          });
       });
-    })
   });
 
   it('will resolve class creation races appropriately', done => {


### PR DESCRIPTION
- Convert to a class
- Cleanup a tad of code duplication
- Most importantly - reduce number of instances of `Schema` that we create.
`this.reloadData()` or the old `this.reload()` no longer returns a new instance, but rather reloads data into the current one.
A bunch of methods where incosistent because of this, since you could be reading data from an old object or a new object.