### PR TITLE
Fix leak warnings in tests, use mongodb-runner from node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "build": "./node_modules/.bin/babel src/ -d lib/",
     "pretest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.0.8} ./node_modules/.bin/mongodb-runner start",
     "test": "cross-env NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node $COVERAGE_OPTION ./node_modules/jasmine/bin/jasmine.js",
-    "posttest": "mongodb-runner stop",
+    "posttest": "./node_modules/.bin/mongodb-runner stop",
     "coverage": "cross-env COVERAGE_OPTION='./node_modules/babel-istanbul/lib/cli.js cover -x **/spec/**' npm test",
     "start": "node ./bin/parse-server",
     "prepublish": "npm run build"

--- a/src/index.js
+++ b/src/index.js
@@ -232,15 +232,18 @@ function ParseServer({
 
   api.use(middlewares.handleParseErrors);
 
-  process.on('uncaughtException', (err) => {
-    if( err.code === "EADDRINUSE" ) { // user-friendly message for this common error
-      console.log(`Unable to listen on port ${err.port}. The port is already in use.`);
-      process.exit(0);
-    }
-    else {
-      throw err;
-    }
-  });
+  //This causes tests to spew some useless warnings, so disable in test
+  if (!process.env.TESTING) {
+    process.on('uncaughtException', (err) => {
+      if( err.code === "EADDRINUSE" ) { // user-friendly message for this common error
+        console.log(`Unable to listen on port ${err.port}. The port is already in use.`);
+        process.exit(0);
+      }
+      else {
+        throw err;
+      }
+    });
+  }
   hooksController.load();
 
   return api;


### PR DESCRIPTION
This will reduce the amount of garbage spewed to the console in tests.