### PR TITLE
Fix Markdown in .github/ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,10 @@
 Make sure these boxes are checked before submitting your issue -- thanks for reporting issues back to Parse Server!
 
--[ ] You've met the [prerequisites](https://github.com/ParsePlatform/parse-server/wiki/Parse-Server-Guide#prerequisites).
+- [ ] You've met the [prerequisites](https://github.com/ParsePlatform/parse-server/wiki/Parse-Server-Guide#prerequisites).
 
--[ ] You're running the [latest version](https://github.com/ParsePlatform/parse-server/releases) of Parse Server.
+- [ ] You're running the [latest version](https://github.com/ParsePlatform/parse-server/releases) of Parse Server.
 
--[ ] You've searched through [existing issues](https://github.com/ParsePlatform/parse-server/issues?utf8=%E2%9C%93&q=). Chances are that your issue has been reported or resolved before.
+- [ ] You've searched through [existing issues](https://github.com/ParsePlatform/parse-server/issues?utf8=%E2%9C%93&q=). Chances are that your issue has been reported or resolved before.
 
 #### Environment Setup
 


### PR DESCRIPTION
Fixed Markdown to make checkboxes work.

Incorrect
```markdown
-[ ] item
```

Correct:
```markdown
- [ ] item (notice space)
```

And this is how it looks like:
-[x] incorrect
- [ ] correct

See [video tutorial](https://youtu.be/ziSkbxWwDIQ?t=26) about checkboxes.