### PR TITLE
Default body to querystring, null encoding

### DIFF
--- a/spec/HTTPRequest.spec.js
+++ b/spec/HTTPRequest.spec.js
@@ -160,13 +160,12 @@ describe("httpRequest", () => {
       done();
     })
   });
+  
   it("should encode a JSON body by default", (done) => {
-    
     let options = {
       body: {"foo": "bar"}, 
     }
-    
-    var result = httpRequest.encodeBody(options);
+    let result = httpRequest.encodeBody(options);
     expect(result.body).toEqual('{"foo":"bar"}');
     expect(result.headers['Content-Type']).toEqual('application/json');
     done();
@@ -174,13 +173,11 @@ describe("httpRequest", () => {
   })
   
   it("should encode a JSON body", (done) => {
-    
     let options = {
       body: {"foo": "bar"}, 
       headers: {'Content-Type': 'application/json'}
     }
-    
-    var result = httpRequest.encodeBody(options);
+    let result = httpRequest.encodeBody(options);
     expect(result.body).toEqual('{"foo":"bar"}');
     done();
     
@@ -190,7 +187,7 @@ describe("httpRequest", () => {
       body: {"foo": "bar", "bar": "baz"},
       headers: {'cOntent-tYpe': 'application/x-www-form-urlencoded'}
     }
-    var result = httpRequest.encodeBody(options);
+    let result = httpRequest.encodeBody(options);
     expect(result.body).toEqual("foo=bar&bar=baz");
     done();
   });
@@ -199,7 +196,7 @@ describe("httpRequest", () => {
       body:{"foo": "bar", "bar": "baz"}, 
       headers: {'cOntent-tYpe': 'mime/jpeg'}
     }
-    var result = httpRequest.encodeBody(options);
+    let result = httpRequest.encodeBody(options);
     expect(result.body).toEqual({"foo": "bar", "bar": "baz"});
     done();
   });

--- a/spec/HTTPRequest.spec.js
+++ b/spec/HTTPRequest.spec.js
@@ -161,13 +161,13 @@ describe("httpRequest", () => {
     })
   });
   
-  it("should encode a JSON body by default", (done) => {
+  it("should encode a query string body by default", (done) => {
     let options = {
       body: {"foo": "bar"}, 
     }
     let result = httpRequest.encodeBody(options);
-    expect(result.body).toEqual('{"foo":"bar"}');
-    expect(result.headers['Content-Type']).toEqual('application/json');
+    expect(result.body).toEqual('foo=bar');
+    expect(result.headers['Content-Type']).toEqual('application/x-www-form-urlencoded');
     done();
     
   })

--- a/spec/HTTPRequest.spec.js
+++ b/spec/HTTPRequest.spec.js
@@ -217,6 +217,17 @@ describe("httpRequest", () => {
         done();
       }
     });
+  });
+  
+  it('should get a cat image', (done) => {
+    httpRequest({
+      url: 'http://thecatapi.com/api/images/get?format=src&type=jpg',
+      followRedirects: true
+    }).then((res) => {
+      expect(res.buffer).not.toBe(null);
+      expect(res.text).not.toBe(null);
+      done();
+    })
   })
 
   it("should params object to query string", (done) => {

--- a/spec/HTTPRequest.spec.js
+++ b/spec/HTTPRequest.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var httpRequest = require("../src/cloud-code/httpRequest"),
     bodyParser = require('body-parser'),
     express = require("express");
@@ -158,31 +160,50 @@ describe("httpRequest", () => {
       done();
     })
   });
+  it("should encode a JSON body by default", (done) => {
+    
+    let options = {
+      body: {"foo": "bar"}, 
+    }
+    
+    var result = httpRequest.encodeBody(options);
+    expect(result.body).toEqual('{"foo":"bar"}');
+    expect(result.headers['Content-Type']).toEqual('application/json');
+    done();
+    
+  })
+  
   it("should encode a JSON body", (done) => {
     
-    var result = httpRequest.encodeBody({"foo": "bar"}, {'Content-Type': 'application/json'});
-    expect(result).toEqual('{"foo":"bar"}');
+    let options = {
+      body: {"foo": "bar"}, 
+      headers: {'Content-Type': 'application/json'}
+    }
+    
+    var result = httpRequest.encodeBody(options);
+    expect(result.body).toEqual('{"foo":"bar"}');
     done();
     
   })
    it("should encode a www-form body", (done) => {
-    
-    var result = httpRequest.encodeBody({"foo": "bar", "bar": "baz"}, {'cOntent-tYpe': 'application/x-www-form-urlencoded'});
-    expect(result).toEqual("foo=bar&bar=baz");
+    let options = {
+      body: {"foo": "bar", "bar": "baz"},
+      headers: {'cOntent-tYpe': 'application/x-www-form-urlencoded'}
+    }
+    var result = httpRequest.encodeBody(options);
+    expect(result.body).toEqual("foo=bar&bar=baz");
     done();
   });
   it("should not encode a wrong content type", (done) => {
-    
-    var result = httpRequest.encodeBody({"foo": "bar", "bar": "baz"}, {'cOntent-tYpe': 'mime/jpeg'});
-    expect(result).toEqual({"foo": "bar", "bar": "baz"});
+    let options = {
+      body:{"foo": "bar", "bar": "baz"}, 
+      headers: {'cOntent-tYpe': 'mime/jpeg'}
+    }
+    var result = httpRequest.encodeBody(options);
+    expect(result.body).toEqual({"foo": "bar", "bar": "baz"});
     done();
   });
-  it("should not encode when missing content type", (done) => {
-    var result = httpRequest.encodeBody({"foo": "bar", "bar": "baz"}, {'X-Custom-Header': 'my-header'});
-    expect(result).toEqual({"foo": "bar", "bar": "baz"});
-    done();
-  });
-  
+
   it("should fail gracefully", (done) => {
     httpRequest({
       url: "http://not a good url",

--- a/src/cloud-code/HTTPResponse.js
+++ b/src/cloud-code/HTTPResponse.js
@@ -1,0 +1,21 @@
+
+export default class HTTPResponse {
+  constructor(response) {
+    this.status = response.statusCode;
+    this.headers = response.headers;
+    this.buffer = response.body;
+    this.cookies = response.headers["set-cookie"];
+  }
+  
+  get text() {
+    return this.buffer.toString('utf-8');
+  }
+  get data() {
+    if (!this._data) {
+      try {
+      this._data = JSON.parse(this.text);
+      } catch (e) {}
+    }
+    return this._data;
+  }
+}

--- a/src/cloud-code/HTTPResponse.js
+++ b/src/cloud-code/HTTPResponse.js
@@ -13,7 +13,7 @@ export default class HTTPResponse {
   get data() {
     if (!this._data) {
       try {
-      this._data = JSON.parse(this.text);
+        this._data = JSON.parse(this.text);
       } catch (e) {}
     }
     return this._data;

--- a/src/cloud-code/httpRequest.js
+++ b/src/cloud-code/httpRequest.js
@@ -1,6 +1,7 @@
 var request = require("request"),
   querystring = require('querystring'),
   Parse = require('parse/node').Parse;
+  HTTPResponse = require('./HTTPResponse').HTTPResponse;
 
 var encodeBody = function(options = {}) {
   let body = options.body;
@@ -62,15 +63,8 @@ module.exports = function(options) {
       }
       return promise.reject(error);
     }
-    var httpResponse = {};
-    httpResponse.status = response.statusCode;
-    httpResponse.headers = response.headers;
-    httpResponse.buffer = response.body;
-    httpResponse.cookies = response.headers["set-cookie"];
-    httpResponse.text = response.body.toString('utf-8');
-    try {
-      httpResponse.data = JSON.parse(httpResponse.text);
-    } catch (e) {}
+    let httpResponse = new HTTPResponse(response);
+    
     // Consider <200 && >= 400 as errors 
     if (httpResponse.status < 200 || httpResponse.status >= 400) {
       if (callbacks.error) {

--- a/src/cloud-code/httpRequest.js
+++ b/src/cloud-code/httpRequest.js
@@ -13,12 +13,10 @@ var encodeBody = function({body, headers = {}}) {
 
   if (contentTypeKeys.length == 0) {
     // no content type
-    try {
-      body = JSON.stringify(body);
-      headers['Content-Type'] = 'application/json';
-    } catch(e) {
-      // do nothing;
-    }
+    //  As per https://parse.com/docs/cloudcode/guide#cloud-code-advanced-sending-a-post-request the default encoding is supposedly x-www-form-urlencoded
+    
+    body = querystring.stringify(body);
+    headers['Content-Type'] = 'application/x-www-form-urlencoded';
   } else {
     /* istanbul ignore next */
     if (contentTypeKeys.length > 1) {
@@ -29,9 +27,7 @@ var encodeBody = function({body, headers = {}}) {
     if (headers[contentType].match(/application\/json/i)) {
       body = JSON.stringify(body);
     } else if(headers[contentType].match(/application\/x-www-form-urlencoded/i)) {
-      body = Object.keys(body).map(function(key){
-        return `${key}=${encodeURIComponent(body[key])}`
-      }).join("&");
+      body = querystring.stringify(body);
     }
   }
   return {body, headers};

--- a/src/cloud-code/httpRequest.js
+++ b/src/cloud-code/httpRequest.js
@@ -52,6 +52,8 @@ module.exports = function(options) {
   } else if (typeof options.params === 'string') {
     options.qs = querystring.parse(options.params);
   }
+  // force the response as a buffer
+  options.encoding = null;
 
   request(options, (error, response, body) => {
     if (error) {
@@ -63,11 +65,11 @@ module.exports = function(options) {
     var httpResponse = {};
     httpResponse.status = response.statusCode;
     httpResponse.headers = response.headers;
-    httpResponse.buffer = new Buffer(response.body);
+    httpResponse.buffer = response.body;
     httpResponse.cookies = response.headers["set-cookie"];
-    httpResponse.text = response.body;
+    httpResponse.text = response.body.toString('utf-8');
     try {
-      httpResponse.data = JSON.parse(response.body);
+      httpResponse.data = JSON.parse(httpResponse.text);
     } catch (e) {}
     // Consider <200 && >= 400 as errors 
     if (httpResponse.status < 200 || httpResponse.status >= 400) {


### PR DESCRIPTION
fixes #727 

- sets the default encoding to null to prevent parsing to utf-8 upon reception as per: https://github.com/flovilmart/parse-image/issues/7


> encoding - Encoding to be used on setEncoding of response data. If null, the body is returned as a Buffer. Anything else (including the default value of undefined) will be passed as the encoding parameter to toString() (meaning this is effectively utf8 by default). (Note: if you expect binary data, you should set encoding: null.)
