### PR TITLE
Migrate ParseGlobalConfig to new database storage API.

### DIFF
--- a/spec/ParseGlobalConfig.spec.js
+++ b/spec/ParseGlobalConfig.spec.js
@@ -5,21 +5,21 @@ var Parse = require('parse/node').Parse;
 let Config = require('../src/Config');
 
 describe('a GlobalConfig', () => {
-  beforeEach(function(done) {
+  beforeEach(function (done) {
     let config = new Config('test');
-    config.database.rawCollection('_GlobalConfig')
-      .then(coll => coll.updateOne({ '_id': 1}, { $set: { params: { companies: ['US', 'DK'] } } }, { upsert: true }))
+    config.database.adaptiveCollection('_GlobalConfig')
+      .then(coll => coll.upsertOne({ '_id': 1 }, { $set: { params: { companies: ['US', 'DK'] } } }))
       .then(done());
   });
 
   it('can be retrieved', (done) => {
     request.get({
-      url: 'http://localhost:8378/1/config',
-      json: true,
+      url    : 'http://localhost:8378/1/config',
+      json   : true,
       headers: {
         'X-Parse-Application-Id': 'test',
-        'X-Parse-Master-Key': 'test',
-      },
+        'X-Parse-Master-Key'    : 'test'
+      }
     }, (error, response, body) => {
       expect(response.statusCode).toEqual(200);
       expect(body.params.companies).toEqual(['US', 'DK']);
@@ -29,13 +29,13 @@ describe('a GlobalConfig', () => {
 
   it('can be updated when a master key exists', (done) => {
     request.put({
-      url: 'http://localhost:8378/1/config',
-      json: true,
-      body: { params: { companies: ['US', 'DK', 'SE'] } },
+      url    : 'http://localhost:8378/1/config',
+      json   : true,
+      body   : { params: { companies: ['US', 'DK', 'SE'] } },
       headers: {
         'X-Parse-Application-Id': 'test',
-        'X-Parse-Master-Key': 'test'
-      },
+        'X-Parse-Master-Key'    : 'test'
+      }
     }, (error, response, body) => {
       expect(response.statusCode).toEqual(200);
       expect(body.result).toEqual(true);
@@ -45,35 +45,35 @@ describe('a GlobalConfig', () => {
 
   it('fail to update if master key is missing', (done) => {
     request.put({
-      url: 'http://localhost:8378/1/config',
-      json: true,
-      body: { params: { companies: [] } },
+      url    : 'http://localhost:8378/1/config',
+      json   : true,
+      body   : { params: { companies: [] } },
       headers: {
         'X-Parse-Application-Id': 'test',
-        'X-Parse-REST-API-Key': 'rest'
-      },
+        'X-Parse-REST-API-Key'  : 'rest'
+      }
     }, (error, response, body) => {
       expect(response.statusCode).toEqual(403);
       expect(body.error).toEqual('unauthorized: master key is required');
       done();
     });
-  });  
+  });
 
   it('failed getting config when it is missing', (done) => {
     let config = new Config('test');
-    config.database.rawCollection('_GlobalConfig')
-      .then(coll => coll.deleteOne({ '_id': 1}, {}, {}))
-      .then(_ => {
+    config.database.adaptiveCollection('_GlobalConfig')
+      .then(coll => coll.deleteOne({ '_id': 1 }))
+      .then(() => {
         request.get({
-          url: 'http://localhost:8378/1/config',
-          json: true,
+          url    : 'http://localhost:8378/1/config',
+          json   : true,
           headers: {
             'X-Parse-Application-Id': 'test',
-            'X-Parse-Master-Key': 'test',
-          },
+            'X-Parse-Master-Key'    : 'test'
+          }
         }, (error, response, body) => {
-          expect(response.statusCode).toEqual(404);
-          expect(body.code).toEqual(Parse.Error.INVALID_KEY_NAME);
+          expect(response.statusCode).toEqual(200);
+          expect(body.params).toEqual({});
           done();
         });
       });

--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -75,6 +75,10 @@ export default class MongoCollection {
     });
   }
 
+  deleteOne(query) {
+    return this._mongoCollection.deleteOne(query);
+  }
+
   remove(query) {
     return this._mongoCollection.remove(query);
   }

--- a/src/Routers/GlobalConfigRouter.js
+++ b/src/Routers/GlobalConfigRouter.js
@@ -1,38 +1,28 @@
 // global_config.js
 
-var Parse = require('parse/node').Parse;
-
 import PromiseRouter from '../PromiseRouter';
 import * as middleware from "../middlewares";
 
 export class GlobalConfigRouter extends PromiseRouter {
   getGlobalConfig(req) {
-    return req.config.database.rawCollection('_GlobalConfig')
-      .then(coll => coll.findOne({'_id': 1}))
-      .then(globalConfig => ({response: { params: globalConfig.params }}))
-      .catch(() => ({
-        status: 404,
-        response: {
-          code: Parse.Error.INVALID_KEY_NAME,
-          error: 'config does not exist',
+    return req.config.database.adaptiveCollection('_GlobalConfig')
+      .then(coll => coll.find({ '_id': 1 }, { limit: 1 }))
+      .then(results => {
+        if (results.length != 1) {
+          // If there is no config in the database - return empty config.
+          return { response: { params: {} } };
         }
-      }));
+        let globalConfig = results[0];
+        return { response: { params: globalConfig.params } };
+      });
   }
+
   updateGlobalConfig(req) {
-    return req.config.database.rawCollection('_GlobalConfig')
-      .then(coll => coll.findOneAndUpdate({ _id: 1 }, { $set: req.body }))
-      .then(response => {
-        return { response: { result: true } }
-      })
-      .catch(() => ({
-        status: 404,
-        response: {
-          code: Parse.Error.INVALID_KEY_NAME,
-          error: 'config cannot be updated',
-        }
-     }));
+    return req.config.database.adaptiveCollection('_GlobalConfig')
+      .then(coll => coll.upsertOne({ _id: 1 }, { $set: req.body }))
+      .then(() => ({ response: { result: true } }));
   }
-  
+
   mountRoutes() {
     this.route('GET', '/config', req => { return this.getGlobalConfig(req) });
     this.route('PUT', '/config', middleware.promiseEnforceMasterKeyAccess, req => { return this.updateGlobalConfig(req) });


### PR DESCRIPTION
Also fix the thing, so it properly upserts if config does not exist.
This is modeled close to how parse.com works.