### PR TITLE
Fix flaky Parse.GeoPoint test.

### DIFF
--- a/spec/ParseGeoPoint.spec.js
+++ b/spec/ParseGeoPoint.spec.js
@@ -39,37 +39,33 @@ describe('Parse.GeoPoint testing', () => {
     });
   });
 
-//
-// This test is disabled, since it's extremely flaky on Travis-CI.
-// Tracking issue: https://github.com/ParsePlatform/parse-server/issues/572
-//
-//  it('geo line', (done) => {
-//     var line = [];
-//     for (var i = 0; i < 10; ++i) {
-//       var obj = new TestObject();
-//       var point = new Parse.GeoPoint(i * 4.0 - 12.0, i * 3.2 - 11.0);
-//       obj.set('location', point);
-//       obj.set('construct', 'line');
-//       obj.set('seq', i);
-//       line.push(obj);
-//     }
-//     Parse.Object.saveAll(line, {
-//       success: function() {
-//         var query = new Parse.Query(TestObject);
-//         var point = new Parse.GeoPoint(24, 19);
-//         query.equalTo('construct', 'line');
-//         query.withinMiles('location', point, 10000);
-//         query.find({
-//           success: function(results) {
-//             equal(results.length, 10);
-//             equal(results[0].get('seq'), 9);
-//             equal(results[3].get('seq'), 6);
-//             done();
-//           }
-//         });
-//       }
-//     });
-//   });
+  it('geo line', (done) => {
+    var line = [];
+    for (var i = 0; i < 10; ++i) {
+      var obj = new TestObject();
+      var point = new Parse.GeoPoint(i * 4.0 - 12.0, i * 3.2 - 11.0);
+      obj.set('location', point);
+      obj.set('construct', 'line');
+      obj.set('seq', i);
+      line.push(obj);
+    }
+    Parse.Object.saveAll(line, {
+      success: function() {
+        var query = new Parse.Query(TestObject);
+        var point = new Parse.GeoPoint(24, 19);
+        query.equalTo('construct', 'line');
+        query.withinMiles('location', point, 10000);
+        query.find({
+          success: function(results) {
+            equal(results.length, 10);
+            equal(results[0].get('seq'), 9);
+            equal(results[3].get('seq'), 6);
+            done();
+          }
+        });
+      }
+    });
+  });
 
   it('geo max distance large', (done) => {
     var objects = [];

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -448,9 +448,12 @@ class Schema {
         geocount++;
       }
       if (geocount > 1) {
-        throw new Parse.Error(
-          Parse.Error.INCORRECT_TYPE,
-          'there can only be one geopoint field in a class');
+        // Make sure all field validation operations run before we return.
+        // If not - we are continuing to run logic, but already provided response from the server.
+        return promise.then(() => {
+          return Promise.reject(new Parse.Error(Parse.Error.INCORRECT_TYPE,
+            'there can only be one geopoint field in a class'));
+        });
       }
       if (!expected) {
         continue;


### PR DESCRIPTION
I finally caught a condition when this fails - turns out that this is impacted by a state overflow from previous test, where upsert one the collection finishes after we deleted everything, ending up creating another column with a double geo point.
This is a valid fix for everyone regardless, because we are starting promises that can mutate schema, but are responding back from the server before the operation finishes. This merely awaits on it, thus eliminating the possibility of any state overflows.
Validated a fix by running tests over 5k times :)

cc @flovilmart, @drewgross

and newcomer - @mcdonamp (you complained about it when building GCS :grin: )