### PR TITLE
#911 support params option in Parse.Cloud.httpRequest

### DIFF
--- a/spec/HTTPRequest.spec.js
+++ b/spec/HTTPRequest.spec.js
@@ -24,7 +24,11 @@ app.get("/301", function(req, res){
 
 app.post('/echo', function(req, res){
   res.json(req.body);
-})
+});
+
+app.get('/qs', function(req, res){
+  res.json(req.query);
+});
 
 app.listen(13371);
 
@@ -193,4 +197,35 @@ describe("httpRequest", () => {
       }
     });
   })
+
+  it("should params object to query string", (done) => {
+    httpRequest({
+      url: httpRequestServer+"/qs",
+      params: {
+         foo: "bar"
+      }
+    }).then(function(httpResponse){
+      expect(httpResponse.status).toBe(200);
+      expect(httpResponse.data).toEqual({foo: "bar"});
+      done();
+    }, function(){
+      fail("should not fail");
+      done();
+    })
+  });
+
+  it("should params string to query string", (done) => {
+    httpRequest({
+      url: httpRequestServer+"/qs",
+      params: "foo=bar&foo2=bar2"
+    }).then(function(httpResponse){
+      expect(httpResponse.status).toBe(200);
+      expect(httpResponse.data).toEqual({foo: "bar", foo2: 'bar2'});
+      done();
+    }, function(){
+      fail("should not fail");
+      done();
+    })
+  });
+
 });

--- a/src/cloud-code/httpRequest.js
+++ b/src/cloud-code/httpRequest.js
@@ -1,4 +1,5 @@
 var request = require("request"),
+  querystring = require('querystring'),
   Parse = require('parse/node').Parse;
 
 var encodeBody = function(body, headers = {}) {
@@ -34,7 +35,13 @@ module.exports = function(options) {
   options.body = encodeBody(options.body, options.headers);
   // set follow redirects to false by default
   options.followRedirect = options.followRedirects == true;
-  
+  // support params options
+  if (typeof options.params === 'object') {
+    options.qs = options.params;
+  } else if (typeof options.params === 'string') {
+    options.qs = querystring.parse(options.params);
+  }
+
   request(options, (error, response, body) => {
     if (error) {
       if (callbacks.error) {


### PR DESCRIPTION
refs #911 

https://parse.com/docs/cloudcode/guide#cloud-code-advanced-query-parameters