### PR TITLE
Minimize db query

### DIFF
--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -168,9 +168,7 @@ RestQuery.prototype.validateClientClassCreation = function() {
   let sysClass = ['_User', '_Installation', '_Role', '_Session', '_Product'];
   if (this.config.allowClientClassCreation === false && !this.auth.isMaster
       && sysClass.indexOf(this.className) === -1) {
-    return this.config.database.loadSchema().then((schema) => {
-      return schema.hasClass(this.className)
-    }).then((hasClass) => {
+    return this.config.database.collectionExists(this.className).then((hasClass) => {
       if (hasClass === true) {
         return Promise.resolve();
       }

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -112,9 +112,7 @@ RestWrite.prototype.validateClientClassCreation = function() {
   let sysClass = ['_User', '_Installation', '_Role', '_Session', '_Product'];
   if (this.config.allowClientClassCreation === false && !this.auth.isMaster
       && sysClass.indexOf(this.className) === -1) {
-    return this.config.database.loadSchema().then((schema) => {
-      return schema.hasClass(this.className)
-    }).then((hasClass) => {
+    return this.config.database.collectionExists(this.className).then((hasClass) => {
       if (hasClass === true) {
         return Promise.resolve();
       }


### PR DESCRIPTION
#896 do exist when `allowClientClassCreation = true`.
Using `loadSchema` and `hasClass` together will call Schema `reloadData` for three times, which is redundant in our case.
Changed to use `collectionExists` from db adapter.

Suppose user(admin) will not always update the schema if disabled allowClientClassCreation, we may consider cache the schema object in the future.