### PR TITLE
Do not require where clause in  condition on queries.

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -2,6 +2,9 @@
 // hungry/js/test/parse_query_test.js
 //
 // Some new tests are added.
+'use strict';
+
+const Parse = require('parse/node');
 
 describe('Parse.Query testing', () => {
   it("basic query", function(done) {
@@ -1574,6 +1577,29 @@ describe('Parse.Query testing', () => {
     });
   });
 
+  it("dontSelect query without conditions", function(done) {
+    const RestaurantObject = Parse.Object.extend("Restaurant");
+    const PersonObject = Parse.Object.extend("Person");
+    const objects = [
+      new RestaurantObject({ location: "Djibouti" }),
+      new RestaurantObject({ location: "Ouagadougou" }),
+      new PersonObject({ name: "Bob", hometown: "Djibouti" }),
+      new PersonObject({ name: "Tom", hometown: "Yoloblahblahblah" }),
+      new PersonObject({ name: "Billy", hometown: "Ouagadougou" })
+    ];
+
+    Parse.Object.saveAll(objects, function() {
+      const query = new Parse.Query(RestaurantObject);
+      const mainQuery = new Parse.Query(PersonObject);
+      mainQuery.doesNotMatchKeyInQuery("hometown", "location", query);
+      mainQuery.find().then(results => {
+        equal(results.length, 1);
+        equal(results[0].get('name'), 'Tom');
+        done();
+      });
+    });
+  });
+
   it("object with length", function(done) {
     var TestObject = Parse.Object.extend("TestObject");
     var obj = new TestObject();
@@ -2088,7 +2114,7 @@ describe('Parse.Query testing', () => {
       console.log(error);
     });
   });
-  
+
   // #371
   it('should properly interpret a query', (done) => {
     var query = new Parse.Query("C1");
@@ -2104,7 +2130,7 @@ describe('Parse.Query testing', () => {
       done();
     })
   });
-  
+
   it('should properly interpret a query', (done) => {
     var user = new Parse.User();
     user.set("username", "foo");
@@ -2112,22 +2138,22 @@ describe('Parse.Query testing', () => {
     return user.save().then( (user) => {
       var objIdQuery = new Parse.Query("_User").equalTo("objectId", user.id);
       var blockedUserQuery = user.relation("blockedUsers").query();
-      
+
       var aResponseQuery = new Parse.Query("MatchRelationshipActivityResponse");
       aResponseQuery.equalTo("userA", user);
       aResponseQuery.equalTo("userAResponse", 1);
-      
+
       var bResponseQuery = new Parse.Query("MatchRelationshipActivityResponse");
       bResponseQuery.equalTo("userB", user);
       bResponseQuery.equalTo("userBResponse", 1);
-      
+
       var matchOr = Parse.Query.or(aResponseQuery, bResponseQuery);
       var matchRelationshipA = new Parse.Query("_User");
       matchRelationshipA.matchesKeyInQuery("objectId", "userAObjectId", matchOr);
       var matchRelationshipB = new Parse.Query("_User");
       matchRelationshipB.matchesKeyInQuery("objectId", "userBObjectId", matchOr);
-      
-      
+
+
       var orQuery = Parse.Query.or(objIdQuery, blockedUserQuery, matchRelationshipA, matchRelationshipB);
       var query = new Parse.Query("_User");
       query.doesNotMatchQuery("objectId", orQuery);
@@ -2140,8 +2166,8 @@ describe('Parse.Query testing', () => {
       fail("should not fail");
       done();
     });
-    
-    
+
+
   });
-  
+
 });

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -324,12 +324,10 @@ RestQuery.prototype.replaceDontSelect = function() {
       !dontSelectValue.key ||
       typeof dontSelectValue.query !== 'object' ||
       !dontSelectValue.query.className ||
-      !dontSelectValue.query.where ||
       Object.keys(dontSelectValue).length !== 2) {
     throw new Parse.Error(Parse.Error.INVALID_QUERY,
                           'improper usage of $dontSelect');
   }
-
   var subquery = new RestQuery(
     this.config, this.auth, dontSelectValue.query.className,
     dontSelectValue.query.where);


### PR DESCRIPTION
This is not required for $select, so looks like it shouldn't be required for $dontSelect.
Fixes ParsePlatform/Parse-SDK-iOS-OSX#845