### PR TITLE
Bug fix: Not getting correct user when using a custom oauth authenticator

### DIFF
--- a/src/Auth.js
+++ b/src/Auth.js
@@ -50,7 +50,7 @@ var getAuthForSessionToken = function({ config, sessionToken, installationId } =
   }
   var restOptions = {
     limit: 1,
-    include: 'user'
+    include: '_p_user'
   };
   var restWhere = {
     _session_token: sessionToken

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -57,7 +57,7 @@ export class UsersRouter extends ClassesRouter {
     let sessionToken = req.info.sessionToken;
     return rest.find(req.config, Auth.master(req.config), '_Session',
       { _session_token: sessionToken },
-      { include: 'user' })
+      { include: '_p_user' })
       .then((response) => {
         if (!response.results ||
           response.results.length == 0 ||


### PR DESCRIPTION
Hi everyone,

we are facing a issue here that the logged user cannot be found when using a [custom OAuth authenticator](https://github.com/ParsePlatform/parse-server/wiki/Parse-Server-Guide#custom-authentication). This patch resolves this issue, but I really don't know if this change is valid or not. Please, let me know if this solution is correct or there is another way to resolve this issue!