### PR TITLE
Add new schema collection type and replace all usages of direct mongo collection for schema operations.

### DIFF
--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -76,17 +76,6 @@ export default class MongoCollection {
     return this._mongoCollection.updateMany(query, update);
   }
 
-  // Atomically find and delete an object based on query.
-  // The result is the promise with an object that was in the database before deleting.
-  // Postgres Note: Translates directly to `DELETE * FROM ... RETURNING *`, which will return data after delete is done.
-  findOneAndDelete(query) {
-    // arguments: query, sort
-    return this._mongoCollection.findAndRemove(query, []).then(document => {
-      // Value is the object where mongo returns multiple fields.
-      return document.value;
-    });
-  }
-
   deleteOne(query) {
     return this._mongoCollection.deleteOne(query);
   }

--- a/src/Adapters/Storage/Mongo/MongoSchemaCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoSchemaCollection.js
@@ -1,0 +1,58 @@
+
+import MongoCollection from './MongoCollection';
+
+function _mongoSchemaQueryFromNameQuery(name: string, query) {
+  return _mongoSchemaObjectFromNameFields(name, query);
+}
+
+function _mongoSchemaObjectFromNameFields(name: string, fields) {
+  let object = { _id: name };
+  if (fields) {
+    Object.keys(fields).forEach(key => {
+      object[key] = fields[key];
+    });
+  }
+  return object;
+}
+
+export default class MongoSchemaCollection {
+  _collection: MongoCollection;
+
+  constructor(collection: MongoCollection) {
+    this._collection = collection;
+  }
+
+  getAllSchemas() {
+    return this._collection._rawFind({});
+  }
+
+  findSchema(name: string) {
+    return this._collection._rawFind(_mongoSchemaQueryFromNameQuery(name), { limit: 1 }).then(results => {
+      return results[0];
+    });
+  }
+
+  // Atomically find and delete an object based on query.
+  // The result is the promise with an object that was in the database before deleting.
+  // Postgres Note: Translates directly to `DELETE * FROM ... RETURNING *`, which will return data after delete is done.
+  findAndDeleteSchema(name: string) {
+    // arguments: query, sort
+    return this._collection._mongoCollection.findAndRemove(_mongoSchemaQueryFromNameQuery(name), []).then(document => {
+      // Value is the object where mongo returns multiple fields.
+      return document.value;
+    });
+  }
+
+  addSchema(name: string, fields) {
+    let mongoObject = _mongoSchemaObjectFromNameFields(name, fields);
+    return this._collection.insertOne(mongoObject);
+  }
+
+  updateSchema(name: string, update) {
+    return this._collection.updateOne(_mongoSchemaQueryFromNameQuery(name), update);
+  }
+
+  upsertSchema(name: string, query: string, update) {
+    return this._collection.upsertOne(_mongoSchemaQueryFromNameQuery(name, query), update);
+  }
+}

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -1,8 +1,11 @@
 
 import MongoCollection from './MongoCollection';
+import MongoSchemaCollection from './MongoSchemaCollection';
 
 let mongodb = require('mongodb');
 let MongoClient = mongodb.MongoClient;
+
+const MongoSchemaCollectionName = '_SCHEMA';
 
 export class MongoStorageAdapter {
   // Private
@@ -36,6 +39,12 @@ export class MongoStorageAdapter {
     return this.connect()
       .then(() => this.database.collection(name))
       .then(rawCollection => new MongoCollection(rawCollection));
+  }
+
+  schemaCollection(collectionPrefix: string) {
+    return this.connect()
+      .then(() => this.adaptiveCollection(collectionPrefix + MongoSchemaCollectionName))
+      .then(collection => new MongoSchemaCollection(collection));
   }
 
   collectionExists(name: string) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -63,7 +63,7 @@ DatabaseController.prototype.validateClassName = function(className) {
 DatabaseController.prototype.loadSchema = function(acceptor = returnsTrue) {
 
   if (!this.schemaPromise) {
-    this.schemaPromise = this.adaptiveCollection('_SCHEMA').then(collection => {
+    this.schemaPromise = this.schemaCollection().then(collection => {
       delete this.schemaPromise;
       return Schema.load(collection);
     });
@@ -74,7 +74,7 @@ DatabaseController.prototype.loadSchema = function(acceptor = returnsTrue) {
     if (acceptor(schema)) {
       return schema;
     }
-    this.schemaPromise = this.adaptiveCollection('_SCHEMA').then(collection => {
+    this.schemaPromise = this.schemaCollection().then(collection => {
       delete this.schemaPromise;
       return Schema.load(collection);
     });

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -33,6 +33,10 @@ DatabaseController.prototype.adaptiveCollection = function(className) {
   return this.adapter.adaptiveCollection(this.collectionPrefix + className);
 };
 
+DatabaseController.prototype.schemaCollection = function() {
+  return this.adapter.schemaCollection(this.collectionPrefix);
+};
+
 DatabaseController.prototype.collectionExists = function(className) {
   return this.adapter.collectionExists(this.collectionPrefix + className);
 };


### PR DESCRIPTION
This abstraction will give us an ability to use different syntax for Postgres, since schemas are not going to be represented as pure objects, but rather as tables and objects.

Also, cleans up the implementation and makes it more safe to build features on top.
Next stop - move schema api->mongo type conversions directly into MongoSchemaCollection.