### PR TITLE
Changed FileLoggerAdapterSpec to fail gracefully on Windows

### DIFF
--- a/spec/FileLoggerAdapter.spec.js
+++ b/spec/FileLoggerAdapter.spec.js
@@ -35,8 +35,13 @@ describe('info logs', () => {
         size: 1,
         level: 'info'
       }, (results) => {
-        expect(results[0].message).toEqual('testing info logs');
-        done();
+        if(results.length == 0) {
+          fail('The adapter should return non-empty results');
+          done();
+        } else {
+          expect(results[0].message).toEqual('testing info logs');
+          done();
+        }
       });
     });
   });
@@ -56,8 +61,14 @@ describe('error logs', () => {
         size: 1,
         level: 'error'
       }, (results) => {
-        expect(results[0].message).toEqual('testing error logs');
-        done();
+        if(results.length == 0) {
+          fail('The adapter should return non-empty results');
+          done();
+        }
+        else {
+          expect(results[0].message).toEqual('testing error logs');
+          done();
+        }
       });
     });
   });


### PR DESCRIPTION
Running tests on Windows caused this error:
```
B:\Projects\Parse Server\parse-server\spec\FileLoggerAdapter.spec.js:38
        expect(results[0].message).toEqual('testing info logs');
                         ^

TypeError: Cannot read property 'message' of undefined
    at B:\Projects\Parse Server\parse-server\spec\FileLoggerAdapter.spec.js:38:26
    at ParsePromise.<anonymous> (B:\Projects\Parse Server\parse-server\src\Adapters\Logger\FileLoggerAdapter.js:9:17440)
    at ParsePromise.wrappedResolvedCallback (B:\Projects\Parse Server\parse-server\node_modules\parse\lib\node\ParsePromise.js:139:41)
    at ParsePromise.resolve (B:\Projects\Parse Server\parse-server\node_modules\parse\lib\node\ParsePromise.js:72:36)
    at resolveOne (B:\Projects\Parse Server\parse-server\node_modules\parse\lib\node\ParsePromise.js:471:29)
    at ParsePromise.object.then.errors.(anonymous function) (B:\Projects\Parse Server\parse-server\node_modules\parse\lib\node\ParsePromise.js:480:13)
    at ParsePromise.wrappedResolvedCallback (B:\Projects\Parse Server\parse-server\node_modules\parse\lib\node\ParsePromise.js:139:41)
    at ParsePromise.resolve (B:\Projects\Parse Server\parse-server\node_modules\parse\lib\node\ParsePromise.js:72:36)
    at ReadFileContext.callback (B:\Projects\Parse Server\parse-server\src\Adapters\Logger\FileLoggerAdapter.js:9:16189)
    at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:303:13)
```
Rest of the tests could not be run as the test runner would break here. This change adds a check to fail when the FileLoggerAdapter returns an empty array from here: https://github.com/ParsePlatform/parse-server/blob/master/src/Adapters/Logger/FileLoggerAdapter.js#L191

Regarding the cause of the error itself, it is due to different filename separators in *nix and Windows. The FileLoggerAdapter would not save logs (have not tested this). This is a separate issue and should also be fixed.