### PR TITLE
Allows Operations on Roles

### DIFF
--- a/src/rest.js
+++ b/src/rest.js
@@ -115,11 +115,6 @@ function update(config, auth, className, objectId, restObject) {
 
 // Disallowing access to the _Role collection except by master key
 function enforceRoleSecurity(method, className, auth) {
-  if (className === '_Role' && !auth.isMaster) {
-    throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN,
-                          'Clients aren\'t allowed to perform the ' +
-                          method + ' operation on the role collection.');
-  }
   if (method === 'delete' && className === '_Installation' && !auth.isMaster) {
     throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN,
                           'Clients aren\'t allowed to perform the ' +


### PR DESCRIPTION
Now that roles are protected by a required ACL upon creation, we can skip the added security.

see: [here](https://github.com/ParsePlatform/parse-server/blob/master/src/Schema.js#L76), [here](https://github.com/ParsePlatform/parse-server/blob/master/src/Schema.js#L533), [here](https://github.com/ParsePlatform/parse-server/blob/master/src/Schema.js#L562)