### PR TITLE
Reset password fix

### DIFF
--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -573,7 +573,15 @@ describe("Password Reset", () => {
             expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/password_reset_success.html');
 
             Parse.User.logIn("zxcv", "hello").then(function(user){
-              done();
+              let config = new Config('test');
+              config.database.adaptiveCollection('_User')
+              .then(coll => coll.find({ 'username': 'zxcv' }, { limit: 1 }))
+              .then((results) => {
+                // _perishable_token should be unset after reset password
+                expect(results.length).toEqual(1);
+                expect(results[0]['_perishable_token']).toEqual(undefined);
+                done();
+              });
             }, (err) => {
               console.error(err);
               fail("should login with new password");

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -173,7 +173,7 @@ export class UserController extends AdaptableController {
       return this.config.database.adaptiveCollection('_User').then(function (collection) {
         // Need direct database access because verification token is not a parse field
         return collection.findOneAndUpdate({ username: username },// query
-          { $set: { _perishable_token: null } } // update
+          { $unset: { _perishable_token: null } } // update
         );
       });
     });

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -2,6 +2,7 @@ import { randomString } from '../cryptoUtils';
 import { inflate } from '../triggers';
 import AdaptableController from './AdaptableController';
 import MailAdapter from '../Adapters/Email/MailAdapter';
+import rest from '../rest';
 
 var DatabaseAdapter = require('../DatabaseAdapter');
 var RestWrite = require('../RestWrite');
@@ -165,8 +166,8 @@ export class UserController extends AdaptableController {
   }
 
   updatePassword(username, token, password, config) {
-   return this.checkResetTokenValidity(username, token).then(() => {
-     return updateUserPassword(username, token, password, this.config);
+   return this.checkResetTokenValidity(username, token).then((user) => {
+     return updateUserPassword(user._id, password, this.config);
    });
   }
 
@@ -192,12 +193,11 @@ export class UserController extends AdaptableController {
 }
 
 // Mark this private
-function updateUserPassword(username, token, password, config) {
-    var write = new RestWrite(config, Auth.master(config), '_User', {
-            username: username,
-            _perishable_token: token
-          }, {password: password, _perishable_token: null }, undefined);
-    return write.execute();
+function updateUserPassword(userId, password, config) {
+    return rest.update(config, Auth.master(config), '_User', userId, {
+      password: password,
+      _perishable_token: null
+    });
  }
 
 export default UserController;


### PR DESCRIPTION
refs #951 

There are 2 updates in this PR.
**1. Fix cannot reset password, when the app defined user before save.**
In the original implementation, `updateUserPassword` update the password directly through `RestWrite` but the `originalData` argument is missing. So if the app has defined user before save, reset password will be fail. To fix this, I updated `updateUserPassword` function to reuse `rest` lib update function.

**2. `_perishable_token` is a private field, clear it through `RestWrite` will cause "Permission denied for this action." error.**
Fix this by access db directly when clear `_perishable_token` after reset password.

Let me know for any problems about the PR, hope this help!:)

