### PR TITLE
Mounts createLiveQueryServer, fix babel induced problem

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -228,4 +228,12 @@ describe('server', () => {
       done();
     })
   });
+
+  it('has createLiveQueryServer', done => {
+    // original implementation through the factory
+    expect(typeof ParseServer.ParseServer.createLiveQueryServer).toEqual('function');
+    // For import calls
+    expect(typeof ParseServer.default.createLiveQueryServer).toEqual('function');
+    done();
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ addParseCloud();
 // "javascriptKey": optional key from Parse dashboard
 // "push": optional key from configure push
 
-export default class ParseServer {
+class ParseServer {
 
   constructor({
     appId = requiredParameter('You must provide an appId!'),
@@ -270,15 +270,18 @@ export default class ParseServer {
     return api;
   }
 
-  static ParseServer(options) {
-    let server = new ParseServer(options);
-    return server.app;
-  }
-
   static createLiveQueryServer(httpServer, config) {
     return new ParseLiveQueryServer(httpServer, config);
   }
 }
+
+// Factory function
+let _ParseServer = function(options) {
+  let server = new ParseServer(options);
+  return server.app;
+}
+// Mount the create liveQueryServer
+_ParseServer.createLiveQueryServer = ParseServer.createLiveQueryServer;
 
 function addParseCloud() {
   const ParseCloud = require("./cloud-code/Parse.Cloud");
@@ -286,9 +289,6 @@ function addParseCloud() {
   global.Parse = Parse;
 }
 
-let runServer = function(options) {
-  return ParseServer.ParseServer(options);
-}
-
+export default ParseServer;
 export { S3Adapter, GCSAdapter, FileSystemAdapter };
-export { runServer as ParseServer };
+export { _ParseServer as ParseServer };


### PR DESCRIPTION
Very very urgent, a babel update seems to have broken the:

```
class ParseServer {
   static ParseServer() {}
}
```

fixes #1147 
fixes #1154

After the merge, we should release 2.2.2 as this is a major break