### PR TITLE
Improve flattening of results from pushAdapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "apn": "^1.7.5",
     "babel-polyfill": "^6.5.0",
     "babel-runtime": "^6.5.0",
     "bcrypt-nodejs": "0.0.3",
@@ -32,7 +31,6 @@
     "mime": "^1.3.4",
     "mongodb": "~2.1.0",
     "multer": "^1.1.0",
-    "node-gcm": "^0.14.0",
     "parse": "^1.8.0",
     "parse-server-fs-adapter": "^1.0.0",
     "parse-server-gcs-adapter": "^1.0.0",

--- a/spec/PushController.spec.js
+++ b/spec/PushController.spec.js
@@ -1,6 +1,6 @@
 "use strict";
 var PushController = require('../src/Controllers/PushController').PushController;
-
+var pushStatusHandler = require('../src/pushStatusHandler');
 var Config = require('../src/Config');
 
 const successfulTransmissions = function(body, installations) {
@@ -357,4 +357,8 @@ describe('PushController', () => {
     });
   });
 
+  it('should flatten', () => {
+    var res = pushStatusHandler.flatten([1, [2], [[3, 4], 5], [[[6]]]])
+    expect(res).toEqual([1,2,3,4,5,6]);
+  })
 });

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -119,16 +119,7 @@ export class PushController extends AdaptableController {
         }
         return this.adapter.send(payload, badgeInstallationsMap[badge]);
       });
-      // Flatten the promises results
-      return Promise.all(promises).then((results) => {
-        if (Array.isArray(results)) {
-          return Promise.resolve(results.reduce((memo, result) => {
-            return memo.concat(result);
-          },[]));
-        } else {
-          return Promise.resolve(results);
-        }
-      })
+      return Promise.all(promises);
     }
     return this.adapter.send(body, installations);
   }

--- a/src/pushStatusHandler.js
+++ b/src/pushStatusHandler.js
@@ -1,5 +1,16 @@
 import { md5Hash, newObjectId } from './cryptoUtils';
 
+export function flatten(array) {
+  return array.reduce((memo, element) => {
+    if (Array.isArray(element)) {
+      memo = memo.concat(flatten(element));
+    } else {
+      memo = memo.concat(element);
+    }
+    return memo;
+  }, []);
+}
+
 export default function pushStatusHandler(config) {
 
   let initialPromise;
@@ -53,6 +64,7 @@ export default function pushStatusHandler(config) {
       numFailed: 0,
     };
     if (Array.isArray(results)) {
+      results = flatten(results);
       results.reduce((memo, result) => {
         // Cannot handle that
         if (!result.device || !result.device.deviceType) {


### PR DESCRIPTION
Better flattens the push adapter results for better handling of push status.

By default the push adapter should return a promise response for each push, and may have multiple senders, so arrays may not be flat