### PR TITLE
Make GlobalConfig work like parse.com

### DIFF
--- a/src/Routers/FeaturesRouter.js
+++ b/src/Routers/FeaturesRouter.js
@@ -2,15 +2,17 @@ import { version }     from '../../package.json';
 import PromiseRouter   from '../PromiseRouter';
 import * as middleware from "../middlewares";
 
+const isGlobalConfigEnabled = !!(process.env.PARSE_EXPERIMENTAL_CONFIG_ENABLED || process.env.TESTING)
+
 export class FeaturesRouter extends PromiseRouter {
   mountRoutes() {
     this.route('GET','/serverInfo', middleware.promiseEnforceMasterKeyAccess, req => {
       const features = {
         globalConfig: {
-          create: false,
-          read: false,
-          update: false,
-          delete: false,
+          create: isGlobalConfigEnabled,
+          read: isGlobalConfigEnabled,
+          update: isGlobalConfigEnabled,
+          delete: isGlobalConfigEnabled,
         },
         hooks: {
           create: false,

--- a/src/Routers/GlobalConfigRouter.js
+++ b/src/Routers/GlobalConfigRouter.js
@@ -19,16 +19,16 @@ export class GlobalConfigRouter extends PromiseRouter {
 
   updateGlobalConfig(req) {
     const params = req.body.params;
-    const update = {};
-    Object.keys(params).forEach((key) => {
+    const update = Object.keys(params).reduce((acc, key) => {
       if(params[key] && params[key].__op && params[key].__op === "Delete") {
-        if (!update.$unset) update.$unset = {};
-        update.$unset["params." + key] = "";
+        if (!acc.$unset) acc.$unset = {};
+        acc.$unset[`params.${key}`] = "";
       } else {
-        if (!update.$set) update.$set = {};
-        update.$set["params." + key] = params[key];
+        if (!acc.$set) acc.$set = {};
+        acc.$set[`params.${key}`] = params[key];
       }
-    });
+      return acc;
+    }, {});
     return req.config.database.adaptiveCollection('_GlobalConfig')
       .then(coll => coll.upsertOne({ _id: 1 }, update))
       .then(() => ({ response: { result: true } }));


### PR DESCRIPTION
As per title:
 - GlobalConfig will merge the existing values with the new ones
 - The new values with { "__op": "Delete" } will be deleted
 - When `PARSE_EXPERIMENTAL_CONFIG_ENABLED` or `TESTING` the server features route will return config, making it work properly with `parse-dashboard` 

A lot of tests are failing with `npm test`, not sure if it's an issue with my setup (Arch Linux, already have mongodb but it's not running) or with the project. For the time being I'll rely on whatever circleci you guys are using.

`npm test spec/ParseGlobalConfig.spec.js` seems fine.