### PR TITLE
Matching queries with doesNotExist constraint

### DIFF
--- a/spec/QueryTools.spec.js
+++ b/spec/QueryTools.spec.js
@@ -112,6 +112,20 @@ describe('matchesQuery', function() {
     expect(matchesQuery(obj, q)).toBe(false);
   });
 
+  it('matches queries with doesNotExist constraint', function() {
+    var obj = {
+      id: new Id('Item', 'O1'),
+      count: 15
+    };
+    var q = new Parse.Query('Item');
+    q.doesNotExist('name');
+    expect(matchesQuery(obj, q)).toBe(true);
+
+    q = new Parse.Query('Item');
+    q.doesNotExist('count');
+    expect(matchesQuery(obj, q)).toBe(false);
+  });
+
   it('matches on equality queries', function() {
     var day = new Date();
     var location = new Parse.GeoPoint({

--- a/src/LiveQuery/QueryTools.js
+++ b/src/LiveQuery/QueryTools.js
@@ -206,7 +206,9 @@ function matchesKeyConstraints(object, key, constraints) {
         }
         break;
       case '$exists':
-        if (typeof object[key] === 'undefined') {
+        let propertyExists = typeof object[key] !== 'undefined';
+        let existenceIsRequired = constraints['$exists'];
+        if ((!propertyExists && existenceIsRequired) || (propertyExists && !existenceIsRequired)) {
           return false;
         }
         break;


### PR DESCRIPTION
I was trying LiveQuery using a query with a doesNotExist constraint and after some time debugging I've found out that QueryTools wasn't matching it correctly.

This pull request resolves this issue.

Feedback is appreciated. 

Thanks.