### PR TITLE
Fixed bug with invalid email verification link on email update.

### DIFF
--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -100,14 +100,13 @@ export class UserController extends AdaptableController {
     })
   }
 
-
   sendVerificationEmail(user) {
     if (!this.shouldVerifyEmails) {
       return;
     }
+    const token = encodeURIComponent(user._email_verify_token);
     // We may need to fetch the user in case of update email
     this.getUserIfNeeded(user).then((user) => {
-      const token = encodeURIComponent(user._email_verify_token);
       const username = encodeURIComponent(user.username);
       let link = `${this.config.verifyEmailURL}?token=${token}&username=${username}`;
       let options = {


### PR DESCRIPTION
I have found a bug with email verification link.
It works first time when user sign up but it sends 'undefined' token when user updates his email.
The verification link looks like:
`parse/apps/rd11pKB86cuL59ApIUn1SfWhXyGYC6AqQS2EGk4T/verify_email?token=undefined&username=krzysztof.zielonka%40droidsonorids.pl`
The problem is that in this case user is fetched before email is sent. The token which is stored in user Object is lost during fetch.