### PR TITLE
use public server url as alternative for mount

### DIFF
--- a/src/Adapters/Files/GridStoreAdapter.js
+++ b/src/Adapters/Files/GridStoreAdapter.js
@@ -63,7 +63,7 @@ export class GridStoreAdapter extends FilesAdapter {
   }
 
   getFileLocation(config, filename) {
-    return (config.mount + '/files/' + config.applicationId + '/' + encodeURIComponent(filename));
+    return (config.publicServerURLOrMount + '/files/' + config.applicationId + '/' + encodeURIComponent(filename));
   }
 }
 

--- a/src/Config.js
+++ b/src/Config.js
@@ -79,6 +79,11 @@ export class Config {
   get verifyEmailURL() {
     return `${this.publicServerURL}/apps/${this.applicationId}/verify_email`;
   }
+  
+  // provide the public server URL if the mount differs from how the parse server is accessed from outside
+  get publicServerURLOrMount() {
+    return this.publicServerURL !== '' ? this.publicServerURL : this.mount;
+  }
 };
 
 export default Config;

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -805,7 +805,7 @@ RestWrite.prototype.runAfterTrigger = function() {
 RestWrite.prototype.location = function() {
   var middle = (this.className === '_User' ? '/users/' :
                 '/classes/' + this.className + '/');
-  return this.config.mount + middle + this.data.objectId;
+  return this.config.publicServerURLOrMount + middle + this.data.objectId;
 };
 
 // A helper to get the object id for this operation.


### PR DESCRIPTION
refs #905 and refs #1131 and tries to follow the instructions in #905. For our setup it works.
This supports the solution with the mentioned usage of `X-Forwarded-Proto` headers or, if given, uses the public server url to create correct links for the files behind a proxy, even without the need to set the 'trust proxy' option in express.