### PR TITLE
Fixes issue #1302

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -1492,7 +1492,52 @@ describe('Parse.Query testing', () => {
       fail('should not fail');
       done();
     })
-  })
+  });
+
+  it('properly nested array of mixed objects with bad ids', (done) => {
+    let objects = [];
+    let total = 0;
+    while(objects.length != 5) {
+      let object = new Parse.Object('AnObject');
+      object.set('key', objects.length);
+      objects.push(object);
+    }
+    while(objects.length != 10) {
+      let object = new Parse.Object('AnotherObject');
+      object.set('key', objects.length);
+      objects.push(object);
+    }
+    Parse.Object.saveAll(objects).then(() => {
+      let object = new Parse.Object("AContainer");
+      for (var i=0; i<objects.length; i++) {
+        if (i%2 == 0) {
+          objects[i].id = 'randomThing'
+        } else {
+          total += objects[i].get('key');
+        }
+      }
+      object.set('objects', objects);
+      return object.save();
+    }).then(() => {
+      let query = new Parse.Query('AContainer');
+      query.include('objects');
+      return query.find()
+    }).then((results) => {
+      expect(results.length).toBe(1);
+      let res = results[0];
+      let objects = res.get('objects');
+      expect(objects.length).toBe(5);
+      objects.forEach((object) => {
+        total -= object.get('key');
+      });
+      expect(total).toBe(0);
+      done()
+    }, (err) => {
+      console.error(err);
+      fail('should not fail');
+      done();
+    })
+  });
 
   it('properly fetches nested pointers', (done) =>  {
     let color = new Parse.Object('Color');

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -537,7 +537,8 @@ function findPointers(object, path) {
 // pointers inflated.
 function replacePointers(object, path, replace) {
   if (object instanceof Array) {
-    return object.map((obj) => replacePointers(obj, path, replace));
+    return object.map((obj) => replacePointers(obj, path, replace))
+              .filter((obj) => obj != null && obj != undefined);
   }
 
   if (typeof object !== 'object') {


### PR DESCRIPTION
fixes #1302 

When querying with include on an array of pointers, filter out the nulls and undefined to keep it going AND to have properly set result arrays sent to the client