### PR TITLE
Fix acl conflict with parse.com when updating acl in parse-server

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -227,13 +227,16 @@ function transformUpdate(schema, className, restUpdate) {
 
   var mongoUpdate = {};
   var acl = transformACL(restUpdate);
-  if (acl._rperm || acl._wperm) {
+  if (acl._rperm || acl._wperm || acl._acl) {
     mongoUpdate['$set'] = {};
     if (acl._rperm) {
       mongoUpdate['$set']['_rperm'] = acl._rperm;
     }
     if (acl._wperm) {
       mongoUpdate['$set']['_wperm'] = acl._wperm;
+    }
+    if (acl._acl) {
+      mongoUpdate['$set']['_acl'] = acl._acl;
     }
   }
 
@@ -284,16 +287,22 @@ function transformACL(restObject) {
   var acl = restObject['ACL'];
   var rperm = [];
   var wperm = [];
+  var _acl = {};
   for (var entry in acl) {
     if (acl[entry].read) {
       rperm.push(entry);
+      _acl[entry] = _acl[entry] || {};
+      _acl[entry]['r'] = true;
     }
     if (acl[entry].write) {
       wperm.push(entry);
+      _acl[entry] = _acl[entry] || {};
+      _acl[entry]['w'] = true;
     }
   }
   output._rperm = rperm;
   output._wperm = wperm;
+  output._acl = _acl;
   delete restObject.ACL;
   return output;
 }


### PR DESCRIPTION
refs #1150 

Would like to bring up and open a discussion on the ACL compatibility problem between parse.com and parse-server. The problem is described clearly in issue #1150. This PR is going to updated the old `_acl` field, so that parse.com can serve the acl in right way.

Parse.com might has its plan on acl schema migration? Would like know if we need this fix in parse-server.

Thanks!