### PR TITLE
Fix for #1334: using relative cloud code files broken 

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -10,7 +10,7 @@ var ParseServer = require('../src/index').ParseServer;
 var path = require('path');
 
 var databaseURI = process.env.DATABASE_URI;
-var cloudMain = process.env.CLOUD_CODE_MAIN || '../spec/cloud/main.js';
+var cloudMain = process.env.CLOUD_CODE_MAIN || './spec/cloud/main.js';
 var port = 8378;
 
 // Default server configuration for tests.

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -175,6 +175,26 @@ describe('server', () => {
     })
   });
 
+  it('can load absolute cloud code file', done => {
+    setServerConfiguration({
+      serverURL: 'http://localhost:8378/1',
+      appId: 'test',
+      masterKey: 'test',
+      cloud: __dirname + '/cloud/main.js'
+    });
+    done();
+  });
+
+  it('can load relative cloud code file', done => {
+    setServerConfiguration({
+      serverURL: 'http://localhost:8378/1',
+      appId: 'test',
+      masterKey: 'test',
+      cloud: './spec/cloud/main.js'
+    });
+    done();
+  });
+
   it('can create a parse-server', done => {
     var parseServer = new ParseServer.default({
       appId: "aTestApp",

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -9,6 +9,7 @@ var batch = require('./batch'),
     middlewares = require('./middlewares'),
     multer = require('multer'),
     Parse = require('parse/node').Parse,
+    path = require('path'),
     authDataManager = require('./authDataManager');
 
 import { logger,
@@ -140,7 +141,7 @@ class ParseServer {
       if (typeof cloud === 'function') {
         cloud(Parse)
       } else if (typeof cloud === 'string') {
-        require(cloud);
+        require(path.resolve(process.cwd(), cloud));
       } else {
         throw "argument 'cloud' must either be a string or a function";
       }


### PR DESCRIPTION
Based on https://github.com/ParsePlatform/parse-server/issues/1334#issuecomment-204740190 by @flovilmart. Includes tests to verify absolute and relative cloud code file loading.