### PR TITLE
:construction: Inject the default schemas properties when loading it

### DIFF
--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -1511,5 +1511,20 @@ describe('schemas', () => {
       fail('should not fail');
       done();
     });
+  });
+
+  it('can login when addFields is false (issue #1355)', (done) => {
+    setPermissionsOnClass('_User', {
+      'addField': {}
+    }).then(() => {
+      return Parse.User.signUp('foo', 'bar');
+    }).then((user) => {
+      expect(user.getUsername()).toBe('foo');
+      done()
+    }, (err) => {
+      console.error(err);
+      fail('should create user');
+      done();
+    })
   })
 });

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -263,6 +263,16 @@ class Schema {
           }
         });
         if (className) {
+          // merge with the default schema
+          let defaultClassData = Object.assign({}, defaultColumns._Default, defaultColumns[className]);
+          defaultClassData = Object.keys(defaultClassData).reduce((memo, key) => {
+            let type = schemaAPITypeToMongoFieldType(defaultClassData[key]).result;
+            if (type) {
+              memo[key] = type;
+            }
+            return memo;
+          }, {});
+          classData = Object.assign({}, defaultClassData, classData);
           this.data[className] = classData;
           if (permsData) {
             this.perms[className] = permsData;


### PR DESCRIPTION
- injects default schema upon schema load

this maximizes the compatibility with previously set CLP before migration where the Schema wouldn't have all the default keys set