### PR TITLE
Fix exception with non-expiring session tokens.

### DIFF
--- a/src/Auth.js
+++ b/src/Auth.js
@@ -64,7 +64,7 @@ var getAuthForSessionToken = function({ config, sessionToken, installationId } =
     }
 
     var now = new Date(),
-        expiresAt = new Date(results[0].expiresAt.iso);
+        expiresAt = results[0].expiresAt ? new Date(results[0].expiresAt.iso) : undefined;
     if(expiresAt < now) {
       throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN,
             'Session token is expired.');


### PR DESCRIPTION
Session objects generated by parse.com (not sure about parse-server yet) will leave expiresAt undefined if they aren't set to expire in a year. Using these session tokens with parse-server causes Node to throw this exception:

```
error: error getting auth for sessionToken TypeError: Cannot read property 'iso' of undefined
    at /parse-example/node_modules/parse-server/lib/Auth.js:88:50
    at run (/parse-example/node_modules/babel-polyfill/node_modules/core-js/modules/es6.promise.js:89:22)
    at /parse-example/node_modules/babel-polyfill/node_modules/core-js/modules/es6.promise.js:102:28
    at flush (/parse-example/node_modules/babel-polyfill/node_modules/core-js/modules/_microtask.js:14:5)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickDomainCallback (internal/process/next_tick.js:122:9)
```
This PR fixes that.