### PR TITLE
Removing sessionToken and authData from _User objects included in a query

### DIFF
--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -450,7 +450,6 @@ function includePath(config, auth, response, path) {
     return response;
   }
   let pointersHash = {};
-  var className = null;
   var objectIds = {};
   for (var pointer of pointers) {
     let className = pointer.className;

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -477,8 +477,9 @@ function includePath(config, auth, response, path) {
         obj.__type = 'Object';
         obj.className = includeResponse.className;
 
-        if(className == "_User"){
+        if (obj.className == "_User") {
           delete obj.sessionToken;
+          delete obj.authData;
         }
         replace[obj.objectId] = obj;
       }


### PR DESCRIPTION
This bug caused sessionToken to be replaced on client side to some old
sessionToken from DB.

There was a similar issue discussed here: https://github.com/ParsePlatform/parse-server/pull/373 , but the proposed fix had a bug in it. 