### PR TITLE
Fixes #1444

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1514,6 +1514,29 @@ describe('Parse.User testing', () => {
     });
   });
 
+  it('should properly error when password is missing', (done) => {
+    var provider = getMockFacebookProvider();
+    Parse.User._registerAuthenticationProvider(provider);
+    Parse.User._logInWith("facebook", {
+      success: function(user) {
+        user.set('username', 'myUser');
+        user.set('email', 'foo@example.com');
+        user.save().then(() => {
+          return Parse.User.logOut();
+        }).then(() => {
+          return Parse.User.logIn('myUser', 'password');
+        }).then(() => {
+          fail('should not succeed');
+          done();
+        }, (err) => {
+          expect(err.code).toBe(Parse.Error.OBJECT_NOT_FOUND);
+          expect(err.message).toEqual('Invalid username/password.');
+          done();
+        })
+      }
+    });
+  });
+
   it('should have authData in beforeSave and afterSave', (done) => {
 
     Parse.Cloud.beforeSave('_User', (request, response) => {

--- a/src/password.js
+++ b/src/password.js
@@ -19,6 +19,10 @@ function hash(password) {
 // hashed password.
 function compare(password, hashedPassword) {
   return new Promise(function(fulfill, reject) {
+    // Cannot bcrypt compare when one is undefined
+    if (!password || !hashedPassword) {
+      return fulfill(false);
+    }
     bcrypt.compare(password, hashedPassword, function(err, success) {
       if (err) {
         reject(err);


### PR DESCRIPTION
Makes sure we have both parameters not undefined to make a call to `bcrypt.compare`, otherwise just consider the comparison to be unsuccessful