### PR TITLE
Move field deletion logic into mongo adapter

### DIFF
--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -684,12 +684,13 @@ describe('Schema', () => {
       .then(() => schema.deleteField('relationField', 'NewClass', config.database))
       .then(() => schema.reloadData())
       .then(() => {
-        expect(schema['data']['NewClass']).toEqual({
+        const expectedSchema = {
           objectId: { type: 'String' },
           updatedAt: { type: 'Date' },
           createdAt: { type: 'Date' },
           ACL: { type: 'ACL' }
-        });
+        };
+        expect(dd(schema.data.NewClass, expectedSchema)).toEqual(undefined);
         done();
       });
     });
@@ -716,6 +717,10 @@ describe('Schema', () => {
         done();
         Parse.Object.enableSingleInstance();
       });
+    })
+    .catch(error => {
+      fail(error);
+      done();
     });
   });
 

--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -28,7 +28,6 @@ export default class MongoCollection {
 
         var index = {};
         index[key] = '2d';
-        //TODO: condiser moving index creation logic into Schema.js
         return this._mongoCollection.createIndex(index)
           // Retry, but just once.
           .then(() => this._rawFind(query, { skip, limit, sort }));


### PR DESCRIPTION
Currently due to the _collectionPrefix not being stored in the database adapter, we need to do all sorts of crazy stuff to make sure the mongo adapter knows where the data it needs to delete is. Will fix in a later PR.