### PR TITLE
Store collection prefix in mongo adapter, and clean up adapter interface

### DIFF
--- a/spec/DatabaseAdapter.spec.js
+++ b/spec/DatabaseAdapter.spec.js
@@ -8,15 +8,15 @@ describe('DatabaseAdapter', () => {
     DatabaseAdapter.setAppDatabaseOptions('optionsTest', {foo: "bar"});
     let optionsTestDatabaseConnection = DatabaseAdapter.getDatabaseConnection('optionsTest');
 
-    expect(optionsTestDatabaseConnection instanceof Object).toBe(true);
-    expect(optionsTestDatabaseConnection.adapter._options instanceof Object).toBe(true);
-    expect(optionsTestDatabaseConnection.adapter._options.foo).toBe("bar");
+    expect(optionsTestDatabaseConnection).toEqual(jasmine.any(Object));
+    expect(optionsTestDatabaseConnection.adapter._mongoOptions).toEqual(jasmine.any(Object));
+    expect(optionsTestDatabaseConnection.adapter._mongoOptions.foo).toBe("bar");
 
     DatabaseAdapter.setAppDatabaseURI('noOptionsTest', 'mongodb://localhost:27017/noOptionsTest');
     let noOptionsTestDatabaseConnection = DatabaseAdapter.getDatabaseConnection('noOptionsTest');
 
-    expect(noOptionsTestDatabaseConnection instanceof Object).toBe(true);
-    expect(noOptionsTestDatabaseConnection.adapter._options instanceof Object).toBe(false);
+    expect(noOptionsTestDatabaseConnection).toEqual(jasmine.any(Object));
+    expect(noOptionsTestDatabaseConnection.adapter._mongoOptions).toEqual(jasmine.any(Object));
 
     done();
   });

--- a/spec/DatabaseController.spec.js
+++ b/spec/DatabaseController.spec.js
@@ -5,9 +5,11 @@ let MongoStorageAdapter = require('../src/Adapters/Storage/Mongo/MongoStorageAda
 
 describe('DatabaseController', () => {
   it('can be constructed', done => {
-    let adapter = new MongoStorageAdapter('mongodb://localhost:27017/test');
+    let adapter = new MongoStorageAdapter({
+      uri: 'mongodb://localhost:27017/test'
+    });
     let databaseController = new DatabaseController(adapter, {
-		collectionPrefix: 'test_'
+      collectionPrefix: 'test_'
     });
     databaseController.connect().then(done, error => {
       console.log('error', error.stack);

--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -6,8 +6,9 @@ const MongoClient = require('mongodb').MongoClient;
 describe('MongoStorageAdapter', () => {
   it('auto-escapes symbols in auth information', () => {
     spyOn(MongoClient, 'connect').and.returnValue(Promise.resolve(null));
-    new MongoStorageAdapter('mongodb://user!with@+ symbols:password!with@+ symbols@localhost:1234/parse', {})
-      .connect();
+    new MongoStorageAdapter({
+      uri: 'mongodb://user!with@+ symbols:password!with@+ symbols@localhost:1234/parse'
+    }).connect();
     expect(MongoClient.connect).toHaveBeenCalledWith(
       'mongodb://user!with%40%2B%20symbols:password!with%40%2B%20symbols@localhost:1234/parse',
       jasmine.any(Object)
@@ -16,8 +17,9 @@ describe('MongoStorageAdapter', () => {
 
   it("doesn't double escape already URI-encoded information", () => {
     spyOn(MongoClient, 'connect').and.returnValue(Promise.resolve(null));
-    new MongoStorageAdapter('mongodb://user!with%40%2B%20symbols:password!with%40%2B%20symbols@localhost:1234/parse', {})
-      .connect();
+    new MongoStorageAdapter({
+      uri: 'mongodb://user!with%40%2B%20symbols:password!with%40%2B%20symbols@localhost:1234/parse'
+    }).connect();
     expect(MongoClient.connect).toHaveBeenCalledWith(
       'mongodb://user!with%40%2B%20symbols:password!with%40%2B%20symbols@localhost:1234/parse',
       jasmine.any(Object)
@@ -27,8 +29,9 @@ describe('MongoStorageAdapter', () => {
   // https://github.com/ParsePlatform/parse-server/pull/148#issuecomment-180407057
   it('preserves replica sets', () => {
     spyOn(MongoClient, 'connect').and.returnValue(Promise.resolve(null));
-    new MongoStorageAdapter('mongodb://test:testpass@ds056315-a0.mongolab.com:59325,ds059315-a1.mongolab.com:59315/testDBname?replicaSet=rs-ds059415', {})
-      .connect();
+    new MongoStorageAdapter({
+      uri: 'mongodb://test:testpass@ds056315-a0.mongolab.com:59325,ds059315-a1.mongolab.com:59315/testDBname?replicaSet=rs-ds059415'
+    }).connect();
     expect(MongoClient.connect).toHaveBeenCalledWith(
       'mongodb://test:testpass@ds056315-a0.mongolab.com:59325,ds059315-a1.mongolab.com:59315/testDBname?replicaSet=rs-ds059415',
       jasmine.any(Object)

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -11,14 +11,20 @@ const MongoSchemaCollectionName = '_SCHEMA';
 export class MongoStorageAdapter {
   // Private
   _uri: string;
-  _options: Object;
+  _collectionPrefix: string;
+  _mongoOptions: Object;
   // Public
   connectionPromise;
   database;
 
-  constructor(uri: string, options: Object) {
+  constructor({
+    uri,
+    collectionPrefix = '',
+    mongoOptions = {},
+  }) {
     this._uri = uri;
-    this._options = options;
+    this._collectionPrefix = collectionPrefix;
+    this._mongoOptions = mongoOptions;
   }
 
   connect() {
@@ -30,7 +36,7 @@ export class MongoStorageAdapter {
     // encoded
     const encodedUri = formatUrl(parseUrl(this._uri));
 
-    this.connectionPromise = MongoClient.connect(encodedUri, this._options).then(database => {
+    this.connectionPromise = MongoClient.connect(encodedUri, this._mongoOptions).then(database => {
       this.database = database;
     });
     return this.connectionPromise;

--- a/src/DatabaseAdapter.js
+++ b/src/DatabaseAdapter.js
@@ -15,20 +15,15 @@
 //
 // Default is MongoStorageAdapter.
 
-import DatabaseController from './Controllers/DatabaseController';
+import DatabaseController  from './Controllers/DatabaseController';
 import MongoStorageAdapter from './Adapters/Storage/Mongo/MongoStorageAdapter';
 
 const DefaultDatabaseURI = 'mongodb://localhost:27017/parse';
 
-let adapter = MongoStorageAdapter;
 let dbConnections = {};
 let databaseURI = DefaultDatabaseURI;
 let appDatabaseURIs = {};
 let appDatabaseOptions = {};
-
-function setAdapter(databaseAdapter) {
-  adapter = databaseAdapter;
-}
 
 function setDatabaseURI(uri) {
   databaseURI = uri;
@@ -68,7 +63,12 @@ function getDatabaseConnection(appId: string, collectionPrefix: string) {
 
   var dbURI = (appDatabaseURIs[appId] ? appDatabaseURIs[appId] : databaseURI);
 
-  let storageAdapter = new adapter(dbURI, appDatabaseOptions[appId]);
+  let storageAdapter = new MongoStorageAdapter({
+    uri: dbURI,
+    collectionPrefix: collectionPrefix,
+    mongoOptions: appDatabaseOptions[appId]
+  });
+
   dbConnections[appId] = new DatabaseController(storageAdapter, {
     collectionPrefix: collectionPrefix
   });
@@ -76,9 +76,7 @@ function getDatabaseConnection(appId: string, collectionPrefix: string) {
 }
 
 module.exports = {
-  dbConnections: dbConnections,
   getDatabaseConnection: getDatabaseConnection,
-  setAdapter: setAdapter,
   setDatabaseURI: setDatabaseURI,
   setAppDatabaseOptions: setAppDatabaseOptions,
   setAppDatabaseURI: setAppDatabaseURI,

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -84,7 +84,6 @@ class ParseServer {
     appId = requiredParameter('You must provide an appId!'),
     masterKey = requiredParameter('You must provide a masterKey!'),
     appName,
-    databaseAdapter,
     filesAdapter,
     push,
     loggerAdapter,
@@ -125,10 +124,6 @@ class ParseServer {
       configureLogger({
         logsFolder
       })
-    }
-
-    if (databaseAdapter) {
-      DatabaseAdapter.setAdapter(databaseAdapter);
     }
 
     if (databaseOptions) {


### PR DESCRIPTION
This removed a couple apis that were either unused or could never have possibly worked. It also stores the collection prefix in the mongo adapter. Actually using that prefix will come in another PR.