### PR TITLE
Remove collection prefix and default mongo URI

### DIFF
--- a/spec/DatabaseController.spec.js
+++ b/spec/DatabaseController.spec.js
@@ -6,11 +6,10 @@ let MongoStorageAdapter = require('../src/Adapters/Storage/Mongo/MongoStorageAda
 describe('DatabaseController', () => {
   it('can be constructed', done => {
     let adapter = new MongoStorageAdapter({
-      uri: 'mongodb://localhost:27017/test'
+      uri: 'mongodb://localhost:27017/test',
+      collectionPrefix: 'test_',
     });
-    let databaseController = new DatabaseController(adapter, {
-      collectionPrefix: 'test_'
-    });
+    let databaseController = new DatabaseController(adapter);
     databaseController.connect().then(done, error => {
       console.log('error', error.stack);
       fail();

--- a/src/Adapters/Files/GridStoreAdapter.js
+++ b/src/Adapters/Files/GridStoreAdapter.js
@@ -7,13 +7,15 @@
  */
 
 import { MongoClient, GridStore, Db} from 'mongodb';
-import { FilesAdapter } from './FilesAdapter';
+import { FilesAdapter }              from './FilesAdapter';
+
+const DefaultMongoURI = 'mongodb://localhost:27017/parse';
 
 export class GridStoreAdapter extends FilesAdapter {
   _databaseURI: string;
   _connectionPromise: Promise<Db>;
 
-  constructor(mongoDatabaseURI: string) {
+  constructor(mongoDatabaseURI = DefaultMongoURI) {
     super();
     this._databaseURI = mongoDatabaseURI;
     this._connect();

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -7,6 +7,7 @@ let mongodb = require('mongodb');
 let MongoClient = mongodb.MongoClient;
 
 const MongoSchemaCollectionName = '_SCHEMA';
+const DefaultMongoURI = 'mongodb://localhost:27017/parse';
 
 export class MongoStorageAdapter {
   // Private
@@ -18,7 +19,7 @@ export class MongoStorageAdapter {
   database;
 
   constructor({
-    uri,
+    uri = DefaultMongoURI,
     collectionPrefix = '',
     mongoOptions = {},
   }) {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -107,13 +107,7 @@ export class MongoStorageAdapter {
   // may do so.
 
   // Returns a Promise.
-
-  // This function currently accepts the adaptive collection as a paramater because it isn't
-  // actually capable of determining the location of it's own _SCHEMA collection without having
-  // the collectionPrefix. Also, Schemas.js, the caller of this function, only stores the collection
-  // itself, and not the prefix. Eventually Parse Server won't care what a SchemaCollection is and
-  // will just tell the DB adapter to do things and it will do them.
-  deleteFields(className: string, fieldNames, pointerFieldNames, adaptiveCollection) {
+  deleteFields(className: string, fieldNames, pointerFieldNames) {
     const nonPointerFieldNames = _.difference(fieldNames, pointerFieldNames);
     const mongoFormatNames = nonPointerFieldNames.concat(pointerFieldNames.map(name => `_p_${name}`));
     const collectionUpdate = { '$unset' : {} };
@@ -126,7 +120,8 @@ export class MongoStorageAdapter {
       schemaUpdate['$unset'][name] = null;
     });
 
-    return adaptiveCollection.updateMany({}, collectionUpdate)
+    return this.adaptiveCollection(className)
+    .then(collection => collection.updateMany({}, collectionUpdate))
     .then(updateResult => this.schemaCollection())
     .then(schemaCollection => schemaCollection.updateSchema(className, schemaUpdate));
   }

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -374,7 +374,7 @@ DatabaseController.prototype.mongoFind = function(className, query, options = {}
     .then(collection => collection.find(query, options));
 };
 
-// Deletes everything in the database matching the current collectionPrefix
+// Deletes everything in the database that belongs to the current app
 // Won't delete collections in the system namespace
 // Returns a promise.
 DatabaseController.prototype.deleteEverything = function() {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -374,7 +374,7 @@ DatabaseController.prototype.mongoFind = function(className, query, options = {}
     .then(collection => collection.find(query, options));
 };
 
-// Deletes everything in the database that belongs to the current app
+// Deletes everything in the database matching the current collectionPrefix
 // Won't delete collections in the system namespace
 // Returns a promise.
 DatabaseController.prototype.deleteEverything = function() {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -10,12 +10,8 @@ var Schema = require('./../Schema');
 var transform = require('./../transform');
 const deepcopy = require('deepcopy');
 
-// options can contain:
-//   collectionPrefix: the string to put in front of every collection name.
-function DatabaseController(adapter, { collectionPrefix } = {}) {
+function DatabaseController(adapter) {
   this.adapter = adapter;
-
-  this.collectionPrefix = collectionPrefix;
 
   // We don't want a mutable this.schema, because then you could have
   // one request that uses different schemas for different parts of
@@ -32,24 +28,20 @@ DatabaseController.prototype.connect = function() {
 };
 
 DatabaseController.prototype.adaptiveCollection = function(className) {
-  return this.adapter.adaptiveCollection(this.collectionPrefix + className);
+  return this.adapter.adaptiveCollection(className);
 };
 
 DatabaseController.prototype.schemaCollection = function() {
-  return this.adapter.schemaCollection(this.collectionPrefix);
+  return this.adapter.schemaCollection();
 };
 
 DatabaseController.prototype.collectionExists = function(className) {
-  return this.adapter.collectionExists(this.collectionPrefix + className);
+  return this.adapter.collectionExists(className);
 };
 
 DatabaseController.prototype.dropCollection = function(className) {
-  return this.adapter.dropCollection(this.collectionPrefix + className);
+  return this.adapter.dropCollection(className);
 };
-
-function returnsTrue() {
-  return true;
-}
 
 DatabaseController.prototype.validateClassName = function(className) {
   if (!Schema.classNameIsValid(className)) {
@@ -62,7 +54,7 @@ DatabaseController.prototype.validateClassName = function(className) {
 // Returns a promise for a schema object.
 // If we are provided a acceptor, then we run it on the schema.
 // If the schema isn't accepted, we reload it at most once.
-DatabaseController.prototype.loadSchema = function(acceptor = returnsTrue) {
+DatabaseController.prototype.loadSchema = function(acceptor = () => true) {
 
   if (!this.schemaPromise) {
     this.schemaPromise = this.schemaCollection().then(collection => {
@@ -388,10 +380,8 @@ DatabaseController.prototype.mongoFind = function(className, query, options = {}
 DatabaseController.prototype.deleteEverything = function() {
   this.schemaPromise = null;
 
-  return this.adapter.collectionsContaining(this.collectionPrefix).then(collections => {
-    let promises = collections.map(collection => {
-      return collection.drop();
-    });
+  return this.adapter.allCollections().then(collections => {
+    let promises = collections.map(collection => collection.drop());
     return Promise.all(promises);
   });
 };

--- a/src/DatabaseAdapter.js
+++ b/src/DatabaseAdapter.js
@@ -21,13 +21,8 @@ import MongoStorageAdapter from './Adapters/Storage/Mongo/MongoStorageAdapter';
 const DefaultDatabaseURI = 'mongodb://localhost:27017/parse';
 
 let dbConnections = {};
-let databaseURI = DefaultDatabaseURI;
 let appDatabaseURIs = {};
 let appDatabaseOptions = {};
-
-function setDatabaseURI(uri) {
-  databaseURI = uri;
-}
 
 function setAppDatabaseURI(appId, uri) {
   appDatabaseURIs[appId] = uri;
@@ -61,26 +56,21 @@ function getDatabaseConnection(appId: string, collectionPrefix: string) {
     return dbConnections[appId];
   }
 
-  var dbURI = (appDatabaseURIs[appId] ? appDatabaseURIs[appId] : databaseURI);
-
   let storageAdapter = new MongoStorageAdapter({
-    uri: dbURI,
+    uri: appDatabaseURIs[appId] ? appDatabaseURIs[appId] : DefaultDatabaseURI,
     collectionPrefix: collectionPrefix,
     mongoOptions: appDatabaseOptions[appId]
   });
 
-  dbConnections[appId] = new DatabaseController(storageAdapter, {
-    collectionPrefix: collectionPrefix
-  });
+  dbConnections[appId] = new DatabaseController(storageAdapter);
   return dbConnections[appId];
 }
 
 module.exports = {
   getDatabaseConnection: getDatabaseConnection,
-  setDatabaseURI: setDatabaseURI,
   setAppDatabaseOptions: setAppDatabaseOptions,
   setAppDatabaseURI: setAppDatabaseURI,
   clearDatabaseSettings: clearDatabaseSettings,
   destroyAllDataPermanently: destroyAllDataPermanently,
-  defaultDatabaseURI: databaseURI
+  defaultDatabaseURI: DefaultDatabaseURI
 };

--- a/src/DatabaseAdapter.js
+++ b/src/DatabaseAdapter.js
@@ -56,10 +56,8 @@ function getDatabaseConnection(appId: string, collectionPrefix: string) {
 
   let mongoAdapterOptions = {
     collectionPrefix: collectionPrefix,
-    mongoOptions: appDatabaseOptions[appId]
-  }
-  if (appDatabaseURIs[appId]) {
-    mongoAdapterOptions.uri = appDatabaseURIs[appId];
+    mongoOptions: appDatabaseOptions[appId],
+    uri: appDatabaseURIs[appId], //may be undefined if the user didn't supply a URI, in which case the default will be used
   }
 
   dbConnections[appId] = new DatabaseController(new MongoStorageAdapter(mongoAdapterOptions));

--- a/src/DatabaseAdapter.js
+++ b/src/DatabaseAdapter.js
@@ -18,8 +18,6 @@
 import DatabaseController  from './Controllers/DatabaseController';
 import MongoStorageAdapter from './Adapters/Storage/Mongo/MongoStorageAdapter';
 
-const DefaultDatabaseURI = 'mongodb://localhost:27017/parse';
-
 let dbConnections = {};
 let appDatabaseURIs = {};
 let appDatabaseOptions = {};
@@ -56,13 +54,16 @@ function getDatabaseConnection(appId: string, collectionPrefix: string) {
     return dbConnections[appId];
   }
 
-  let storageAdapter = new MongoStorageAdapter({
-    uri: appDatabaseURIs[appId] ? appDatabaseURIs[appId] : DefaultDatabaseURI,
+  let mongoAdapterOptions = {
     collectionPrefix: collectionPrefix,
     mongoOptions: appDatabaseOptions[appId]
-  });
+  }
+  if (appDatabaseURIs[appId]) {
+    mongoAdapterOptions.uri = appDatabaseURIs[appId];
+  }
 
-  dbConnections[appId] = new DatabaseController(storageAdapter);
+  dbConnections[appId] = new DatabaseController(new MongoStorageAdapter(mongoAdapterOptions));
+
   return dbConnections[appId];
 }
 
@@ -72,5 +73,4 @@ module.exports = {
   setAppDatabaseURI: setAppDatabaseURI,
   clearDatabaseSettings: clearDatabaseSettings,
   destroyAllDataPermanently: destroyAllDataPermanently,
-  defaultDatabaseURI: DefaultDatabaseURI
 };

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -53,6 +53,8 @@ addParseCloud();
 
 // ParseServer works like a constructor of an express app.
 // The args that we understand are:
+// "databaseAdapter": a class like DatabaseController providing create, find,
+//                    update, and delete
 // "filesAdapter": a class like GridStoreAdapter providing create, get,
 //                 and delete
 // "loggerAdapter": a class like FileLoggerAdapter providing info, error,
@@ -166,6 +168,7 @@ class ParseServer {
     cache.apps.set(appId, {
       masterKey: masterKey,
       serverURL: serverURL,
+      collectionPrefix: collectionPrefix,
       clientKey: clientKey,
       javascriptKey: javascriptKey,
       dotNetKey: dotNetKey,

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -53,8 +53,6 @@ addParseCloud();
 
 // ParseServer works like a constructor of an express app.
 // The args that we understand are:
-// "databaseAdapter": a class like DatabaseController providing create, find,
-//                    update, and delete
 // "filesAdapter": a class like GridStoreAdapter providing create, get,
 //                 and delete
 // "loggerAdapter": a class like FileLoggerAdapter providing info, error,
@@ -88,7 +86,7 @@ class ParseServer {
     push,
     loggerAdapter,
     logsFolder,
-    databaseURI = DatabaseAdapter.defaultDatabaseURI,
+    databaseURI,
     databaseOptions,
     cloud,
     collectionPrefix = '',
@@ -130,9 +128,7 @@ class ParseServer {
       DatabaseAdapter.setAppDatabaseOptions(appId, databaseOptions);
     }
 
-    if (databaseURI) {
-      DatabaseAdapter.setAppDatabaseURI(appId, databaseURI);
-    }
+    DatabaseAdapter.setAppDatabaseURI(appId, databaseURI);
 
     if (cloud) {
       addParseCloud();

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -53,8 +53,6 @@ addParseCloud();
 
 // ParseServer works like a constructor of an express app.
 // The args that we understand are:
-// "databaseAdapter": a class like DatabaseController providing create, find,
-//                    update, and delete
 // "filesAdapter": a class like GridStoreAdapter providing create, get,
 //                 and delete
 // "loggerAdapter": a class like FileLoggerAdapter providing info, error,
@@ -168,7 +166,6 @@ class ParseServer {
     cache.apps.set(appId, {
       masterKey: masterKey,
       serverURL: serverURL,
-      collectionPrefix: collectionPrefix,
       clientKey: clientKey,
       javascriptKey: javascriptKey,
       dotNetKey: dotNetKey,

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -526,7 +526,7 @@ class Schema {
       if (this.data[className][fieldName].type == 'Relation') {
         //For relations, drop the _Join table
         return database.adaptiveCollection(className).then(collection => {
-          return database.adapter.deleteFields(className, [fieldName], [], database.collectionPrefix, collection);
+          return database.adapter.deleteFields(className, [fieldName], [], collection);
         })
         .then(() => database.dropCollection(`_Join:${fieldName}:${className}`))
         .catch(error => {
@@ -542,7 +542,7 @@ class Schema {
       const fieldNames = [fieldName];
       const pointerFieldNames = this.data[className][fieldName].type === 'Pointer' ? [fieldName] : [];
       return database.adaptiveCollection(className)
-      .then(collection => database.adapter.deleteFields(className, fieldNames, pointerFieldNames, database.collectionPrefix, collection));
+      .then(collection => database.adapter.deleteFields(className, fieldNames, pointerFieldNames, collection));
     });
   }
 

--- a/src/Schema.js
+++ b/src/Schema.js
@@ -525,9 +525,7 @@ class Schema {
 
       if (this.data[className][fieldName].type == 'Relation') {
         //For relations, drop the _Join table
-        return database.adaptiveCollection(className).then(collection => {
-          return database.adapter.deleteFields(className, [fieldName], [], collection);
-        })
+        return database.adapter.deleteFields(className, [fieldName], [])
         .then(() => database.dropCollection(`_Join:${fieldName}:${className}`))
         .catch(error => {
           // 'ns not found' means collection was already gone. Ignore deletion attempt.
@@ -541,8 +539,7 @@ class Schema {
 
       const fieldNames = [fieldName];
       const pointerFieldNames = this.data[className][fieldName].type === 'Pointer' ? [fieldName] : [];
-      return database.adaptiveCollection(className)
-      .then(collection => database.adapter.deleteFields(className, fieldNames, pointerFieldNames, collection));
+      return database.adapter.deleteFields(className, fieldNames, pointerFieldNames);
     });
   }
 

--- a/src/testing-routes.js
+++ b/src/testing-routes.js
@@ -1,8 +1,8 @@
 // testing-routes.js
-import cache from './cache';
+import cache            from './cache';
 import * as middlewares from './middlewares';
-import { ParseServer } from './index';
-import { Parse } from 'parse/node';
+import { ParseServer }  from './index';
+import { Parse }        from 'parse/node';
 
 var express = require('express'),
   cryptoUtils = require('./cryptoUtils');
@@ -31,7 +31,7 @@ function createApp(req, res) {
   res.status(200).send(keys);
 }
 
-// deletes all collections with the collectionPrefix of the app
+// deletes all collections that belong to the app
 function clearApp(req, res) {
   if (!req.auth.isMaster) {
     return res.status(401).send({ "error": "unauthorized" });


### PR DESCRIPTION
This removes the collection prefix and default mongo URI from DatabaseAdapter.

The DefaultMongoURI is now duplicated across the MongoAdapter and GridStore but those are separate adapters that will eventually be in separate repos, so it makes sense for them to be duplicated.