### PR TITLE
Checking if object has defined key for Pointer constraints in liveQuery

### DIFF
--- a/src/LiveQuery/QueryTools.js
+++ b/src/LiveQuery/QueryTools.js
@@ -141,6 +141,7 @@ function matchesKeyConstraints(object, key, constraints) {
   if (constraints.__type) {
     if (constraints.__type === 'Pointer') {
       return (
+        typeof object[key] !== 'undefined' &&
         constraints.className === object[key].className &&
         constraints.objectId === object[key].objectId
       );

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -450,7 +450,6 @@ function includePath(config, auth, response, path) {
     return response;
   }
   let pointersHash = {};
-  var className = null;
   var objectIds = {};
   for (var pointer of pointers) {
     let className = pointer.className;

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -477,8 +477,9 @@ function includePath(config, auth, response, path) {
         obj.__type = 'Object';
         obj.className = includeResponse.className;
 
-        if(className == "_User"){
+        if (obj.className == "_User") {
           delete obj.sessionToken;
+          delete obj.authData;
         }
         replace[obj.objectId] = obj;
       }


### PR DESCRIPTION
If there is a liveQuery subscription, with Pointer type constrains (e.g.
query.equalTo('user', Parse.User.current())), and new object has
undefined value for that field, we get this error:

error: Uncaught internal server error. [TypeError: Cannot read
property 'className' of undefined] TypeError: Cannot read property
'className' of undefined
at matchesKeyConstraints
(…/node_modules/parse-server/lib/LiveQuery/QueryTools.js:145:51)