### PR TITLE
Apply credential stripping to all untransforms for _User

### DIFF
--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -119,12 +119,13 @@ DatabaseController.prototype.untransformObject = function(
     return object;
   }
 
+  delete object.authData;
+  delete object.sessionToken;
+
   if (isMaster || (aclGroup.indexOf(object.objectId) > -1)) {
     return object;
   }
 
-  delete object.authData;
-  delete object.sessionToken;
   return object;
 };
 


### PR DESCRIPTION
The tests describe what is going on. Basically we also want to strip sessionToken and auth data when isMaster is used. Fixes #1482 