### PR TITLE
Remove acceptor parameter

### DIFF
--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -58,26 +58,15 @@ DatabaseController.prototype.validateClassName = function(className) {
 // Returns a promise for a schema object.
 // If we are provided a acceptor, then we run it on the schema.
 // If the schema isn't accepted, we reload it at most once.
-DatabaseController.prototype.loadSchema = function(acceptor = () => true) {
+DatabaseController.prototype.loadSchema = function() {
 
   if (!this.schemaPromise) {
     this.schemaPromise = this.schemaCollection().then(collection => {
       delete this.schemaPromise;
       return SchemaController.load(collection, this.adapter);
     });
-    return this.schemaPromise;
   }
-
-  return this.schemaPromise.then((schema) => {
-    if (acceptor(schema)) {
-      return schema;
-    }
-    this.schemaPromise = this.schemaCollection().then(collection => {
-      delete this.schemaPromise;
-      return SchemaController.load(collection, this.adapter);
-    });
-    return this.schemaPromise;
-  });
+  return this.schemaPromise;
 };
 
 // Returns a promise for the classname that is related to the given
@@ -147,13 +136,10 @@ DatabaseController.prototype.update = function(className, query, update, options
   // Make a copy of the object, so we don't mutate the incoming data.
   update = deepcopy(update);
 
-  var acceptor = function(schema) {
-    return schema.hasKeys(className, Object.keys(query));
-  };
   var isMaster = !('acl' in options);
   var aclGroup = options.acl || [];
   var mongoUpdate, schema;
-  return this.loadSchema(acceptor)
+  return this.loadSchema()
     .then(s => {
       schema = s;
       if (!isMaster) {
@@ -586,9 +572,8 @@ DatabaseController.prototype.find = function(className, query, options = {}) {
   }
   let isMaster = !('acl' in options);
   let aclGroup = options.acl || [];
-  let acceptor = schema => schema.hasKeys(className, keysForQuery(query))
   let schema = null;
-  return this.loadSchema(acceptor).then(s => {
+  return this.loadSchema().then(s => {
     schema = s;
     if (options.sort) {
       mongoOptions.sort = {};


### PR DESCRIPTION
This parameter doesn't seem to do anything, tests pass without it, and it makes shifting the schema to the database adapter impossible, so I'm removing it.

@gfosco can you explain why it was there in the first place? I generally try not to remove code I don't understand so I would like you to help me understand if possible.