### PR TITLE
Fix #1591

### DIFF
--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -23,13 +23,11 @@ var dummySchema = {
 };
 
 
-describe('parseObjectToMongoObjectForCreate', () => {
+describe('parseObjectToMongoObject', () => {
 
   it('a basic number', (done) => {
     var input = {five: 5};
-    var output = transform.parseObjectToMongoObjectForCreate(dummySchema, null, input, {
-      fields: {five: {type: 'Number'}}
-    });
+    var output = transform.parseObjectToMongoObject(dummySchema, null, input);
     jequal(input, output);
     done();
   });
@@ -39,7 +37,7 @@ describe('parseObjectToMongoObjectForCreate', () => {
       createdAt: "2015-10-06T21:24:50.332Z",
       updatedAt: "2015-10-06T21:24:50.332Z"
     };
-    var output = transform.parseObjectToMongoObjectForCreate(dummySchema, null, input);
+    var output = transform.parseObjectToMongoObject(dummySchema, null, input);
     expect(output._created_at instanceof Date).toBe(true);
     expect(output._updated_at instanceof Date).toBe(true);
     done();
@@ -51,25 +49,21 @@ describe('parseObjectToMongoObjectForCreate', () => {
       objectId: 'myId',
       className: 'Blah',
     };
-    var out = transform.parseObjectToMongoObjectForCreate(dummySchema, null, {pointers: [pointer]},{
-      fields: {pointers: {type: 'Array'}}
-    });
+    var out = transform.parseObjectToMongoObject(dummySchema, null, {pointers: [pointer]});
     jequal([pointer], out.pointers);
     done();
   });
 
-  //TODO: object creation requests shouldn't be seeing __op delete, it makes no sense to
-  //have __op delete in a new object. Figure out what this should actually be testing.
-  notWorking('a delete op', (done) => {
+  it('a delete op', (done) => {
     var input = {deleteMe: {__op: 'Delete'}};
-    var output = transform.parseObjectToMongoObjectForCreate(dummySchema, null, input);
+    var output = transform.parseObjectToMongoObject(dummySchema, null, input);
     jequal(output, {});
     done();
   });
 
   it('basic ACL', (done) => {
     var input = {ACL: {'0123': {'read': true, 'write': true}}};
-    var output = transform.parseObjectToMongoObjectForCreate(dummySchema, null, input);
+    var output = transform.parseObjectToMongoObject(dummySchema, null, input);
     // This just checks that it doesn't crash, but it should check format.
     done();
   });
@@ -77,27 +71,21 @@ describe('parseObjectToMongoObjectForCreate', () => {
   describe('GeoPoints', () => {
     it('plain', (done) => {
       var geoPoint = {__type: 'GeoPoint', longitude: 180, latitude: -180};
-      var out = transform.parseObjectToMongoObjectForCreate(dummySchema, null, {location: geoPoint},{
-        fields: {location: {type: 'GeoPoint'}}
-      });
+      var out = transform.parseObjectToMongoObject(dummySchema, null, {location: geoPoint});
       expect(out.location).toEqual([180, -180]);
       done();
     });
 
     it('in array', (done) => {
       var geoPoint = {__type: 'GeoPoint', longitude: 180, latitude: -180};
-      var out = transform.parseObjectToMongoObjectForCreate(dummySchema, null, {locations: [geoPoint, geoPoint]},{
-        fields: {locations: {type: 'Array'}}
-      });
+      var out = transform.parseObjectToMongoObject(dummySchema, null, {locations: [geoPoint, geoPoint]});
       expect(out.locations).toEqual([geoPoint, geoPoint]);
       done();
     });
 
     it('in sub-object', (done) => {
       var geoPoint = {__type: 'GeoPoint', longitude: 180, latitude: -180};
-      var out = transform.parseObjectToMongoObjectForCreate(dummySchema, null, { locations: { start: geoPoint }},{
-        fields: {locations: {type: 'Object'}}
-      });
+      var out = transform.parseObjectToMongoObject(dummySchema, null, { locations: { start: geoPoint }});
       expect(out).toEqual({ locations: { start: geoPoint } });
       done();
     });
@@ -208,9 +196,7 @@ describe('transform schema key changes', () => {
     var input = {
       somePointer: {__type: 'Pointer', className: 'Micro', objectId: 'oft'}
     };
-    var output = transform.parseObjectToMongoObjectForCreate(dummySchema, null, input, {
-      fields: {somePointer: {type: 'Pointer'}}
-    });
+    var output = transform.parseObjectToMongoObject(dummySchema, null, input);
     expect(typeof output._p_somePointer).toEqual('string');
     expect(output._p_somePointer).toEqual('Micro$oft');
     done();
@@ -220,9 +206,7 @@ describe('transform schema key changes', () => {
     var input = {
       userPointer: {__type: 'Pointer', className: '_User', objectId: 'qwerty'}
     };
-    var output = transform.parseObjectToMongoObjectForCreate(dummySchema, null, input, {
-      fields: {userPointer: {type: 'Pointer'}}
-    });
+    var output = transform.parseObjectToMongoObject(dummySchema, null, input);
     expect(typeof output._p_userPointer).toEqual('string');
     expect(output._p_userPointer).toEqual('_User$qwerty');
     done();
@@ -235,7 +219,7 @@ describe('transform schema key changes', () => {
         "Kevin": { "write": true }
       }
     };
-    var output = transform.parseObjectToMongoObjectForCreate(dummySchema, null, input);
+    var output = transform.parseObjectToMongoObject(dummySchema, null, input);
     expect(typeof output._rperm).toEqual('object');
     expect(typeof output._wperm).toEqual('object');
     expect(output.ACL).toBeUndefined();

--- a/spec/Parse.Push.spec.js
+++ b/spec/Parse.Push.spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-let request = require('request');
 
 describe('Parse.Push', () => {
 
@@ -88,59 +87,6 @@ describe('Parse.Push', () => {
       console.error();
       fail('should not fail sending push')
       done();
-    });
-  });
-
-  it('should not allow clients to query _PushStatus', done => {
-    setup()
-    .then(() => Parse.Push.send({
-      where: {
-        deviceType: 'ios'
-      },
-      data: {
-        badge: 'increment',
-        alert: 'Hello world!'
-      }
-    }, {useMasterKey: true}))
-    .then(() => {
-      request.get({
-        url: 'http://localhost:8378/1/classes/_PushStatus',
-        json: true,
-        headers: {
-          'X-Parse-Application-Id': 'test',
-        },
-      }, (error, response, body) => {
-        expect(body.results.length).toEqual(0);
-        done();
-      });
-    });
-  });
-
-  it('should allow master key to query _PushStatus', done => {
-    setup()
-    .then(() => Parse.Push.send({
-      where: {
-        deviceType: 'ios'
-      },
-      data: {
-        badge: 'increment',
-        alert: 'Hello world!'
-      }
-    }, {useMasterKey: true}))
-    .then(() => {
-      request.get({
-        url: 'http://localhost:8378/1/classes/_PushStatus',
-        json: true,
-        headers: {
-          'X-Parse-Application-Id': 'test',
-          'X-Parse-Master-Key': 'test',
-        },
-      }, (error, response, body) => {
-        expect(body.results.length).toEqual(1);
-        expect(body.results[0].query).toEqual('{"deviceType":"ios"}');
-        expect(body.results[0].payload).toEqual('{"badge":"increment","alert":"Hello world!"}');
-        done();
-      });
     });
   });
 });

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -145,16 +145,14 @@ export class MongoStorageAdapter {
   // this adapter doesn't know about the schema, return a promise that rejects with
   // undefined as the reason.
   getOneSchema(className) {
-    return this.schemaCollection()
-    .then(schemasCollection => schemasCollection._fechOneSchemaFrom_SCHEMA(className));
+    return this.schemaCollection().then(schemasCollection => schemasCollection._fechOneSchemaFrom_SCHEMA(className));
   }
 
-  // TODO: As yet not particularly well specified. Creates an object. Shouldn't need the
-  // schemaController, but MongoTransform still needs it :( maybe shouldn't even need the schema,
-  // and should infer from the type. Or maybe does need the schema for validations. Or maybe needs
-  // the schem only for the legacy mongo format. We'll figure that out later.
-  createObject(className, object, schemaController, parseFormatSchema) {
-    const mongoObject = transform.parseObjectToMongoObjectForCreate(schemaController, className, object, parseFormatSchema);
+  // TODO: As yet not particularly well specified. Creates an object. Does it really need the schema?
+  // or can it fetch the schema itself? Also the schema is not currently a Parse format schema, and it
+  // should be, if we are passing it at all.
+  createObject(className, object, schema) {
+    const mongoObject = transform.parseObjectToMongoObject(schema, className, object);
     return this.adaptiveCollection(className)
     .then(collection => collection.insertOne(mongoObject));
   }


### PR DESCRIPTION
This reverts the change that caused #1591. We'll need to come up with some strategy for handling system classes that are new in Parse Server. In the meantime, doing this means we aren't blocked from releasing 2.2.8