### PR TITLE
Fix for #1642 - copy query parameters to request body

### DIFF
--- a/spec/InstallationsRouter.spec.js
+++ b/spec/InstallationsRouter.spec.js
@@ -22,7 +22,8 @@ describe('InstallationsRouter', () => {
         where: {
           deviceType: 'android'
         }
-      }
+      },
+      query: {}
     };
 
     var router = new InstallationsRouter();

--- a/spec/InstallationsRouter.spec.js
+++ b/spec/InstallationsRouter.spec.js
@@ -1,0 +1,73 @@
+var auth = require('../src/Auth');
+var Config = require('../src/Config');
+var rest = require('../src/rest');
+var InstallationsRouter = require('../src/Routers/InstallationsRouter').InstallationsRouter;
+
+var config = new Config('test');
+
+describe('InstallationsRouter', () => {
+  it('uses find condition from request.body', (done) => {
+    var androidDeviceRequest = {
+      'installationId': '12345678-abcd-abcd-abcd-123456789abc',
+      'deviceType': 'android'
+    };
+    var iosDeviceRequest = {
+      'installationId': '12345678-abcd-abcd-abcd-123456789abd',
+      'deviceType': 'ios'
+    };
+    var request = {
+      config: config,
+      auth: auth.master(config),
+      body: {
+        where: {
+          deviceType: 'android'
+        }
+      }
+    };
+
+    var router = new InstallationsRouter();
+    rest.create(config, auth.nobody(config), '_Installation', androidDeviceRequest)
+    .then(() => {
+      return rest.create(config, auth.nobody(config), '_Installation', iosDeviceRequest);
+    }).then(() => {
+      return router.handleFind(request);
+    }).then((res) => {
+      var results = res.response.results;
+      expect(results.length).toEqual(1);
+      done();
+    });
+  });
+
+  it('uses find condition from request.query', (done) => {
+    var androidDeviceRequest = {
+      'installationId': '12345678-abcd-abcd-abcd-123456789abc',
+      'deviceType': 'android'
+    };
+    var iosDeviceRequest = {
+      'installationId': '12345678-abcd-abcd-abcd-123456789abd',
+      'deviceType': 'ios'
+    };
+    var request = {
+      config: config,
+      auth: auth.master(config),
+      body: {},
+      query: {
+        where: {
+          deviceType: 'android'
+        }
+      }
+    };
+
+    var router = new InstallationsRouter();
+    rest.create(config, auth.nobody(config), '_Installation', androidDeviceRequest)
+        .then(() => {
+          return rest.create(config, auth.nobody(config), '_Installation', iosDeviceRequest);
+        }).then(() => {
+      return router.handleFind(request);
+    }).then((res) => {
+      var results = res.response.results;
+      expect(results.length).toEqual(1);
+      done();
+    });
+  });
+});

--- a/src/Routers/InstallationsRouter.js
+++ b/src/Routers/InstallationsRouter.js
@@ -6,25 +6,27 @@ import rest from '../rest';
 
 export class InstallationsRouter extends ClassesRouter {
   handleFind(req) {
+    let body = Object.assign(req.body, ClassesRouter.JSONFromQuery(req.query));
     var options = {};
-    if (req.body.skip) {
-      options.skip = Number(req.body.skip);
+
+    if (body.skip) {
+      options.skip = Number(body.skip);
     }
-    if (req.body.limit) {
-      options.limit = Number(req.body.limit);
+    if (body.limit) {
+      options.limit = Number(body.limit);
     }
-    if (req.body.order) {
-      options.order = String(req.body.order);
+    if (body.order) {
+      options.order = String(body.order);
     }
-    if (req.body.count) {
+    if (body.count) {
       options.count = true;
     }
-    if (req.body.include) {
-      options.include = String(req.body.include);
+    if (body.include) {
+      options.include = String(body.include);
     }
 
     return rest.find(req.config, req.auth,
-      '_Installation', req.body.where, options)
+      '_Installation', body.where, options)
       .then((response) => {
         return {response: response};
       });


### PR DESCRIPTION
This fixes a bug with query string parameters not being used on queries on _Installation. The bug does not exist in ClassesRouter. Issue is #1642 

@nlutsenko 
InstallationsRouter.handleFind has code duplicated from ClassesRouter.handleFind without some of the useful looking checks in ClassesRouter. It might make sense to refactor the common functionality out/up. I have just fixed the bug here and leave the refactoring for another day.