### PR TITLE
Added support for legacy session tokens

### DIFF
--- a/src/Auth.js
+++ b/src/Auth.js
@@ -68,7 +68,7 @@ var getAuthForSessionToken = function({ config, sessionToken, installationId } =
       let userObject = Parse.Object.fromJSON(obj);
       cache.users.set(sessionToken, userObject);
       return new Auth({ config, isMaster: false, installationId, user: userObject });
-    }
+    });
   } else {
     var query = new RestQuery(config, master(config), '_Session', { sessionToken }, restOptions);
     return query.execute().then((response) => {
@@ -90,8 +90,8 @@ var getAuthForSessionToken = function({ config, sessionToken, installationId } =
       let userObject = Parse.Object.fromJSON(obj);
       cache.users.set(sessionToken, userObject);
       return new Auth({ config, isMaster: false, installationId, user: userObject });
-    }
-  });
+    });
+  }
 };
 
 // Returns a promise that resolves to an array of role names

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -52,26 +52,45 @@ var getAuthForSessionToken = function({ config, sessionToken, installationId } =
     limit: 1,
     include: 'user'
   };
-  var query = new RestQuery(config, master(config), '_Session', { sessionToken }, restOptions);
-  return query.execute().then((response) => {
-    var results = response.results;
-    if (results.length !== 1 || !results[0]['user']) {
-      return nobody(config);
-    }
 
-    var now = new Date(),
-        expiresAt = results[0].expiresAt ? new Date(results[0].expiresAt.iso) : undefined;
-    if(expiresAt < now) {
-      throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN,
-            'Session token is expired.');
+  if(config.legacySessionTokens) {
+    var query = new RestQuery(config, master(config), '_User', { sessionToken }, restOptions);
+    return query.execute().then((response) => {
+      var results = response.results;
+      if (results.length !== 1) {
+        return nobody(config);
+      }
+
+      var obj = results[0];
+      delete obj.password;
+      obj['className'] = '_User';
+      obj['sessionToken'] = sessionToken;
+      let userObject = Parse.Object.fromJSON(obj);
+      cache.users.set(sessionToken, userObject);
+      return new Auth({ config, isMaster: false, installationId, user: userObject });
     }
-    var obj = results[0]['user'];
-    delete obj.password;
-    obj['className'] = '_User';
-    obj['sessionToken'] = sessionToken;
-    let userObject = Parse.Object.fromJSON(obj);
-    cache.users.set(sessionToken, userObject);
-    return new Auth({ config, isMaster: false, installationId, user: userObject });
+  } else {
+    var query = new RestQuery(config, master(config), '_Session', { sessionToken }, restOptions);
+    return query.execute().then((response) => {
+      var results = response.results;
+      if (results.length !== 1 || !results[0]['user']) {
+        return nobody(config);
+      }
+
+      var now = new Date(),
+          expiresAt = results[0].expiresAt ? new Date(results[0].expiresAt.iso) : undefined;
+      if(expiresAt < now) {
+        throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN,
+              'Session token is expired.');
+      }
+      var obj = results[0]['user'];
+      delete obj.password;
+      obj['className'] = '_User';
+      obj['sessionToken'] = sessionToken;
+      let userObject = Parse.Object.fromJSON(obj);
+      cache.users.set(sessionToken, userObject);
+      return new Auth({ config, isMaster: false, installationId, user: userObject });
+    }
   });
 };
 

--- a/src/Config.js
+++ b/src/Config.js
@@ -51,6 +51,7 @@ export class Config {
     this.expireInactiveSessions = cacheInfo.expireInactiveSessions;
     this.generateSessionExpiresAt = this.generateSessionExpiresAt.bind(this);
     this.revokeSessionOnPasswordReset = cacheInfo.revokeSessionOnPasswordReset;
+    this.legacySessionTokens = cacheInfo.legacySessionTokens;
   }
 
   static validate(options) {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -117,6 +117,7 @@ class ParseServer {
     expireInactiveSessions = true,
     verbose = false,
     revokeSessionOnPasswordReset = true,
+    legacySessionTokens = false
   }) {
     // Initialize the node client SDK automatically
     Parse.initialize(appId, javascriptKey || 'unused', masterKey);
@@ -190,7 +191,8 @@ class ParseServer {
       liveQueryController: liveQueryController,
       sessionLength: Number(sessionLength),
       expireInactiveSessions: expireInactiveSessions,
-      revokeSessionOnPasswordReset
+      revokeSessionOnPasswordReset,
+      legacySessionTokens
     });
 
     // To maintain compatibility. TODO: Remove in some version that breaks backwards compatability


### PR DESCRIPTION
For people with older Parse apps that need to migrate and haven't upgraded yet to revocable sessions, this will allow them to set `legacySessionTokens` to `true` in order to look for `sessionToken` from `_User` in `Auth`.