### PR TITLE
Fix malformed config.json in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -103,7 +103,7 @@ cat > ./config.json << EOF
   "masterKey": "$MASTER_KEY",
   "appName": "$APP_NAME",
   "cloud": "./cloud/main",
-  "mongodbURI": "$MONGODB_URI"
+  "databaseURI": "$MONGODB_URI"
 }
 EOF
 echo "${CHECK} Created config.json"


### PR DESCRIPTION
The bootstrap bash script generates a wrong config.json file.
Instead of having a databaseURI property, it has a mongodbURI prop.

![screen shot 2016-05-10 at 6 04 17 pm](https://cloud.githubusercontent.com/assets/1928544/15162517/b3314df0-16d9-11e6-8fa0-8dbc2fe96f6f.png)