### PR TITLE
Fix keys aren't enforced

### DIFF
--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1164,7 +1164,71 @@ describe('miscellaneous', function() {
     });
   });
 
+  it('should not fail without any key', done => {
+    let customConfig = Object.assign({}, defaultConfiguration);
+    delete customConfig.clientKey;
+    delete customConfig.javascriptKey;
+    delete customConfig.dotNetKey;
+    delete customConfig.restAPIKey;
+    setServerConfiguration(customConfig);
+    var headers = {
+      'Content-Type': 'application/octet-stream',
+      'X-Parse-Application-Id': 'test'
+    };
+    request.get({
+      headers: headers,
+      url: 'http://localhost:8378/1/classes/TestObject'
+    }, (error, response, body) => {
+      expect(error).toBe(null);
+      var b = JSON.parse(body);
+      expect(b.results.length).toEqual(0);
+      done();
+    });
+  });
+
+  it('fails on missing key when empty keys are defined', done => {
+    let customConfig = Object.assign({}, defaultConfiguration);
+    customConfig.clientKey = '';
+    customConfig.javascriptKey = '';
+    customConfig.dotNetKey = '';
+    customConfig.restAPIKey = '';
+    setServerConfiguration(customConfig);
+    var headers = {
+      'Content-Type': 'application/octet-stream',
+      'X-Parse-Application-Id': 'test'
+    };
+    request.get({
+      headers: headers,
+      url: 'http://localhost:8378/1/classes/TestObject'
+    }, (error, response, body) => {
+      expect(error).toBe(null);
+      var b = JSON.parse(body);
+      expect(b.error).toEqual('unauthorized');
+      done();
+    });
+  });
+
   it('fails on invalid client key', done => {
+    var headers = {
+      'Content-Type': 'application/octet-stream',
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-Client-Key': 'notclient'
+    };
+    request.get({
+      headers: headers,
+      url: 'http://localhost:8378/1/classes/TestObject'
+    }, (error, response, body) => {
+      expect(error).toBe(null);
+      var b = JSON.parse(body);
+      expect(b.error).toEqual('unauthorized');
+      done();
+    });
+  });
+
+  it('fails on invalid client key when only some keys are defined', done => {
+    let customConfig = Object.assign({}, defaultConfiguration);
+    delete customConfig.restAPIKey;
+    setServerConfiguration(customConfig);
     var headers = {
       'Content-Type': 'application/octet-stream',
       'X-Parse-Application-Id': 'test',
@@ -1198,6 +1262,26 @@ describe('miscellaneous', function() {
     });
   });
 
+  it('fails on invalid windows key when only some keys are defined', done => {
+    let customConfig = Object.assign({}, defaultConfiguration);
+    delete customConfig.restAPIKey;
+    setServerConfiguration(customConfig);
+    var headers = {
+      'Content-Type': 'application/octet-stream',
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-Windows-Key': 'notwindows'
+    };
+    request.get({
+      headers: headers,
+      url: 'http://localhost:8378/1/classes/TestObject'
+    }, (error, response, body) => {
+      expect(error).toBe(null);
+      var b = JSON.parse(body);
+      expect(b.error).toEqual('unauthorized');
+      done();
+    });
+  });
+
   it('fails on invalid javascript key', done => {
     var headers = {
       'Content-Type': 'application/octet-stream',
@@ -1215,7 +1299,47 @@ describe('miscellaneous', function() {
     });
   });
 
+  it('fails on invalid javascript key when only some keys are defined', done => {
+    let customConfig = Object.assign({}, defaultConfiguration);
+    delete customConfig.restAPIKey;
+    setServerConfiguration(customConfig);
+    var headers = {
+      'Content-Type': 'application/octet-stream',
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-Javascript-Key': 'notjavascript'
+    };
+    request.get({
+      headers: headers,
+      url: 'http://localhost:8378/1/classes/TestObject'
+    }, (error, response, body) => {
+      expect(error).toBe(null);
+      var b = JSON.parse(body);
+      expect(b.error).toEqual('unauthorized');
+      done();
+    });
+  });
+
   it('fails on invalid rest api key', done => {
+    var headers = {
+      'Content-Type': 'application/octet-stream',
+      'X-Parse-Application-Id': 'test',
+      'X-Parse-REST-API-Key': 'notrest'
+    };
+    request.get({
+      headers: headers,
+      url: 'http://localhost:8378/1/classes/TestObject'
+    }, (error, response, body) => {
+      expect(error).toBe(null);
+      var b = JSON.parse(body);
+      expect(b.error).toEqual('unauthorized');
+      done();
+    });
+  });
+
+  it('fails on invalid rest api key when only some keys are defined', done => {
+    let customConfig = Object.assign({}, defaultConfiguration);
+    delete customConfig.clientKey;
+    setServerConfiguration(customConfig);
     var headers = {
       'Content-Type': 'application/octet-stream',
       'X-Parse-Application-Id': 'test',

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -102,19 +102,23 @@ function handleParseHeaders(req, res, next) {
   // Client keys are not required in parse-server, but if any have been configured in the server, validate them
   //  to preserve original behavior.
   let keys = ["clientKey", "javascriptKey", "dotNetKey", "restAPIKey"];
+  let missingKeys = [];
 
   // We do it with mismatching keys to support no-keys config
   var keyMismatch = keys.reduce(function(mismatch, key){
 
     // check if set in the config and compare
-    if (req.config[key] && info[key] !== req.config[key]) {
+    if (!req.config[key] && req.config[key] !== '') {
+      missingKeys.push(key);
+    } else if (info[key] !== req.config[key]) {
       mismatch++;
     }
     return mismatch;
   }, 0);
 
   // All keys mismatch
-  if (keyMismatch == keys.length) {
+  keys = keys.filter(key => missingKeys.indexOf(key) < 0);
+  if (keyMismatch == keys.length && keys.length > 0) {
     return invalidRequest(req, res);
   }
 


### PR DESCRIPTION
#1733 will happen when only some client keys are defined, like defined `clientKey`, `javascriptKey` and `restAPIKey` but missing the `dotNetKey`.
Added some test cases to demonstrate the fix.