### PR TITLE
Write old ACL format in _acl in addition to new format

### DIFF
--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -244,6 +244,21 @@ describe('transform schema key changes', () => {
     done();
   });
 
+  it('writes the old ACL format in addition to rperm and wperm', (done) => {
+    var input = {
+      ACL: {
+        "*": { "read": true },
+        "Kevin": { "write": true }
+      }
+    };
+
+    var output = transform.parseObjectToMongoObjectForCreate(dummySchema, null, input);
+    expect(typeof output._acl).toEqual('object');
+    expect(output._acl["Kevin"].w).toBeTruthy();
+    expect(output._acl["Kevin"].r).toBeUndefined();
+    done();
+  })
+
   it('untransforms from _rperm and _wperm to ACL', (done) => {
     var input = {
       _rperm: ["*"],

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -354,13 +354,16 @@ function transformUpdate(schema, className, restUpdate) {
 
   var mongoUpdate = {};
   var acl = transformACL(restUpdate);
-  if (acl._rperm || acl._wperm) {
+  if (acl._rperm || acl._wperm || acl._acl) {
     mongoUpdate['$set'] = {};
     if (acl._rperm) {
       mongoUpdate['$set']['_rperm'] = acl._rperm;
     }
     if (acl._wperm) {
       mongoUpdate['$set']['_wperm'] = acl._wperm;
+    }
+    if (acl._acl) {
+      mongoUpdate['$set']['_acl'] = acl._acl;
     }
   }
 
@@ -410,16 +413,23 @@ function transformACL(restObject) {
   var acl = restObject['ACL'];
   var rperm = [];
   var wperm = [];
+  var _acl = {}; // old format
+
   for (var entry in acl) {
     if (acl[entry].read) {
       rperm.push(entry);
+      _acl[entry] = _acl[entry] || {};
+      _acl[entry]['r'] = true;
     }
     if (acl[entry].write) {
       wperm.push(entry);
+      _acl[entry] = _acl[entry] || {};
+      _acl[entry]['w'] = true;
     }
   }
   output._rperm = rperm;
   output._wperm = wperm;
+  output._acl = _acl;
   delete restObject.ACL;
   return output;
 }


### PR DESCRIPTION
Putting up some rebased code from #1317 with a test. The code writes objects with the legacy parse ACL format in addition to the new format so that ACLs are backwards compatible with api.parse.com