### PR TITLE
Refactor MongoTransform.js

### DIFF
--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1449,4 +1449,24 @@ describe('miscellaneous', function() {
       done();
     });
   });
+
+  it('bans interior keys containing . or $', done => {
+    new Parse.Object('Obj').save({innerObj: {'key with a $': 'fails'}})
+    .catch(error => {
+      expect(error.code).toEqual(Parse.Error.INVALID_NESTED_KEY);
+      return new Parse.Object('Obj').save({innerObj: {'key with a .': 'fails'}});
+    })
+    .catch(error => {
+      expect(error.code).toEqual(Parse.Error.INVALID_NESTED_KEY);
+      return new Parse.Object('Obj').save({innerObj: {innerInnerObj: {'key with $': 'fails'}}});
+    })
+    .catch(error => {
+      expect(error.code).toEqual(Parse.Error.INVALID_NESTED_KEY);
+      return new Parse.Object('Obj').save({innerObj: {innerInnerObj: {'key with .': 'fails'}}});
+    })
+    .catch(error => {
+      expect(error.code).toEqual(Parse.Error.INVALID_NESTED_KEY);
+      done();
+    })
+  });
 });

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1437,4 +1437,16 @@ describe('miscellaneous', function() {
       done();
     });
   });
+
+  it('doesnt convert interior keys of objects that use special names', done => {
+    let obj = new Parse.Object('Obj');
+    obj.set('val', { createdAt: 'a', updatedAt: 1 });
+    obj.save()
+    .then(obj => new Parse.Query('Obj').get(obj.id))
+    .then(obj => {
+      expect(obj.get('val').createdAt).toEqual('a');
+      expect(obj.get('val').updatedAt).toEqual(1);
+      done();
+    });
+  });
 });

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -10,7 +10,7 @@ var Parse = require('parse/node').Parse;
 // converted to static data.
 //
 // Returns an object with {key: key, value: value}.
-function transformKeyValue(schema, className, restKey, restValue, { interior, update } = {}) {
+const transformKeyValue = (schema, className, restKey, restValue, { update } = {}) => {
   // Check if the schema is known since it's a built-in field.
   var key = restKey;
   var timeField = false;
@@ -73,7 +73,7 @@ function transformKeyValue(schema, className, restKey, restValue, { interior, up
   var expectedTypeIsArray = (expected && expected.type === 'Array');
 
   // Handle atomic values
-  var value = interior ? transformInteriorAtom(restValue) : transformTopLevelAtom(restValue, false);
+  var value = transformTopLevelAtom(restValue, false);
   if (value !== CannotTransform) {
     if (timeField && (typeof value === 'string')) {
       value = new Date(value);
@@ -83,7 +83,7 @@ function transformKeyValue(schema, className, restKey, restValue, { interior, up
 
   // Handle arrays
   if (restValue instanceof Array) {
-    value = restValue.map(restObj => transformKeyValue(schema, className, restKey, restObj, { interior: true }).value);
+    value = restValue.map(restObj => transformInteriorKeyValue(schema, className, restKey, restObj).value);
     return {key, value};
   }
 
@@ -97,7 +97,101 @@ function transformKeyValue(schema, className, restKey, restValue, { interior, up
   value = {};
   for (var subRestKey in restValue) {
     var subRestValue = restValue[subRestKey];
-    var out = transformKeyValue(schema, className, subRestKey, subRestValue, { interior: true });
+    var out = transformInteriorKeyValue(schema, className, subRestKey, subRestValue);
+    // For recursed objects, keep the keys in rest format
+    value[subRestKey] = out.value;
+  }
+  return {key, value};
+}
+
+const transformInteriorKeyValue = (schema, className, restKey, restValue, { update } = {}) => {
+  // Check if the schema is known since it's a built-in field.
+  var key = restKey;
+  var timeField = false;
+  switch(key) {
+  case 'objectId':
+  case '_id':
+    key = '_id';
+    break;
+  case 'createdAt':
+  case '_created_at':
+    key = '_created_at';
+    timeField = true;
+    break;
+  case 'updatedAt':
+  case '_updated_at':
+    key = '_updated_at';
+    timeField = true;
+    break;
+  case '_email_verify_token':
+    key = "_email_verify_token";
+    break;
+  case '_perishable_token':
+    key = "_perishable_token";
+    break;
+  case 'sessionToken':
+  case '_session_token':
+    key = '_session_token';
+    break;
+  case 'expiresAt':
+  case '_expiresAt':
+    key = 'expiresAt';
+    timeField = true;
+    break;
+  case '_rperm':
+  case '_wperm':
+    return {key: key, value: restValue};
+    break;
+  case '$or':
+    throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'you can only use $or in queries');
+  case '$and':
+    throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'you can only use $and in queries');
+  default:
+    // Other auth data
+    var authDataMatch = key.match(/^authData\.([a-zA-Z0-9_]+)\.id$/);
+    if (authDataMatch) {
+      throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'can only query on ' + key);
+    }
+  }
+
+  // Handle special schema key changes
+  // TODO: it seems like this is likely to have edge cases where
+  // pointer types are missed
+  var expected = undefined;
+  if (schema && schema.getExpectedType) {
+    expected = schema.getExpectedType(className, key);
+  }
+  if ((expected && expected.type == 'Pointer') || (!expected && restValue && restValue.__type == 'Pointer')) {
+    key = '_p_' + key;
+  }
+  var expectedTypeIsArray = (expected && expected.type === 'Array');
+
+  // Handle atomic values
+  var value = transformInteriorAtom(restValue);
+  if (value !== CannotTransform) {
+    if (timeField && (typeof value === 'string')) {
+      value = new Date(value);
+    }
+    return {key, value};
+  }
+
+  // Handle arrays
+  if (restValue instanceof Array) {
+    value = restValue.map(restObj => transformInteriorKeyValue(schema, className, restKey, restObj).value);
+    return {key, value};
+  }
+
+  // Handle update operators
+  value = transformUpdateOperator(restValue, !update);
+  if (value !== CannotTransform) {
+    return {key, value};
+  }
+
+  // Handle normal objects by recursing
+  value = {};
+  for (var subRestKey in restValue) {
+    var subRestValue = restValue[subRestKey];
+    var out = transformInteriorKeyValue(schema, className, subRestKey, subRestValue);
     // For recursed objects, keep the keys in rest format
     value[subRestKey] = out.value;
   }
@@ -272,7 +366,7 @@ const parseObjectKeyValueToMongoObjectKeyValue = (
   // Handle arrays
   if (restValue instanceof Array) {
     value = restValue.map((restObj) => {
-      var out = transformKeyValue(schema, className, restKey, restObj, { interior: true });
+      var out = transformInteriorKeyValue(schema, className, restKey, restObj);
       return out.value;
     });
     return {key: restKey, value: value};
@@ -288,7 +382,7 @@ const parseObjectKeyValueToMongoObjectKeyValue = (
   value = {};
   for (var subRestKey in restValue) {
     var subRestValue = restValue[subRestKey];
-    var out = transformKeyValue(schema, className, subRestKey, subRestValue, { interior: true });
+    var out = transformInteriorKeyValue(schema, className, subRestKey, subRestValue);
     // For recursed objects, keep the keys in rest format
     value[subRestKey] = out.value;
   }

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -3,41 +3,28 @@ import _   from 'lodash';
 var mongodb = require('mongodb');
 var Parse = require('parse/node').Parse;
 
-// There are several options that can help transform:
-//
-// update: true indicates that __op operators like Add and Delete
-// in the value are converted to a mongo update form. Otherwise they are
-// converted to static data.
-//
-// Returns an object with {key: key, value: value}.
-const transformKey = (schema, className, key) => {
-  switch(key) {
+const transformKey = (className, fieldName, schema) => {
+  // Check if the schema is known since it's a built-in field.
+  switch(fieldName) {
   case 'objectId':
-    key = '_id';
+    fieldName = '_id';
     break;
   case 'createdAt':
-    key = '_created_at';
+    fieldName = '_created_at';
     break;
   case 'updatedAt':
-    key = '_updated_at';
+    fieldName = '_updated_at';
     break;
   case 'sessionToken':
-    key = '_session_token';
+    fieldName = '_session_token';
     break;
   }
 
-  // Handle special schema key changes
-  // TODO: it seems like this is likely to have edge cases where
-  // pointer types are missed
-  var expected = undefined;
-  if (schema && schema.getExpectedType) {
-    expected = schema.getExpectedType(className, key);
-  }
-  if (expected && expected.type == 'Pointer') {
-    key = '_p_' + key;
+  if (schema.fields[fieldName] && schema.fields[fieldName].__type == 'Pointer') {
+    fieldName = '_p_' + fieldName;
   }
 
-  return key;
+  return fieldName;
 }
 
 const transformKeyValueForUpdate = (schema, className, restKey, restValue) => {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -70,7 +70,6 @@ const transformKeyValue = (schema, className, restKey, restValue) => {
   if ((expected && expected.type == 'Pointer') || (!expected && restValue && restValue.__type == 'Pointer')) {
     key = '_p_' + key;
   }
-  var expectedTypeIsArray = (expected && expected.type === 'Array');
 
   // Handle atomic values
   var value = transformTopLevelAtom(restValue, false);
@@ -163,7 +162,6 @@ const transformKeyValueForUpdate = (schema, className, restKey, restValue) => {
   if ((expected && expected.type == 'Pointer') || (!expected && restValue && restValue.__type == 'Pointer')) {
     key = '_p_' + key;
   }
-  var expectedTypeIsArray = (expected && expected.type === 'Array');
 
   // Handle atomic values
   var value = transformTopLevelAtom(restValue, false);
@@ -256,7 +254,6 @@ const transformInteriorKeyValue = (schema, className, restKey, restValue) => {
   if ((expected && expected.type == 'Pointer') || (!expected && restValue && restValue.__type == 'Pointer')) {
     key = '_p_' + key;
   }
-  var expectedTypeIsArray = (expected && expected.type === 'Array');
 
   // Handle atomic values
   var value = transformInteriorAtom(restValue);

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -104,7 +104,7 @@ const transformKeyValue = (schema, className, restKey, restValue, { update } = {
   return {key, value};
 }
 
-const transformInteriorKeyValue = (schema, className, restKey, restValue, { update } = {}) => {
+const transformInteriorKeyValue = (schema, className, restKey, restValue) => {
   // Check if the schema is known since it's a built-in field.
   var key = restKey;
   var timeField = false;
@@ -182,7 +182,7 @@ const transformInteriorKeyValue = (schema, className, restKey, restValue, { upda
   }
 
   // Handle update operators
-  value = transformUpdateOperator(restValue, !update);
+  value = transformUpdateOperator(restValue, true);
   if (value !== CannotTransform) {
     return {key, value};
   }

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -10,50 +10,20 @@ var Parse = require('parse/node').Parse;
 // converted to static data.
 //
 // Returns an object with {key: key, value: value}.
-const transformKey = (schema, className, restKey) => {
-  // Check if the schema is known since it's a built-in field.
-  var key = restKey;
+const transformKey = (schema, className, key) => {
   switch(key) {
   case 'objectId':
-  case '_id':
     key = '_id';
     break;
   case 'createdAt':
-  case '_created_at':
     key = '_created_at';
     break;
   case 'updatedAt':
-  case '_updated_at':
     key = '_updated_at';
     break;
-  case '_email_verify_token':
-    key = "_email_verify_token";
-    break;
-  case '_perishable_token':
-    key = "_perishable_token";
-    break;
   case 'sessionToken':
-  case '_session_token':
     key = '_session_token';
     break;
-  case 'expiresAt':
-  case '_expiresAt':
-    key = 'expiresAt';
-    break;
-  case '_rperm':
-  case '_wperm':
-    return key;
-    break;
-  case '$or':
-    throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'you can only use $or in queries');
-  case '$and':
-    throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'you can only use $and in queries');
-  default:
-    // Other auth data
-    var authDataMatch = key.match(/^authData\.([a-zA-Z0-9_]+)\.id$/);
-    if (authDataMatch) {
-      throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, 'can only query on ' + key);
-    }
   }
 
   // Handle special schema key changes

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -6,18 +6,10 @@ var Parse = require('parse/node').Parse;
 const transformKey = (className, fieldName, schema) => {
   // Check if the schema is known since it's a built-in field.
   switch(fieldName) {
-  case 'objectId':
-    fieldName = '_id';
-    break;
-  case 'createdAt':
-    fieldName = '_created_at';
-    break;
-  case 'updatedAt':
-    fieldName = '_updated_at';
-    break;
-  case 'sessionToken':
-    fieldName = '_session_token';
-    break;
+    case 'objectId': return '_id';
+    case 'createdAt': return '_created_at';
+    case 'updatedAt': return '_updated_at';
+    case 'sessionToken': return '_session_token';
   }
 
   if (schema.fields[fieldName] && schema.fields[fieldName].__type == 'Pointer') {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -616,67 +616,67 @@ DatabaseController.prototype.find = function(className, query, {
   let op = typeof query.objectId == 'string' && Object.keys(query).length === 1 ? 'get' : 'find';
   return this.loadSchema()
   .then(schemaController => {
-    if (sort) {
-      mongoOptions.sort = {};
-      for (let fieldName in sort) {
-        // Parse.com treats queries on _created_at and _updated_at as if they were queries on createdAt and updatedAt,
-        // so duplicate that behaviour here.
-        if (fieldName === '_created_at') {
-          fieldName = 'createdAt';
-          sort['createdAt'] = sort['_created_at'];
-        } else if (fieldName === '_updated_at') {
-          fieldName = 'updatedAt';
-          sort['updatedAt'] = sort['_updated_at'];
-        }
+    return schemaController.getOneSchema(className)
+    .catch(error => {
+      // If the schema doesn't exist, pretend it exists with no fields. This behaviour
+      // will likely need revisiting.
+      if (error === undefined) {
+        return { fields: {} };
+      }
+      throw error;
+    })
+    .then(schema => {
+      if (sort) {
+        mongoOptions.sort = {};
+        for (let fieldName in sort) {
+          // Parse.com treats queries on _created_at and _updated_at as if they were queries on createdAt and updatedAt,
+          // so duplicate that behaviour here.
+          if (fieldName === '_created_at') {
+            fieldName = 'createdAt';
+            sort['createdAt'] = sort['_created_at'];
+          } else if (fieldName === '_updated_at') {
+            fieldName = 'updatedAt';
+            sort['updatedAt'] = sort['_updated_at'];
+          }
 
-        if (!SchemaController.fieldNameIsValid(fieldName)) {
-          throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid field name: ${fieldName}.`);
-        }
-        if (fieldName.match(/^authData\.([a-zA-Z0-9_]+)\.id$/)) {
-          throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `can only query on ${fieldName}`);
-        }
-        const mongoKey = this.transform.transformKey(schemaController, className, fieldName);
-        mongoOptions.sort[mongoKey] = sort[fieldName];
-      }
-    }
-    return (isMaster ? Promise.resolve() : schemaController.validatePermission(className, aclGroup, op))
-    .then(() => this.reduceRelationKeys(className, query))
-    .then(() => this.reduceInRelation(className, query, schemaController))
-    .then(() => this.adapter.adaptiveCollection(className))
-    .then(collection => {
-      if (!isMaster) {
-        query = this.addPointerPermissions(schemaController, className, op, query, aclGroup);
-      }
-      if (!query) {
-        if (op == 'get') {
-          return Promise.reject(new Parse.Error(Parse.Error.OBJECT_NOT_FOUND,
-            'Object not found.'));
-        } else {
-          return Promise.resolve([]);
+          if (!SchemaController.fieldNameIsValid(fieldName)) {
+            throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid field name: ${fieldName}.`);
+          }
+          if (fieldName.match(/^authData\.([a-zA-Z0-9_]+)\.id$/)) {
+            throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `can only query on ${fieldName}`);
+          }
+          const mongoKey = this.transform.transformKey(className, fieldName, schema);
+          mongoOptions.sort[mongoKey] = sort[fieldName];
         }
       }
-      if (!isMaster) {
-        query = addReadACL(query, aclGroup);
-      }
-      return schemaController.getOneSchema(className)
-      .catch(error => {
-        // If the schema doesn't exist, pretend it exists with no fields. This behaviour
-        // will likely need revisiting.
-        if (error === undefined) {
-          return { fields: {} };
+      return (isMaster ? Promise.resolve() : schemaController.validatePermission(className, aclGroup, op))
+      .then(() => this.reduceRelationKeys(className, query))
+      .then(() => this.reduceInRelation(className, query, schemaController))
+      .then(() => this.adapter.adaptiveCollection(className))
+      .then(collection => {
+        if (!isMaster) {
+          query = this.addPointerPermissions(schemaController, className, op, query, aclGroup);
         }
-        throw error;
-      })
-      .then(parseFormatSchema => {
-        let mongoWhere = this.transform.transformWhere(className, query, {}, parseFormatSchema);
+        if (!query) {
+          if (op == 'get') {
+            return Promise.reject(new Parse.Error(Parse.Error.OBJECT_NOT_FOUND,
+              'Object not found.'));
+          } else {
+            return Promise.resolve([]);
+          }
+        }
+        if (!isMaster) {
+          query = addReadACL(query, aclGroup);
+        }
+        let mongoWhere = this.transform.transformWhere(className, query, {}, schema);
         if (count) {
           delete mongoOptions.limit;
           return collection.count(mongoWhere, mongoOptions);
         } else {
           return collection.find(mongoWhere, mongoOptions)
-          .then((mongoResults) => {
-            return mongoResults.map((r) => {
-              return this.untransformObject(schemaController, isMaster, aclGroup, className, r);
+          .then(mongoResults => {
+            return mongoResults.map(result => {
+              return this.untransformObject(schemaController, isMaster, aclGroup, className, result);
             });
           });
         }

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -632,7 +632,7 @@ DatabaseController.prototype.find = function(className, query, {
         if (!SchemaController.fieldNameIsValid(fieldName)) {
           throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid field name: ${fieldName}.`);
         }
-        const mongoKey = this.transform.transformKeyValue(schemaController, className, fieldName, null).key;
+        const mongoKey = this.transform.transformKey(schemaController, className, fieldName);
         mongoOptions.sort[mongoKey] = sort[fieldName];
       }
     }

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -632,6 +632,9 @@ DatabaseController.prototype.find = function(className, query, {
         if (!SchemaController.fieldNameIsValid(fieldName)) {
           throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid field name: ${fieldName}.`);
         }
+        if (fieldName.match(/^authData\.([a-zA-Z0-9_]+)\.id$/)) {
+          throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `can only query on ${fieldName}`);
+        }
         const mongoKey = this.transform.transformKey(schemaController, className, fieldName);
         mongoOptions.sort[mongoKey] = sort[fieldName];
       }

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -643,7 +643,7 @@ DatabaseController.prototype.find = function(className, query, {
             throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid field name: ${fieldName}.`);
           }
           if (fieldName.match(/^authData\.([a-zA-Z0-9_]+)\.id$/)) {
-            throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `can only query on ${fieldName}`);
+            throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Cannot sort by ${fieldName}`);
           }
           const mongoKey = this.transform.transformKey(className, fieldName, schema);
           mongoOptions.sort[mongoKey] = sort[fieldName];


### PR DESCRIPTION
- Partially breaks dependency of MongoTransform on schemaController

- Lifts a lots of validation higher in the call tree. Ideally all validation would happen very early in the request.

- Fixes a lot of bugs involving keys in nested objects with names like "createdAt"

- Reduce the number of bool parameters in transform functions that do minor tweaks to how the function works.