### PR TITLE
Move query format validation into Parse Server

### DIFF
--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -25,6 +25,7 @@ const storageAdapterAllCollections = mongoAdapter => {
   });
 }
 
+const specialQuerykeys = ['$and', '$or', '_rperm', '_wperm', '_perishable_token', '_email_verify_token'];
 export class MongoStorageAdapter {
   // Private
   _uri: string;
@@ -187,7 +188,10 @@ export class MongoStorageAdapter {
       if (query.ACL) {
         throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
       }
-      let mongoWhere = transform.transformWhere(className, query, { validate }, schema);
+      if (validate && Object.keys(query).some(restKey => !specialQuerykeys.includes(restKey) && !restKey.match(/^[a-zA-Z][a-zA-Z0-9_\.]*$/))) {
+        throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: ${restKey}`);
+      }
+      let mongoWhere = transform.transformWhere(className, query, schema);
       return collection.deleteMany(mongoWhere)
     })
     .then(({ result }) => {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -184,6 +184,9 @@ export class MongoStorageAdapter {
   deleteObjectsByQuery(className, query, validate, schema) {
     return this.adaptiveCollection(className)
     .then(collection => {
+      if (query.ACL) {
+        throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
+      }
       let mongoWhere = transform.transformWhere(className, query, { validate }, schema);
       return collection.deleteMany(mongoWhere)
     })

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -25,7 +25,6 @@ const storageAdapterAllCollections = mongoAdapter => {
   });
 }
 
-const specialQuerykeys = ['$and', '$or', '_rperm', '_wperm', '_perishable_token', '_email_verify_token'];
 export class MongoStorageAdapter {
   // Private
   _uri: string;

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -181,8 +181,8 @@ export class MongoStorageAdapter {
   // If no objects match, reject with OBJECT_NOT_FOUND. If objects are found and deleted, resolve with undefined.
   // If there is some other error, reject with INTERNAL_SERVER_ERROR.
 
-  // Currently accepts validate for legacy reasons. Currently accepts the schema, that may not actually be necessary.
-  deleteObjectsByQuery(className, query, validate, schema) {
+  // Currently accepts the schema, that may not actually be necessary.
+  deleteObjectsByQuery(className, query, schema) {
     return this.adaptiveCollection(className)
     .then(collection => {
       let mongoWhere = transform.transformWhere(className, query, schema);

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -185,7 +185,6 @@ export class MongoStorageAdapter {
   deleteObjectsByQuery(className, query, validate, schema) {
     return this.adaptiveCollection(className)
     .then(collection => {
-      transform.validateQuery(query);
       let mongoWhere = transform.transformWhere(className, query, schema);
       return collection.deleteMany(mongoWhere)
     })

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -185,12 +185,7 @@ export class MongoStorageAdapter {
   deleteObjectsByQuery(className, query, validate, schema) {
     return this.adaptiveCollection(className)
     .then(collection => {
-      if (query.ACL) {
-        throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
-      }
-      if (validate && Object.keys(query).some(restKey => !specialQuerykeys.includes(restKey) && !restKey.match(/^[a-zA-Z][a-zA-Z0-9_\.]*$/))) {
-        throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: ${restKey}`);
-      }
+      transform.validateQuery(query);
       let mongoWhere = transform.transformWhere(className, query, schema);
       return collection.deleteMany(mongoWhere)
     })

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -112,6 +112,7 @@ const transformInteriorValue = restValue => {
   if (typeof restValue === 'object' && Object.keys(restValue).some(key => key.includes('$') || key.includes('.'))) {
     throw new Parse.Error(Parse.Error.INVALID_NESTED_KEY, "Nested keys should not contain the '$' or '.' characters");
   }
+
   // Handle atomic values
   var value = transformInteriorAtom(restValue);
   if (value !== CannotTransform) {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -112,7 +112,6 @@ const transformInteriorValue = restValue => {
   if (typeof restValue === 'object' && Object.keys(restValue).some(key => key.includes('$') || key.includes('.'))) {
     throw new Parse.Error(Parse.Error.INVALID_NESTED_KEY, "Nested keys should not contain the '$' or '.' characters");
   }
-
   // Handle atomic values
   var value = transformInteriorAtom(restValue);
   if (value !== CannotTransform) {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -211,39 +211,9 @@ function transformQueryKeyValue(className, key, value, schema) {
   }
 }
 
-const validateQuery = query => {
-  if (query.ACL) {
-    throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
-  }
-
-  if (query.$or) {
-    if (query.$or instanceof Array) {
-      query.$or.forEach(validateQuery);
-    } else {
-      throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Bad $or format - use an array value.');
-    }
-  }
-
-  if (query.$and) {
-    if (query.$and instanceof Array) {
-      query.$and.forEach(validateQuery);
-    } else {
-      throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Bad $and format - use an array value.');
-    }
-  }
-
-  Object.keys(query).forEach(key => {
-    if (!specialQuerykeys.includes(key) && !key.match(/^[a-zA-Z][a-zA-Z0-9_\.]*$/)) {
-      throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: ${key}`);
-    }
-  });
-}
-
 // Main exposed method to help run queries.
 // restWhere is the "where" clause in REST API form.
 // Returns the mongo form of the query.
-// Throws a Parse.Error if the input query is invalid.
-const specialQuerykeys = ['$and', '$or', '_rperm', '_wperm', '_perishable_token', '_email_verify_token'];
 function transformWhere(className, restWhere, schema) {
   let mongoWhere = {};
   for (let restKey in restWhere) {
@@ -1048,7 +1018,6 @@ var FileCoder = {
 
 module.exports = {
   transformKey,
-  validateQuery,
   parseObjectToMongoObjectForCreate,
   transformUpdate,
   transformWhere,

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -172,6 +172,11 @@ function transformQueryKeyValue(className, key, value, schema) {
     }
     if (value.some(subQuery => subQuery.ACL)) {
       throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
+      Object.keys(subQuery).forEach(restKey => {
+        if (!specialQuerykeys.includes(restKey) && !restKey.match(/^[a-zA-Z][a-zA-Z0-9_\.]*$/)) {
+          throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: ${restKey}`);
+        }
+      });
     }
     return {key: '$or', value: value.map(subQuery => transformWhere(className, subQuery, {}, schema))};
   case '$and':
@@ -180,6 +185,11 @@ function transformQueryKeyValue(className, key, value, schema) {
     }
     if (value.some(subQuery => subQuery.ACL)) {
       throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
+      Object.keys(subQuery).forEach(restKey => {
+        if (!specialQuerykeys.includes(restKey) && !restKey.match(/^[a-zA-Z][a-zA-Z0-9_\.]*$/)) {
+          throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: ${restKey}`);
+        }
+      });
     }
     return {key: '$and', value: value.map(subQuery => transformWhere(className, subQuery, {}, schema))};
   default:

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -170,10 +170,16 @@ function transformQueryKeyValue(className, key, value, schema) {
     if (!(value instanceof Array)) {
       throw new Parse.Error(Parse.Error.INVALID_QUERY, 'bad $or format - use an array value');
     }
+    if (value.some(subQuery => subQuery.ACL)) {
+      throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
+    }
     return {key: '$or', value: value.map(subQuery => transformWhere(className, subQuery, {}, schema))};
   case '$and':
     if (!(value instanceof Array)) {
       throw new Parse.Error(Parse.Error.INVALID_QUERY, 'bad $and format - use an array value');
+    }
+    if (value.some(subQuery => subQuery.ACL)) {
+      throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
     }
     return {key: '$and', value: value.map(subQuery => transformWhere(className, subQuery, {}, schema))};
   default:
@@ -224,9 +230,6 @@ function transformQueryKeyValue(className, key, value, schema) {
 const specialQuerykeys = ['$and', '$or', '_rperm', '_wperm', '_perishable_token', '_email_verify_token'];
 function transformWhere(className, restWhere, { validate = true } = {}, schema) {
   let mongoWhere = {};
-  if (restWhere['ACL']) {
-    throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
-  }
   for (let restKey in restWhere) {
     if (validate && !specialQuerykeys.includes(restKey) && !restKey.match(/^[a-zA-Z][a-zA-Z0-9_\.]*$/)) {
       throw new Parse.Error(Parse.Error.INVALID_KEY_NAME, `Invalid key name: ${restKey}`);

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -184,6 +184,9 @@ DatabaseController.prototype.update = function(className, query, update, {
         throw error;
       })
       .then(parseFormatSchema => {
+        if (query.ACL) {
+          throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
+        }
         var mongoWhere = this.transform.transformWhere(className, query, {validate: !this.skipValidation}, parseFormatSchema);
         mongoUpdate = this.transform.transformUpdate(
           schemaController,
@@ -667,6 +670,9 @@ DatabaseController.prototype.find = function(className, query, {
         }
         if (!isMaster) {
           query = addReadACL(query, aclGroup);
+        }
+        if (query.ACL) {
+          throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
         }
         let mongoWhere = this.transform.transformWhere(className, query, {}, schema);
         if (count) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -368,7 +368,7 @@ DatabaseController.prototype.destroy = function(className, query, { acl } = {}) 
         }
         throw error;
       })
-      .then(parseFormatSchema => this.adapter.deleteObjectsByQuery(className, query, !this.skipValidation, parseFormatSchema))
+      .then(parseFormatSchema => this.adapter.deleteObjectsByQuery(className, query, parseFormatSchema))
       .catch(error => {
         // When deleting sessions while changing passwords, don't throw an error if they don't have any sessions.
         if (className === "_Session" && error.code === Parse.Error.OBJECT_NOT_FOUND) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -184,10 +184,8 @@ DatabaseController.prototype.update = function(className, query, update, {
         throw error;
       })
       .then(parseFormatSchema => {
-        if (query.ACL) {
-          throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
-        }
-        var mongoWhere = this.transform.transformWhere(className, query, {validate: !this.skipValidation}, parseFormatSchema);
+        this.transform.validateQuery(query);
+        var mongoWhere = this.transform.transformWhere(className, query, parseFormatSchema);
         mongoUpdate = this.transform.transformUpdate(
           schemaController,
           className,
@@ -671,10 +669,8 @@ DatabaseController.prototype.find = function(className, query, {
         if (!isMaster) {
           query = addReadACL(query, aclGroup);
         }
-        if (query.ACL) {
-          throw new Parse.Error(Parse.Error.INVALID_QUERY, 'Cannot query on ACL.');
-        }
-        let mongoWhere = this.transform.transformWhere(className, query, {}, schema);
+        this.transform.validateQuery(query);
+        let mongoWhere = this.transform.transformWhere(className, query, schema);
         if (count) {
           delete mongoOptions.limit;
           return collection.count(mongoWhere, mongoOptions);

--- a/src/Routers/GlobalConfigRouter.js
+++ b/src/Routers/GlobalConfigRouter.js
@@ -24,7 +24,7 @@ export class GlobalConfigRouter extends PromiseRouter {
       return acc;
     }, {});
     let database = req.config.database.WithoutValidation();
-    return database.update('_GlobalConfig', {_id: 1}, update, {upsert: true}).then(() => {
+    return database.update('_GlobalConfig', {objectId: 1}, update, {upsert: true}).then(() => {
       return Promise.resolve({ response: { result: true } });
     });
   }


### PR DESCRIPTION
Mongo Adapter shouldn't need to do it's own validation of what a query looks like.