### PR TITLE
Add MongoDB 3.2 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   matrix:
   - MONGODB_VERSION=2.6.11
   - MONGODB_VERSION=3.0.8
+  - MONGODB_VERSION=3.2.6
 branches:
   only:
   - master

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "deep-diff": "^0.3.3",
     "gaze": "^1.0.0",
     "jasmine": "^2.3.2",
-    "mongodb-runner": "git://github.com/TylerBrock/runner.git#old-mongo-storage-fix",
+    "mongodb-runner": "^3.3.2",
     "nodemon": "^1.8.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "deep-diff": "^0.3.3",
     "gaze": "^1.0.0",
     "jasmine": "^2.3.2",
-    "mongodb-runner": "^3.3.1",
+    "mongodb-runner": "git://github.com/TylerBrock/runner.git#old-mongo-storage-fix",
     "nodemon": "^1.8.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -59,13 +59,13 @@
     "deep-diff": "^0.3.3",
     "gaze": "^1.0.0",
     "jasmine": "^2.3.2",
-    "mongodb-runner": "3.2.2",
+    "mongodb-runner": "^3.3.1",
     "nodemon": "^1.8.1"
   },
   "scripts": {
     "dev": "npm run build && node bin/dev",
     "build": "./node_modules/.bin/babel src/ -d lib/",
-    "pretest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.0.8} ./node_modules/.bin/mongodb-runner start",
+    "pretest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 ./node_modules/.bin/mongodb-runner start",
     "test": "cross-env NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node $COVERAGE_OPTION ./node_modules/jasmine/bin/jasmine.js",
     "test:win": "npm run pretest && cross-env NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node ./node_modules/babel-istanbul/lib/cli.js cover -x **/spec/** ./node_modules/jasmine/bin/jasmine.js && npm run posttest",
     "posttest": "./node_modules/.bin/mongodb-runner stop",

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -1,6 +1,6 @@
 // Sets up a Parse API server for testing.
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
 
 var cache = require('../src/cache').default;
 var DatabaseAdapter = require('../src/DatabaseAdapter');

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -1,6 +1,6 @@
 // Sets up a Parse API server for testing.
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 2000;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
 var cache = require('../src/cache').default;
 var DatabaseAdapter = require('../src/DatabaseAdapter');


### PR DESCRIPTION
 - Updated mongodb-runner to support specifying storage engine
 - Specifying mmapv1 explictly because of new 3.2 default