### PR TITLE
Cache users by objectID, and clear cache when updated via master key (fixes #1836)

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -495,7 +495,7 @@ describe('Cloud Code', () => {
 
   it('clears out the user cache for all sessions when the user is changed', done => {
     const cacheAdapter = new InMemoryCacheAdapter({ ttl: 100000000 });
-    setServerConfiguration({ ...defaultConfiguration, cacheAdapter });
+    setServerConfiguration(Object.assign({}, defaultConfiguration, { cacheAdapter: cacheAdapter }));
     Parse.Cloud.define('checkStaleUser', (request, response) => {
       response.success(request.user.get('data'));
     });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -530,9 +530,9 @@ describe('Cloud Code', () => {
             }
           }, (error, response, body) => {
             Parse.Promise.all([cacheAdapter.get('test:user:' + session1), cacheAdapter.get('test:user:' + session2)])
-            .then(([cacheVal1, cacheVal2]) => {
-              expect(cacheVal1.objectId).toEqual(user.id);
-              expect(cacheVal2.objectId).toEqual(user.id);
+            .then(cachedVals => {
+              expect(cachedVals[0].objectId).toEqual(user.id);
+              expect(cachedVals[1].objectId).toEqual(user.id);
 
               //Change with session 1 and then read with session 2.
               user.set('data', 'second data');

--- a/src/Adapters/Cache/InMemoryCache.js
+++ b/src/Adapters/Cache/InMemoryCache.js
@@ -53,7 +53,6 @@ export class InMemoryCache {
     if (record.timeout) {
       clearTimeout(record.timeout);
     }
-
     delete this.cache[key];
   }
 

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -71,7 +71,7 @@ var getAuthForSessionToken = function({ config, sessionToken, installationId } =
       delete obj.password;
       obj['className'] = '_User';
       obj['sessionToken'] = sessionToken;
-      config.cacheController.user.put(sessionToken, obj);
+      config.cacheController.user.put(obj.objectId, obj);
 
       let userObject = Parse.Object.fromJSON(obj);
       return new Auth({config, isMaster: false, installationId, user: userObject});

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -71,7 +71,7 @@ var getAuthForSessionToken = function({ config, sessionToken, installationId } =
       delete obj.password;
       obj['className'] = '_User';
       obj['sessionToken'] = sessionToken;
-      config.cacheController.user.put(obj.objectId, obj);
+      config.cacheController.user.put(sessionToken, obj);
 
       let userObject = Parse.Object.fromJSON(obj);
       return new Auth({config, isMaster: false, installationId, user: userObject});

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -72,7 +72,6 @@ var getAuthForSessionToken = function({ config, sessionToken, installationId } =
       obj['className'] = '_User';
       obj['sessionToken'] = sessionToken;
       config.cacheController.user.put(sessionToken, obj);
-
       let userObject = Parse.Object.fromJSON(obj);
       return new Auth({config, isMaster: false, installationId, user: userObject});
     });

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -319,9 +319,8 @@ RestWrite.prototype.transformUser = function() {
   var promise = Promise.resolve();
 
   // If we're updating a _User object, clear the user cache for the session
-  if (this.query && this.auth.user && this.auth.user.getSessionToken()) {
-    let cacheAdapter = this.config.cacheController;
-    cacheAdapter.user.del(this.auth.user.getSessionToken());
+  if (this.query) {
+    this.config.cacheController.user.del(this.data.objectId);
   }
 
   return promise.then(() => {

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -85,6 +85,7 @@ export class UsersRouter extends ClassesRouter {
         user = results[0];
         return passwordCrypto.compare(req.body.password, user.password);
       }).then((correct) => {
+
         if (!correct) {
           throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Invalid username/password.');
         }

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -27,9 +27,9 @@ function handleParseHeaders(req, res, next) {
     dotNetKey: req.get('X-Parse-Windows-Key'),
     restAPIKey: req.get('X-Parse-REST-API-Key')
   };
-  
+
   var basicAuth = httpAuth(req);
-  
+
   if (basicAuth) {
     info.appId = basicAuth.appId
     info.masterKey = basicAuth.masterKey || info.masterKey;
@@ -156,24 +156,24 @@ function httpAuth(req) {
   if (!(req.req || req).headers.authorization)
     return ;
 
-  var header = (req.req || req).headers.authorization;  
-  var appId, masterKey, javascriptKey;  
+  var header = (req.req || req).headers.authorization;
+  var appId, masterKey, javascriptKey;
 
   // parse header
   var authPrefix = 'basic ';
-  
+
   var match = header.toLowerCase().indexOf(authPrefix);
-  
+
   if (match == 0) {
     var encodedAuth = header.substring(authPrefix.length, header.length);
     var credentials = decodeBase64(encodedAuth).split(':');
-    
+
     if (credentials.length == 2) {
       appId = credentials[0];
       var key = credentials[1];
-    
+
       var jsKeyPrefix = 'javascript-key=';
-    
+
       var matchKey = key.indexOf(jsKeyPrefix)
       if (matchKey == 0) {
         javascriptKey = key.substring(jsKeyPrefix.length, key.length);
@@ -183,7 +183,7 @@ function httpAuth(req) {
       }
     }
   }
-  
+
   return {appId: appId, masterKey: masterKey, javascriptKey: javascriptKey};
 }
 


### PR DESCRIPTION
Previously users were cached by session token, which doesn't work when using master key to update a user, as we don't know the session token, and would have to do an extra query to get it. This caches by objectId so that they user cache can be cleared when the user is updated via master key.