### PR TITLE
Add MongoDB storage engine WiredTiger to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ env:
   - MONGODB_VERSION=2.6.11
   - MONGODB_VERSION=3.0.8
   - MONGODB_VERSION=3.2.6
+  - MONGODB_ENGINE=wiredTiger
+  - MONGODB_ENGINE=mmapv1
+matrix:
+  exclude:
+      - MONGODB_VERSION: 2.6.11
+      - MONGODB_ENGINE: wiredTiger
 branches:
   only:
   - master

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "scripts": {
     "dev": "npm run build && node bin/dev",
     "build": "./node_modules/.bin/babel src/ -d lib/",
-    "pretest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 ./node_modules/.bin/mongodb-runner start",
+    "pretest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=${MONGODB_ENGINE:=mmapv1} ./node_modules/.bin/mongodb-runner start",
     "test": "cross-env NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node $COVERAGE_OPTION ./node_modules/jasmine/bin/jasmine.js",
     "test:win": "npm run pretest && cross-env NODE_ENV=test TESTING=1 ./node_modules/.bin/babel-node ./node_modules/babel-istanbul/lib/cli.js cover -x **/spec/** ./node_modules/jasmine/bin/jasmine.js && npm run posttest",
     "posttest": "./node_modules/.bin/mongodb-runner stop",


### PR DESCRIPTION
Adds the WiredTiger storage engine to the matrix to ensure that parse-server works with WiredTiger on MongoDB 3.0 and 3.2.