### PR TITLE
Change existsSync to exception handler

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -46,8 +46,10 @@ export function configureLogger({logsFolder, level = winston.level}) {
   if (!path.isAbsolute(logsFolder)) {
     logsFolder = path.resolve(process.cwd(), logsFolder);
   }
-  if (!fs.existsSync(logsFolder)) {
+  try {
     fs.mkdirSync(logsFolder);
+  } catch (exception) {
+    // Ignore, assume the folder already exists
   }
   currentLogsFolder = logsFolder;
 


### PR DESCRIPTION
gs.existsSync is deprecated but fs.statSync could give incorrect results if a concurrent process creates the folder. We could check for a specific error case but as there is no error handling currently, e.g. for not having write permission, the intention of this PR is just to fix the bug #1806 

http://stackoverflow.com/questions/28532820/fs-exists-fs-existssync-why-are-they-deprecated