### PR TITLE
Move query logic into mongo

### DIFF
--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -121,10 +121,10 @@ describe('transformWhere', () => {
   });
 });
 
-describe('untransformObject', () => {
+describe('mongoObjectToParseObject', () => {
   it('built-in timestamps', (done) => {
     var input = {createdAt: new Date(), updatedAt: new Date()};
-    var output = transform.untransformObject(dummySchema, null, input);
+    var output = transform.mongoObjectToParseObject(dummySchema, null, input);
     expect(typeof output.createdAt).toEqual('string');
     expect(typeof output.updatedAt).toEqual('string');
     done();
@@ -132,7 +132,7 @@ describe('untransformObject', () => {
 
   it('pointer', (done) => {
     var input = {_p_userPointer: '_User$123'};
-    var output = transform.untransformObject(dummySchema, null, input);
+    var output = transform.mongoObjectToParseObject(dummySchema, null, input);
     expect(typeof output.userPointer).toEqual('object');
     expect(output.userPointer).toEqual(
       {__type: 'Pointer', className: '_User', objectId: '123'}
@@ -142,14 +142,14 @@ describe('untransformObject', () => {
 
   it('null pointer', (done) => {
     var input = {_p_userPointer: null};
-    var output = transform.untransformObject(dummySchema, null, input);
+    var output = transform.mongoObjectToParseObject(dummySchema, null, input);
     expect(output.userPointer).toBeUndefined();
     done();
   });
 
   it('file', (done) => {
     var input = {picture: 'pic.jpg'};
-    var output = transform.untransformObject(dummySchema, null, input);
+    var output = transform.mongoObjectToParseObject(dummySchema, null, input);
     expect(typeof output.picture).toEqual('object');
     expect(output.picture).toEqual({__type: 'File', name: 'pic.jpg'});
     done();
@@ -157,7 +157,7 @@ describe('untransformObject', () => {
 
   it('geopoint', (done) => {
     var input = {location: [180, -180]};
-    var output = transform.untransformObject(dummySchema, null, input);
+    var output = transform.mongoObjectToParseObject(dummySchema, null, input);
     expect(typeof output.location).toEqual('object');
     expect(output.location).toEqual(
       {__type: 'GeoPoint', longitude: 180, latitude: -180}
@@ -167,7 +167,7 @@ describe('untransformObject', () => {
 
   it('nested array', (done) => {
     var input = {arr: [{_testKey: 'testValue' }]};
-    var output = transform.untransformObject(dummySchema, null, input);
+    var output = transform.mongoObjectToParseObject(dummySchema, null, input);
     expect(Array.isArray(output.arr)).toEqual(true);
     expect(output.arr).toEqual([{ _testKey: 'testValue'}]);
     done();
@@ -185,7 +185,7 @@ describe('untransformObject', () => {
       },
       regularKey: "some data",
     }]}
-    let output = transform.untransformObject(dummySchema, null, input);
+    let output = transform.mongoObjectToParseObject(dummySchema, null, input);
     expect(dd(output, input)).toEqual(undefined);
     done();
   });
@@ -253,7 +253,7 @@ describe('transform schema key changes', () => {
       _rperm: ["*"],
       _wperm: ["Kevin"]
     };
-    var output = transform.untransformObject(dummySchema, null, input);
+    var output = transform.mongoObjectToParseObject(dummySchema, null, input);
     expect(typeof output.ACL).toEqual('object');
     expect(output._rperm).toBeUndefined();
     expect(output._wperm).toBeUndefined();
@@ -267,7 +267,7 @@ describe('transform schema key changes', () => {
       long: mongodb.Long.fromNumber(Number.MAX_SAFE_INTEGER),
       double: new mongodb.Double(Number.MAX_VALUE)
     }
-    var output = transform.untransformObject(dummySchema, null, input);
+    var output = transform.mongoObjectToParseObject(dummySchema, null, input);
     expect(output.long).toBe(Number.MAX_SAFE_INTEGER);
     expect(output.double).toBe(Number.MAX_VALUE);
     done();

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1147,4 +1147,27 @@ describe('miscellaneous', function() {
       done();
     });
   });
+
+  it('does not change inner objects if the key has the same name as a geopoint field on the class, and the value is an array of length 2, or if the key has the same name as a file field on the class, and the value is a string', done => {
+    let file = new Parse.File('myfile.txt', { base64: 'eAo=' });
+    file.save()
+    .then(f => {
+      let obj = new Parse.Object('O');
+      obj.set('fileField', f);
+      obj.set('geoField', new Parse.GeoPoint(0, 0));
+      obj.set('innerObj', {
+        fileField: "data",
+        geoField: [1,2],
+      });
+      return obj.save();
+    })
+    .then(object => object.fetch())
+    .then(object => {
+      expect(object.get('innerObj')).toEqual({
+        fileField: "data",
+        geoField: [1,2],
+      });
+      done();
+    });
+  });
 });

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1120,4 +1120,13 @@ describe('miscellaneous', function() {
       done();
     })
   });
+
+  it('does not change inner object keys names _auth_data_something', done => {
+    new Parse.Object('O').save({ innerObj: {_auth_data_facebook: 7}})
+    .then(object => new Parse.Query('O').get(object.id))
+    .then(object => {
+      expect(object.get('innerObj')).toEqual({_auth_data_facebook: 7});
+      done();
+    });
+  });
 });

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1138,4 +1138,13 @@ describe('miscellaneous', function() {
       done();
     });
   });
+
+  it('does not change inner object key names _rperm, _wperm', done => {
+    new Parse.Object('O').save({ innerObj: {_rperm: 7, _wperm: 8}})
+    .then(object => new Parse.Query('O').get(object.id))
+    .then(object => {
+      expect(object.get('innerObj')).toEqual({_rperm: 7, _wperm: 8});
+      done();
+    });
+  });
 });

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1121,11 +1121,20 @@ describe('miscellaneous', function() {
     })
   });
 
-  it('does not change inner object keys names _auth_data_something', done => {
+  it('does not change inner object key names _auth_data_something', done => {
     new Parse.Object('O').save({ innerObj: {_auth_data_facebook: 7}})
     .then(object => new Parse.Query('O').get(object.id))
     .then(object => {
       expect(object.get('innerObj')).toEqual({_auth_data_facebook: 7});
+      done();
+    });
+  });
+
+  it('does not change inner object key names _p_somethign', done => {
+    new Parse.Object('O').save({ innerObj: {_p_data: 7}})
+    .then(object => new Parse.Query('O').get(object.id))
+    .then(object => {
+      expect(object.get('innerObj')).toEqual({_p_data: 7});
       done();
     });
   });

--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -1,5 +1,6 @@
 let mongodb = require('mongodb');
 let Collection = mongodb.Collection;
+import * as transform from './MongoTransform';
 
 export default class MongoCollection {
   _mongoCollection:Collection;
@@ -13,25 +14,28 @@ export default class MongoCollection {
   // none, then build the geoindex.
   // This could be improved a lot but it's not clear if that's a good
   // idea. Or even if this behavior is a good idea.
+
+  // Depends on the className and schemaController because mongoObjectToParseObject does.
+  // TODO: break this dependency
   find(query, { skip, limit, sort } = {}) {
     return this._rawFind(query, { skip, limit, sort })
-      .catch(error => {
-        // Check for "no geoindex" error
-        if (error.code != 17007 && !error.message.match(/unable to find index for .geoNear/)) {
-          throw error;
-        }
-        // Figure out what key needs an index
-        let key = error.message.match(/field=([A-Za-z_0-9]+) /)[1];
-        if (!key) {
-          throw error;
-        }
+    .catch(error => {
+      // Check for "no geoindex" error
+      if (error.code != 17007 && !error.message.match(/unable to find index for .geoNear/)) {
+        throw error;
+      }
+      // Figure out what key needs an index
+      let key = error.message.match(/field=([A-Za-z_0-9]+) /)[1];
+      if (!key) {
+        throw error;
+      }
 
-        var index = {};
-        index[key] = '2d';
-        return this._mongoCollection.createIndex(index)
-          // Retry, but just once.
-          .then(() => this._rawFind(query, { skip, limit, sort }));
-      });
+      var index = {};
+      index[key] = '2d';
+      return this._mongoCollection.createIndex(index)
+      // Retry, but just once.
+      .then(() => this._rawFind(query, { skip, limit, sort }));
+    })
   }
 
   _rawFind(query, { skip, limit, sort } = {}) {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -197,6 +197,14 @@ export class MongoStorageAdapter {
     });
   }
 
+  // Executes a find. Accepts: className, query in Parse format, and { skip, limit, sort }.
+  // Accepts the schemaController for legacy reasons.
+  find(className, query, { skip, limit, sort }, schemaController) {
+    return this.adaptiveCollection(className)
+    .then(collection => collection.find(query, { skip, limit, sort }))
+    .then(objects => objects.map(object => transform.mongoObjectToParseObject(schemaController, className, object)));
+  }
+
   get transform() {
     return transform;
   }

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -747,21 +747,7 @@ const nestedMongoObjectToNestedParseObject = (schema, className, mongoObject) =>
       return BytesCoder.databaseToJSON(mongoObject);
     }
 
-    var restObject = {};
-    for (var key in mongoObject) {
-      var expectedType = schema.getExpectedType(className, key);
-      var value = mongoObject[key];
-      if (expectedType && expectedType.type === 'File' && FileCoder.isValidDatabaseObject(value)) {
-        restObject[key] = FileCoder.databaseToJSON(value);
-        break;
-      }
-      if (expectedType && expectedType.type === 'GeoPoint' && GeoPointCoder.isValidDatabaseObject(value)) {
-        restObject[key] = GeoPointCoder.databaseToJSON(value);
-        break;
-      }
-      restObject[key] = nestedMongoObjectToNestedParseObject(schema, className, mongoObject[key]);
-    }
-    return restObject;
+    return _.mapValues(mongoObject, value => nestedMongoObjectToNestedParseObject(schema, className, value));
   default:
     throw 'unknown js type';
   }

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -747,7 +747,7 @@ const nestedMongoObjectToNestedParseObject = (schema, className, mongoObject) =>
       return BytesCoder.databaseToJSON(mongoObject);
     }
 
-    var restObject = untransformACL(mongoObject);
+    var restObject = {};
     for (var key in mongoObject) {
       var expectedType = schema.getExpectedType(className, key);
       var value = mongoObject[key];

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -713,22 +713,6 @@ function transformUpdateOperator({
   }
 }
 
-const specialKeysForUntransform = [
-  '_id',
-  '_hashed_password',
-  '_acl',
-  '_email_verify_token',
-  '_perishable_token',
-  '_tombstone',
-  '_session_token',
-  'updatedAt',
-  '_updated_at',
-  'createdAt',
-  '_created_at',
-  'expiresAt',
-  '_expiresAt',
-];
-
 const nestedMongoObjectToNestedParseObject = (schema, className, mongoObject) => {
   switch(typeof mongoObject) {
   case 'string':
@@ -744,9 +728,7 @@ const nestedMongoObjectToNestedParseObject = (schema, className, mongoObject) =>
       return null;
     }
     if (mongoObject instanceof Array) {
-      return mongoObject.map(arrayEntry => {
-        return nestedMongoObjectToNestedParseObject(schema, className, arrayEntry);
-      });
+      return mongoObject.map(arrayEntry => nestedMongoObjectToNestedParseObject(schema, className, arrayEntry));
     }
 
     if (mongoObject instanceof Date) {
@@ -767,91 +749,58 @@ const nestedMongoObjectToNestedParseObject = (schema, className, mongoObject) =>
 
     var restObject = untransformACL(mongoObject);
     for (var key in mongoObject) {
-      if (_.includes(specialKeysForUntransform, key)) {
-        restObject[key] = nestedMongoObjectToNestedParseObject(schema, className, mongoObject[key]);
-        continue;
+      // Check auth data keys
+      var authDataMatch = key.match(/^_auth_data_([a-zA-Z0-9_]+)$/);
+      if (authDataMatch) {
+        var provider = authDataMatch[1];
+        restObject['authData'] = restObject['authData'] || {};
+        restObject['authData'][provider] = mongoObject[key];
+        break;
       }
-      switch(key) {
-      case '_id':
-        restObject['objectId'] = '' + mongoObject[key];
-        break;
-      case '_hashed_password':
-        restObject['password'] = mongoObject[key];
-        break;
-      case '_acl':
-      case '_email_verify_token':
-      case '_perishable_token':
-      case '_tombstone':
-        break;
-      case '_session_token':
-        restObject['sessionToken'] = mongoObject[key];
-        break;
-      case 'updatedAt':
-      case '_updated_at':
-        restObject['updatedAt'] = Parse._encode(new Date(mongoObject[key])).iso;
-        break;
-      case 'createdAt':
-      case '_created_at':
-        restObject['createdAt'] = Parse._encode(new Date(mongoObject[key])).iso;
-        break;
-      case 'expiresAt':
-      case '_expiresAt':
-        restObject['expiresAt'] = Parse._encode(new Date(mongoObject[key]));
-        break;
-      default:
-        // Check other auth data keys
-        var authDataMatch = key.match(/^_auth_data_([a-zA-Z0-9_]+)$/);
-        if (authDataMatch) {
-          var provider = authDataMatch[1];
-          restObject['authData'] = restObject['authData'] || {};
-          restObject['authData'][provider] = mongoObject[key];
-          break;
-        }
 
-        if (key.indexOf('_p_') == 0) {
-          var newKey = key.substring(3);
-          var expected;
-          if (schema && schema.getExpectedType) {
-            expected = schema.getExpectedType(className, newKey);
-          }
-          if (!expected) {
-            log.info('transform.js',
-              'Found a pointer column not in the schema, dropping it.',
-              className, newKey);
-            break;
-          }
-          if (expected && expected.type !== 'Pointer') {
-            log.info('transform.js', 'Found a pointer in a non-pointer column, dropping it.', className, key);
-            break;
-          }
-          if (mongoObject[key] === null) {
-            break;
-          }
-          var objData = mongoObject[key].split('$');
-          var newClass = (expected ? expected.targetClass : objData[0]);
-          if (objData[0] !== newClass) {
-            throw 'pointer to incorrect className';
-          }
-          restObject[newKey] = {
-            __type: 'Pointer',
-            className: objData[0],
-            objectId: objData[1]
-          };
-          break;
-        } else {
-          var expectedType = schema.getExpectedType(className, key);
-          var value = mongoObject[key];
-          if (expectedType && expectedType.type === 'File' && FileCoder.isValidDatabaseObject(value)) {
-            restObject[key] = FileCoder.databaseToJSON(value);
-            break;
-          }
-          if (expectedType && expectedType.type === 'GeoPoint' && GeoPointCoder.isValidDatabaseObject(value)) {
-            restObject[key] = GeoPointCoder.databaseToJSON(value);
-            break;
-          }
+      if (key.indexOf('_p_') == 0) {
+        var newKey = key.substring(3);
+        var expected;
+        if (schema && schema.getExpectedType) {
+          expected = schema.getExpectedType(className, newKey);
         }
-        restObject[key] = nestedMongoObjectToNestedParseObject(schema, className, mongoObject[key]);
+        if (!expected) {
+          log.info('transform.js',
+            'Found a pointer column not in the schema, dropping it.',
+            className, newKey);
+          break;
+        }
+        if (expected && expected.type !== 'Pointer') {
+          log.info('transform.js', 'Found a pointer in a non-pointer column, dropping it.', className, key);
+          break;
+        }
+        if (mongoObject[key] === null) {
+          break;
+        }
+        var objData = mongoObject[key].split('$');
+        var newClass = (expected ? expected.targetClass : objData[0]);
+        if (objData[0] !== newClass) {
+          throw 'pointer to incorrect className';
+        }
+        restObject[newKey] = {
+          __type: 'Pointer',
+          className: objData[0],
+          objectId: objData[1]
+        };
+        break;
+      } else {
+        var expectedType = schema.getExpectedType(className, key);
+        var value = mongoObject[key];
+        if (expectedType && expectedType.type === 'File' && FileCoder.isValidDatabaseObject(value)) {
+          restObject[key] = FileCoder.databaseToJSON(value);
+          break;
+        }
+        if (expectedType && expectedType.type === 'GeoPoint' && GeoPointCoder.isValidDatabaseObject(value)) {
+          restObject[key] = GeoPointCoder.databaseToJSON(value);
+          break;
+        }
       }
+      restObject[key] = nestedMongoObjectToNestedParseObject(schema, className, mongoObject[key]);
     }
     return restObject;
   default:

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -731,7 +731,7 @@ const specialKeysForUntransform = [
 
 // Converts from a mongo-format object to a REST-format object.
 // Does not strip out anything based on a lack of authentication.
-function untransformObject(schema, className, mongoObject, isNestedObject = false) {
+function mongoObjectToParseObject(schema, className, mongoObject, isNestedObject = false) {
   switch(typeof mongoObject) {
   case 'string':
   case 'number':
@@ -740,14 +740,14 @@ function untransformObject(schema, className, mongoObject, isNestedObject = fals
   case 'undefined':
   case 'symbol':
   case 'function':
-    throw 'bad value in untransformObject';
+    throw 'bad value in mongoObjectToParseObject';
   case 'object':
     if (mongoObject === null) {
       return null;
     }
     if (mongoObject instanceof Array) {
       return mongoObject.map(arrayEntry => {
-        return untransformObject(schema, className, arrayEntry, true);
+        return mongoObjectToParseObject(schema, className, arrayEntry, true);
       });
     }
 
@@ -770,7 +770,7 @@ function untransformObject(schema, className, mongoObject, isNestedObject = fals
     var restObject = untransformACL(mongoObject);
     for (var key in mongoObject) {
       if (isNestedObject && _.includes(specialKeysForUntransform, key)) {
-        restObject[key] = untransformObject(schema, className, mongoObject[key], true);
+        restObject[key] = mongoObjectToParseObject(schema, className, mongoObject[key], true);
         continue;
       }
       switch(key) {
@@ -854,7 +854,7 @@ function untransformObject(schema, className, mongoObject, isNestedObject = fals
             break;
           }
         }
-        restObject[key] = untransformObject(schema, className, mongoObject[key], true);
+        restObject[key] = mongoObjectToParseObject(schema, className, mongoObject[key], true);
       }
     }
 
@@ -961,5 +961,5 @@ module.exports = {
   parseObjectToMongoObjectForCreate,
   transformUpdate,
   transformWhere,
-  untransformObject
+  mongoObjectToParseObject,
 };

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -713,7 +713,7 @@ function transformUpdateOperator({
   }
 }
 
-const nestedMongoObjectToNestedParseObject = (schema, className, mongoObject) => {
+const nestedMongoObjectToNestedParseObject = mongoObject => {
   switch(typeof mongoObject) {
   case 'string':
   case 'number':
@@ -728,7 +728,7 @@ const nestedMongoObjectToNestedParseObject = (schema, className, mongoObject) =>
       return null;
     }
     if (mongoObject instanceof Array) {
-      return mongoObject.map(arrayEntry => nestedMongoObjectToNestedParseObject(schema, className, arrayEntry));
+      return mongoObject.map(nestedMongoObjectToNestedParseObject);
     }
 
     if (mongoObject instanceof Date) {
@@ -747,7 +747,7 @@ const nestedMongoObjectToNestedParseObject = (schema, className, mongoObject) =>
       return BytesCoder.databaseToJSON(mongoObject);
     }
 
-    return _.mapValues(mongoObject, value => nestedMongoObjectToNestedParseObject(schema, className, value));
+    return _.mapValues(mongoObject, nestedMongoObjectToNestedParseObject);
   default:
     throw 'unknown js type';
   }
@@ -770,9 +770,7 @@ const mongoObjectToParseObject = (schema, className, mongoObject) => {
       return null;
     }
     if (mongoObject instanceof Array) {
-      return mongoObject.map(arrayEntry => {
-        return nestedMongoObjectToNestedParseObject(schema, className, arrayEntry);
-      });
+      return mongoObject.map(nestedMongoObjectToNestedParseObject);
     }
 
     if (mongoObject instanceof Date) {
@@ -874,7 +872,7 @@ const mongoObjectToParseObject = (schema, className, mongoObject) => {
             break;
           }
         }
-        restObject[key] = nestedMongoObjectToNestedParseObject(schema, className, mongoObject[key]);
+        restObject[key] = nestedMongoObjectToNestedParseObject(mongoObject[key]);
       }
     }
 

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -749,15 +749,6 @@ const nestedMongoObjectToNestedParseObject = (schema, className, mongoObject) =>
 
     var restObject = untransformACL(mongoObject);
     for (var key in mongoObject) {
-      // Check auth data keys
-      var authDataMatch = key.match(/^_auth_data_([a-zA-Z0-9_]+)$/);
-      if (authDataMatch) {
-        var provider = authDataMatch[1];
-        restObject['authData'] = restObject['authData'] || {};
-        restObject['authData'][provider] = mongoObject[key];
-        break;
-      }
-
       if (key.indexOf('_p_') == 0) {
         var newKey = key.substring(3);
         var expected;

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -868,66 +868,6 @@ function untransformObject(schema, className, mongoObject, isNestedObject = fals
   }
 }
 
-function transformSelect(selectObject, key ,objects) {
-  var values = [];
-  for (var result of objects) {
-    values.push(result[key]);
-  }
-  delete selectObject['$select'];
-  if (Array.isArray(selectObject['$in'])) {
-    selectObject['$in'] = selectObject['$in'].concat(values);
-  } else {
-    selectObject['$in'] = values;
-  }
-}
-
-function transformDontSelect(dontSelectObject, key, objects) {
-  var values = [];
-  for (var result of objects) {
-    values.push(result[key]);
-  }
-  delete dontSelectObject['$dontSelect'];
-  if (Array.isArray(dontSelectObject['$nin'])) {
-    dontSelectObject['$nin'] = dontSelectObject['$nin'].concat(values);
-  } else {
-    dontSelectObject['$nin'] = values;
-  }
-}
-
-function transformInQuery(inQueryObject, className, results) {
-  var values = [];
-  for (var result of results) {
-    values.push({
-      __type: 'Pointer',
-      className: className,
-      objectId: result.objectId
-    });
-  }
-  delete inQueryObject['$inQuery'];
-  if (Array.isArray(inQueryObject['$in'])) {
-    inQueryObject['$in'] = inQueryObject['$in'].concat(values);
-  } else {
-    inQueryObject['$in'] = values;
-  }
-}
-
-function transformNotInQuery(notInQueryObject, className, results) {
-  var values = [];
-  for (var result of results) {
-    values.push({
-      __type: 'Pointer',
-      className: className,
-      objectId: result.objectId
-    });
-  }
-  delete notInQueryObject['$notInQuery'];
-  if (Array.isArray(notInQueryObject['$nin'])) {
-    notInQueryObject['$nin'] = notInQueryObject['$nin'].concat(values);
-  } else {
-    notInQueryObject['$nin'] = values;
-  }
-}
-
 var DateCoder = {
   JSONToDatabase(json) {
     return new Date(json.iso);
@@ -1021,9 +961,5 @@ module.exports = {
   parseObjectToMongoObjectForCreate,
   transformUpdate,
   transformWhere,
-  transformSelect,
-  transformDontSelect,
-  transformInQuery,
-  transformNotInQuery,
   untransformObject
 };

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -701,11 +701,8 @@ DatabaseController.prototype.find = function(className, query, {
           delete mongoOptions.limit;
           return collection.count(mongoWhere, mongoOptions);
         } else {
-          return collection.find(mongoWhere, mongoOptions)
-          .then(mongoResults => mongoResults.map(mongoObject => {
-            var parseObject = this.transform.untransformObject(schemaController, className, mongoObject);
-            return filterSensitiveData(isMaster, aclGroup, className, parseObject);
-          }));
+          return this.adapter.find(className, mongoWhere, mongoOptions, schemaController)
+          .then(objects => objects.map(object => filterSensitiveData(isMaster, aclGroup, className, object)));
         }
       });
     });

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -188,6 +188,23 @@ RestQuery.prototype.validateClientClassCreation = function() {
   }
 };
 
+function transformInQuery(inQueryObject, className, results) {
+  var values = [];
+  for (var result of results) {
+    values.push({
+      __type: 'Pointer',
+      className: className,
+      objectId: result.objectId
+    });
+  }
+  delete inQueryObject['$inQuery'];
+  if (Array.isArray(inQueryObject['$in'])) {
+    inQueryObject['$in'] = inQueryObject['$in'].concat(values);
+  } else {
+    inQueryObject['$in'] = values;
+  }
+}
+
 // Replaces a $inQuery clause by running the subquery, if there is an
 // $inQuery clause.
 // The $inQuery clause turns into an $in with values that are just
@@ -213,11 +230,28 @@ RestQuery.prototype.replaceInQuery = function() {
     this.config, this.auth, inQueryValue.className,
     inQueryValue.where, additionalOptions);
   return subquery.execute().then((response) => {
-    this.config.database.transform.transformInQuery(inQueryObject, subquery.className, response.results);
+    transformInQuery(inQueryObject, subquery.className, response.results);
     // Recurse to repeat
     return this.replaceInQuery();
   });
 };
+
+function transformNotInQuery(notInQueryObject, className, results) {
+  var values = [];
+  for (var result of results) {
+    values.push({
+      __type: 'Pointer',
+      className: className,
+      objectId: result.objectId
+    });
+  }
+  delete notInQueryObject['$notInQuery'];
+  if (Array.isArray(notInQueryObject['$nin'])) {
+    notInQueryObject['$nin'] = notInQueryObject['$nin'].concat(values);
+  } else {
+    notInQueryObject['$nin'] = values;
+  }
+}
 
 // Replaces a $notInQuery clause by running the subquery, if there is an
 // $notInQuery clause.
@@ -244,11 +278,24 @@ RestQuery.prototype.replaceNotInQuery = function() {
     this.config, this.auth, notInQueryValue.className,
     notInQueryValue.where, additionalOptions);
   return subquery.execute().then((response) => {
-    this.config.database.transform.transformNotInQuery(notInQueryObject, subquery.className, response.results);
+    transformNotInQuery(notInQueryObject, subquery.className, response.results);
     // Recurse to repeat
     return this.replaceNotInQuery();
   });
 };
+
+const transformSelect = (selectObject, key ,objects) => {
+  var values = [];
+  for (var result of objects) {
+    values.push(result[key]);
+  }
+  delete selectObject['$select'];
+  if (Array.isArray(selectObject['$in'])) {
+    selectObject['$in'] = selectObject['$in'].concat(values);
+  } else {
+    selectObject['$in'] = values;
+  }
+}
 
 // Replaces a $select clause by running the subquery, if there is a
 // $select clause.
@@ -281,11 +328,24 @@ RestQuery.prototype.replaceSelect = function() {
     this.config, this.auth, selectValue.query.className,
     selectValue.query.where, additionalOptions);
   return subquery.execute().then((response) => {
-    this.config.database.transform.transformSelect(selectObject, selectValue.key, response.results);
+    transformSelect(selectObject, selectValue.key, response.results);
     // Keep replacing $select clauses
     return this.replaceSelect();
   })
 };
+
+const transformDontSelect = (dontSelectObject, key, objects) => {
+  var values = [];
+  for (var result of objects) {
+    values.push(result[key]);
+  }
+  delete dontSelectObject['$dontSelect'];
+  if (Array.isArray(dontSelectObject['$nin'])) {
+    dontSelectObject['$nin'] = dontSelectObject['$nin'].concat(values);
+  } else {
+    dontSelectObject['$nin'] = values;
+  }
+}
 
 // Replaces a $dontSelect clause by running the subquery, if there is a
 // $dontSelect clause.
@@ -316,7 +376,7 @@ RestQuery.prototype.replaceDontSelect = function() {
     this.config, this.auth, dontSelectValue.query.className,
     dontSelectValue.query.where, additionalOptions);
   return subquery.execute().then((response) => {
-    this.config.database.transform.transformDontSelect(dontSelectObject, dontSelectValue.key, response.results);
+    transformDontSelect(dontSelectObject, dontSelectValue.key, response.results);
     // Keep replacing $dontSelect clauses
     return this.replaceDontSelect();
   })


### PR DESCRIPTION
- Move some query related logic that uses mongo format into the mongo adapter.

- Move some Parse Server related logic out of MongoTransform and into Parse Server

- Fix a bunch of bugs involving untransforming Parse Objects by splitting untransformation of nested objects into it's own function.