### PR TITLE
Changed deprecated res.send(status) to res.sendStatus(status)

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -198,7 +198,7 @@ var allowCrossDomain = function(req, res, next) {
 
   // intercept OPTIONS method
   if ('OPTIONS' == req.method) {
-    res.send(200);
+    res.sendStatus(200);
   }
   else {
     next();


### PR DESCRIPTION
foreverJs was logging this

    express deprecated res.send(status): Use res.sendStatus(status) instead at node_modules/parse-server/lib/middlewares.js:156:9