### PR TITLE
Add webhookKey support

### DIFF
--- a/spec/ParseHooks.spec.js
+++ b/spec/ParseHooks.spec.js
@@ -17,7 +17,7 @@ app.listen(12345);
 
 describe('Hooks', () => {
 
-   it("should have some hooks registered", (done) => {
+   it("should have no hooks registered", (done) => {
      Parse.Hooks.getFunctions().then((res) => {
        expect(res.constructor).toBe(Array.prototype.constructor);
        done();
@@ -27,7 +27,7 @@ describe('Hooks', () => {
      });
    });
 
-   it("should have some triggers registered", (done) => {
+   it("should have no triggers registered", (done) => {
      Parse.Hooks.getTriggers().then( (res) => {
        expect(res.constructor).toBe(Array.prototype.constructor);
        done();
@@ -291,7 +291,7 @@ describe('Hooks', () => {
        console.error(err);
        fail("Should not fail calling a function");
        done();
-     })
+     });
    });
 
    it("should run the function on the test server", (done) => {
@@ -299,7 +299,7 @@ describe('Hooks', () => {
      app.post("/SomeFunctionError", function(req, res) {
         res.json({error: {code: 1337, error: "hacking that one!"}});
      });
-     // The function is delete as the DB is dropped between calls
+     // The function is deleted as the DB is dropped between calls
      Parse.Hooks.createFunction("SOME_TEST_FUNCTION", hookServerURL+"/SomeFunctionError").then(function(){
        return Parse.Cloud.run("SOME_TEST_FUNCTION")
      }, (err) => {
@@ -313,6 +313,57 @@ describe('Hooks', () => {
        expect(err.code).toBe(141);
        expect(err.message.code).toEqual(1337)
        expect(err.message.error).toEqual("hacking that one!");
+       done();
+     });
+   });
+
+   it("should provide X-Parse-Webhook-Key when defined", (done) => {
+     app.post("/ExpectingKey", function(req, res) {
+       if (req.get('X-Parse-Webhook-Key') === 'hook') {
+         res.json({success: "correct key provided"});
+       } else {
+         res.json({error: "incorrect key provided"});
+       }
+     });
+
+     Parse.Hooks.createFunction("SOME_TEST_FUNCTION", hookServerURL+"/ExpectingKey").then(function(){
+       return Parse.Cloud.run("SOME_TEST_FUNCTION")
+     }, (err) => {
+       console.error(err);
+       fail("Should not fail creating a function");
+       done();
+     }).then(function(res){
+       expect(res).toBe("correct key provided");
+       done();
+     }, (err) => {
+       console.error(err);
+       fail("Should not fail calling a function");
+       done();
+     });
+   });
+
+   it("should not pass X-Parse-Webhook-Key if not provided", (done) => {
+     setServerConfiguration(Object.assign({}, defaultConfiguration, { webhookKey: undefined }));
+     app.post("/ExpectingKeyAlso", function(req, res) {
+       if (req.get('X-Parse-Webhook-Key') === 'hook') {
+         res.json({success: "correct key provided"});
+       } else {
+         res.json({error: "incorrect key provided"});
+       }
+     });
+
+     Parse.Hooks.createFunction("SOME_TEST_FUNCTION", hookServerURL+"/ExpectingKeyAlso").then(function(){
+       return Parse.Cloud.run("SOME_TEST_FUNCTION")
+     }, (err) => {
+       console.error(err);
+       fail("Should not fail creating a function");
+       done();
+     }).then(function(res){
+       fail("Should not succeed calling that function");
+       done();
+     }, (err) => {
+       expect(err.code).toBe(141);
+       expect(err.message).toEqual("incorrect key provided");
        done();
      });
    });

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -23,6 +23,7 @@ var defaultConfiguration = {
   dotNetKey: 'windows',
   clientKey: 'client',
   restAPIKey: 'rest',
+  webhookKey: 'hook',
   masterKey: 'test',
   collectionPrefix: 'test_',
   fileKey: 'test',

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -98,6 +98,7 @@ class ParseServer {
     javascriptKey,
     dotNetKey,
     restAPIKey,
+    webhookKey,
     fileKey = 'invalid-file-key',
     facebookAppIds = [],
     enableAnonymousUsers = true,
@@ -166,7 +167,7 @@ class ParseServer {
     const filesController = new FilesController(filesControllerAdapter, appId);
     const pushController = new PushController(pushControllerAdapter, appId);
     const loggerController = new LoggerController(loggerControllerAdapter, appId);
-    const hooksController = new HooksController(appId, collectionPrefix);
+    const hooksController = new HooksController(appId, collectionPrefix, webhookKey);
     const userController = new UserController(emailControllerAdapter, appId, { verifyUserEmails });
     const liveQueryController = new LiveQueryController(liveQuery);
     const cacheController = new CacheController(cacheControllerAdapter, appId);
@@ -179,6 +180,7 @@ class ParseServer {
       javascriptKey: javascriptKey,
       dotNetKey: dotNetKey,
       restAPIKey: restAPIKey,
+      webhookKey: webhookKey,
       fileKey: fileKey,
       facebookAppIds: facebookAppIds,
       cacheController: cacheController,


### PR DESCRIPTION
Noticed that web hooks invoked from parse-server do not provide webhook key. Implemented this after discussing with @flovilmart 