### PR TITLE
Set push.storedPushData in serverInfo features if push is available

### DIFF
--- a/src/Routers/FeaturesRouter.js
+++ b/src/Routers/FeaturesRouter.js
@@ -28,7 +28,7 @@ export class FeaturesRouter extends PromiseRouter {
         push: {
           immediatePush: req.config.pushController.pushIsAvailable,
           scheduledPush: false,
-          storedPushData: false,
+          storedPushData: req.config.pushController.pushIsAvailable,
           pushAudiences: false,
         },
         schemas: {


### PR DESCRIPTION
It's assumed that when push is available, the pushHandler is used and data is saved in `_PushStatus` class.
This allows Parse Dashboard push history to be enabled: ParsePlatform/parse-dashboard#378