### PR TITLE
Strip objectId out of responses from HooksController

### DIFF
--- a/spec/ParseHooks.spec.js
+++ b/spec/ParseHooks.spec.js
@@ -46,10 +46,12 @@ describe('Hooks', () => {
       // Find
       return Parse.Hooks.getFunction("My-Test-Function")
     }).then(response => {
+      expect(response.objectId).toBeUndefined();
       expect(response.url).toBe("http://someurl");
       return Parse.Hooks.updateFunction("My-Test-Function", "http://anotherurl");
     })
     .then((res) => {
+      expect(res.objectId).toBeUndefined();
       expect(res.functionName).toBe("My-Test-Function");
       expect(res.url).toBe("http://anotherurl")
       // delete
@@ -90,6 +92,7 @@ describe('Hooks', () => {
      }).then((res) => {
        expect(res).not.toBe(null);
        expect(res).not.toBe(undefined);
+       expect(res.objectId).toBeUndefined();
        expect(res.url).toBe("http://someurl");
        // delete
         return Parse.Hooks.updateTrigger("MyClass","beforeDelete", "http://anotherurl");
@@ -99,6 +102,7 @@ describe('Hooks', () => {
      }).then((res) => {
        expect(res.className).toBe("MyClass");
        expect(res.url).toBe("http://anotherurl")
+       expect(res.objectId).toBeUndefined();
 
        return Parse.Hooks.deleteTrigger("MyClass","beforeDelete");
      }, (err) => {

--- a/src/Controllers/HooksController.js
+++ b/src/Controllers/HooksController.js
@@ -57,7 +57,12 @@ export class HooksController {
 
   _getHooks(query = {}, limit) {
     let options = limit ? { limit: limit } : undefined;
-    return this.database.find(DefaultHooksCollectionName, query);
+    return this.database.find(DefaultHooksCollectionName, query).then((results) => {
+      return results.map((result) => {
+        delete result.objectId;
+        return result;
+      });
+    });
   }
 
   _removeHooks(query) {


### PR DESCRIPTION
Saw this during testing today:

Results from api.parse.com query to /hooks/triggers:
```js
{
  "results": [
    {
      "triggerName": "beforeSave",
      "className": "blah",
      "url": "https://xxx"
    }
  ]
}
```

Results from parse-server query to /hook/triggers:
```js
{
  "results": [
    {
      "objectId": "57464f6830ba6971a3025cbc",
      "triggerName": "beforeSave",
      "className": "blah",
      "url": "xxx"
    }
  ]
}
```

Approach seems ok-ish...