### PR TITLE
Fix expected webhook external response format

### DIFF
--- a/spec/ParseHooks.spec.js
+++ b/spec/ParseHooks.spec.js
@@ -381,7 +381,7 @@ describe('Hooks', () => {
        object.hello = "world";
        // Would need parse cloud express to set much more
        // But this should override the key upon return
-        res.json({success: {object: object}});
+       res.json({success: object});
      });
      // The function is delete as the DB is dropped between calls
      Parse.Hooks.createTrigger("SomeRandomObject", "beforeSave" ,hookServerURL+"/BeforeSaveSome").then(function(){

--- a/src/Controllers/HooksController.js
+++ b/src/Controllers/HooksController.js
@@ -190,7 +190,7 @@ function wrapToHTTPRequest(hook, key) {
     request.post(hook.url, jsonRequest, function (err, httpResponse, body) {
       var result;
       if (body) {
-        if (typeof body == "string") {
+        if (typeof body === "string") {
           try {
             body = JSON.parse(body);
           } catch (e) {
@@ -204,6 +204,8 @@ function wrapToHTTPRequest(hook, key) {
       }
       if (err) {
         return res.error(err);
+      } else if (hook.triggerName === 'beforeSave') {
+        return res.success({object: result});
       } else {
         return res.success(result);
       }


### PR DESCRIPTION
The actual contract between parse-server and external webhooks specifies that the response to a beforeSave return the object directly instead of wrapped in an object under a key named "object" (like it does in cloud code)