### PR TITLE
Fixing #1900 JS SDK file upload

### DIFF
--- a/spec/Middlewares.spec.js
+++ b/spec/Middlewares.spec.js
@@ -1,5 +1,5 @@
-import * as middlewares from "../src/middlewares";
-import {AppCache} from '../src/cache';
+var middlewares = require('../src/middlewares');
+var AppCache = require('../src/cache').AppCache;
 
 describe('middlewares', () => {
 
@@ -14,7 +14,7 @@ describe('middlewares', () => {
             },
             headers: {},
             get: (key) => {
-                return fakeReq.headers[key]
+                return fakeReq.headers[key.toLowerCase()]
             }
         };
         AppCache.clear();

--- a/spec/Middlewares.spec.js
+++ b/spec/Middlewares.spec.js
@@ -17,8 +17,11 @@ describe('middlewares', () => {
                 return fakeReq.headers[key.toLowerCase()]
             }
         };
-        AppCache.clear();
         AppCache.put(fakeReq.body._ApplicationId, {});
+    });
+
+    afterEach(() => {
+        AppCache.del(fakeReq.body._ApplicationId);
     });
 
     it('should use _ContentType if provided', (done) => {

--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -36,6 +36,31 @@ describe('Parse.File testing', () => {
       });
     });
 
+
+    it('works with _ContentType', done => {
+
+      request.post({
+        url: 'http://localhost:8378/1/files/file',
+        body: JSON.stringify({
+          _ApplicationId: 'test',
+          _JavaScriptKey: 'test',
+          _ContentType: 'text/html',
+          base64: 'PGh0bWw+PC9odG1sPgo='
+        })
+      }, (error, response, body) => {
+        expect(error).toBe(null);
+        var b = JSON.parse(body);
+        expect(b.name).toMatch(/_file.html/);
+        expect(b.url).toMatch(/^http:\/\/localhost:8378\/1\/files\/test\/.*file.html$/);
+        request.get(b.url, (error, response, body) => {
+          expect(response.headers['content-type']).toMatch('^text/html');
+          expect(error).toBe(null);
+          expect(body).toEqual('<html></html>\n');
+          done();
+        });
+      });
+    });
+
     it('works without Content-Type', done => {
       var headers = {
         'X-Parse-Application-Id': 'test',

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -84,6 +84,10 @@ function handleParseHeaders(req, res, next) {
         info.masterKey = req.body._MasterKey;
         delete req.body._MasterKey;
       }
+      if (req.body._ContentType) {
+        req.headers['content-type'] = req.body._ContentType;
+        delete req.body_contentType;
+      }
     } else {
       return invalidRequest(req, res);
     }


### PR DESCRIPTION
JS SDK file upload uses req.body._ContentType to specify the upload content type