### PR TITLE
Adding a test demonstrating issue #1942.

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -589,4 +589,30 @@ describe('Cloud Code', () => {
       done();
     });
   });
+
+  it('set("key", undefined) should remove value at "key" before beforeSave', done => {
+    var BeforeSaveObject = Parse.Object.extend('BeforeSaveUnchanged');
+
+    Parse.Cloud.beforeSave('BeforeSaveUnchanged', (req, res) => {
+     var object = req.object;
+      if (object.has('removed') && object.get('removed')) {
+        expect(object.get('remove')).toEqual(undefined);
+      }
+      res.success();
+    });
+
+    var object = new BeforeSaveObject({remove: 'me'});
+    return object.save()
+    .then(object => {
+      expect(object.get('remove')).toEqual('me');
+      expect(object.has('removed')).toEqual(false);
+      object.set('remove', undefined);
+      object.set('removed', true);
+      return object.save();
+    })
+    .then(object => {
+      expect(object.get('remove')).toEqual(undefined);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
This test demonstrates #1942: saving an object after calling `set('key', undefined)` does not result in `key` being `undefined` in object's `beforeSave`. I originally thought this was Cloud Code only, but that is not the case.