### PR TITLE
Fix for #1840, Strip operations from results, forwards delete operations to SDKs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "redis": "2.6.2",
     "request": "2.73.0",
     "request-promise": "3.0.0",
+    "semver": "^5.2.0",
     "tv4": "1.2.7",
     "winston": "2.2.0",
     "winston-daily-rotate-file": "1.0.1",

--- a/spec/ClientSDK.spec.js
+++ b/spec/ClientSDK.spec.js
@@ -1,0 +1,41 @@
+var ClientSDK = require('../src/ClientSDK');
+
+describe('ClientSDK', () => {
+  it('should properly parse the SDK versions', () => {
+      let clientSDKFromVersion = ClientSDK.fromString;
+      expect(clientSDKFromVersion('i1.1.1')).toEqual({
+          sdk: 'i',
+          version: '1.1.1'
+      });
+      expect(clientSDKFromVersion('i1')).toEqual({
+          sdk: 'i',
+          version: '1'
+      });
+      expect(clientSDKFromVersion('apple-tv1.13.0')).toEqual({
+          sdk: 'apple-tv',
+          version: '1.13.0'
+      });
+      expect(clientSDKFromVersion('js1.9.0')).toEqual({
+          sdk: 'js',
+          version: '1.9.0'
+      });
+  });
+  
+  it('should properly sastisfy', () => {
+    expect(ClientSDK.compatible({
+      js: '>=1.9.0'
+    })("js1.9.0")).toBe(true);
+    
+    expect(ClientSDK.compatible({
+      js: '>=1.9.0'
+    })("js2.0.0")).toBe(true);
+
+    expect(ClientSDK.compatible({
+      js: '>=1.9.0'
+    })("js1.8.0")).toBe(false);
+
+    expect(ClientSDK.compatible({
+      js: '>=1.9.0'
+    })(undefined)).toBe(true);
+  })
+})

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -723,7 +723,7 @@ describe('Cloud Code', () => {
     });
   });
 
-  it('should fully delete objects when using `unset` with beforeSave (regression test for #1840)', done => {
+  it_exclude_dbs(['postgres'])('should fully delete objects when using `unset` with beforeSave (regression test for #1840)', done => {
     var TestObject = Parse.Object.extend('TestObject');
     var BeforeSaveObject = Parse.Object.extend('BeforeSaveChanged');
 

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -666,4 +666,60 @@ describe('Cloud Code', () => {
       done();
     });
   });
+
+  it('should fully delete objects when using `unset` with beforeSave (regression test for #1840)', done => {
+    var TestObject = Parse.Object.extend('TestObject');
+    var NoBeforeSaveObject = Parse.Object.extend('NoBeforeSave');
+    var BeforeSaveObject = Parse.Object.extend('BeforeSaveChanged');
+
+    Parse.Cloud.beforeSave('BeforeSaveChanged', (req, res) => {
+      var object = req.object;
+      object.set('before', 'save');
+      res.success();
+    });
+
+    Parse.Cloud.define('removeme', (req, res) => {
+      var testObject = new TestObject();
+      testObject.save()
+      .then(testObject => {
+        var object = new NoBeforeSaveObject({remove: testObject});
+        return object.save();
+      })
+      .then(object => {
+        object.unset('remove');
+        return object.save();
+      })
+      .then(object => {
+        res.success(object);
+      });
+    });
+
+    Parse.Cloud.define('removeme2', (req, res) => {
+      var testObject = new TestObject();
+      testObject.save()
+      .then(testObject => {
+        var object = new BeforeSaveObject({remove: testObject});
+        return object.save();
+      })
+      .then(object => {
+        object.unset('remove');
+        return object.save();
+      })
+      .then(object => {
+        res.success(object);
+      });
+    });
+
+    Parse.Cloud.run('removeme')
+    .then(aNoBeforeSaveObj => {
+      expect(aNoBeforeSaveObj.get('remove')).toEqual(undefined);
+
+      return Parse.Cloud.run('removeme2');
+    })
+    .then(aBeforeSaveObj => {
+      expect(aBeforeSaveObj.get('before')).toEqual('save');
+      expect(aBeforeSaveObj.get('remove')).toEqual(undefined);
+      done();
+    });
+  });
 });

--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -667,7 +667,7 @@ describe('Cloud Code', () => {
     });
   });
 
-  it('should fully delete objects when using `unset` with beforeSave (regression test for #1840)', done => {
+  it_exclude_dbs(['postgres'])('should fully delete objects when using `unset` with beforeSave (regression test for #1840)', done => {
     var TestObject = Parse.Object.extend('TestObject');
     var NoBeforeSaveObject = Parse.Object.extend('NoBeforeSave');
     var BeforeSaveObject = Parse.Object.extend('BeforeSaveChanged');

--- a/spec/Middlewares.spec.js
+++ b/spec/Middlewares.spec.js
@@ -66,24 +66,4 @@ describe('middlewares', () => {
             });
         });
     });
-
-    it('should properly parse the SDK versions', () => {
-        let clientSDKFromVersion = middlewares.clientSDKFromVersion;
-        expect(clientSDKFromVersion('i1.1.1')).toEqual({
-            sdk: 'i',
-            version: '1.1.1'
-        });
-        expect(clientSDKFromVersion('i1')).toEqual({
-            sdk: 'i',
-            version: '1'
-        });
-        expect(clientSDKFromVersion('apple-tv1.13.0')).toEqual({
-            sdk: 'apple-tv',
-            version: '1.13.0'
-        });
-        expect(clientSDKFromVersion('js1.9.0')).toEqual({
-            sdk: 'js',
-            version: '1.9.0'
-        });
-    })
 });

--- a/src/ClientSDK.js
+++ b/src/ClientSDK.js
@@ -1,0 +1,40 @@
+var semver = require('semver');
+
+function compatible(compatibleSDK) {
+  return function(clientSDK) {
+    if (typeof clientSDK === 'string') {
+      clientSDK = fromString(clientSDK);
+    }
+    // REST API, or custom SDK
+    if (!clientSDK) {
+      return true;
+    }
+    let clientVersion = clientSDK.version;
+    let compatiblityVersion = compatibleSDK[clientSDK.sdk];
+    return semver.satisfies(clientVersion, compatiblityVersion);
+  }
+}
+
+function supportsForwardDelete(clientSDK) {
+  return compatible({
+    js: '>=1.9.0'
+  })(clientSDK);
+}
+
+function fromString(version) {
+  let versionRE = /([-a-zA-Z]+)([0-9\.]+)/;
+  let match = version.toLowerCase().match(versionRE);
+  if (match && match.length === 3) {
+    return {
+      sdk: match[1],
+      version: match[2]
+    }
+  }
+  return undefined;
+}
+
+module.exports = {
+  compatible,
+  supportsForwardDelete,
+  fromString
+}

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -916,10 +916,15 @@ RestWrite.prototype.updateResponseWithData = function(response, data) {
   Object.keys(data).forEach(fieldName => {
     let dataValue = data[fieldName];
     let responseValue = response[fieldName];
-    if (!clientSupportsDelete && dataValue && dataValue.__op === 'Delete') {
+
+    response[fieldName] = responseValue || dataValue;
+    
+    // Strips operations from responses
+    if (response[fieldName] && response[fieldName].__op) {
       delete response[fieldName];
-    } else {
-      response[fieldName] = responseValue || dataValue;
+      if (clientSupportsDelete && dataValue.__op == 'Delete') {
+        response[fieldName] = dataValue;
+      }
     }
   });
   return response;

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -915,7 +915,7 @@ function updateResponseWithData(response, data) {
     let dataValue = data[fieldName];
     let responseValue = response[fieldName];
     if (dataValue && dataValue.__op === 'Delete') {
-      delete response[fieldName];
+      response[fieldName] = undefined;
     } else {
       response[fieldName] = responseValue || dataValue;
     }

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -914,11 +914,7 @@ function updateResponseWithData(response, data) {
   Object.keys(data).forEach(fieldName => {
     let dataValue = data[fieldName];
     let responseValue = response[fieldName];
-    if (dataValue && dataValue.__op === 'Delete') {
-      response[fieldName] = undefined;
-    } else {
-      response[fieldName] = responseValue || dataValue;
-    }
+    response[fieldName] = responseValue || dataValue;
   });
   return response;
 }

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -763,9 +763,7 @@ RestWrite.prototype.runDatabaseOperation = function() {
     .then(response => {
       response.updatedAt = this.updatedAt;
       if (this.storage.changedByTrigger) {
-        Object.keys(this.data).forEach(fieldName => {
-          response[fieldName] = response[fieldName] || this.data[fieldName];
-        });
+        updateResponseWithData(response, this.data);
       }
       this.response = { response };
     });
@@ -823,9 +821,7 @@ RestWrite.prototype.runDatabaseOperation = function() {
         response.username = this.data.username;
       }
       if (this.storage.changedByTrigger) {
-        Object.keys(this.data).forEach(fieldName => {
-          response[fieldName] = response[fieldName] || this.data[fieldName];
-        });
+        updateResponseWithData(response, this.data);
       }
       this.response = {
         status: 201,
@@ -913,6 +909,19 @@ RestWrite.prototype.cleanUserAuthData = function() {
     }
   }
 };
+
+function updateResponseWithData(response, data) {
+  Object.keys(data).forEach(fieldName => {
+    let dataValue = data[fieldName];
+    let responseValue = response[fieldName];
+    if (dataValue && dataValue.__op === 'Delete') {
+      delete response[fieldName];
+    } else {
+      response[fieldName] = responseValue || dataValue;
+    }
+  });
+  return response;
+}
 
 export default RestWrite;
 module.exports = RestWrite;

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -5,17 +5,7 @@ var Parse = require('parse/node').Parse;
 
 var auth = require('./Auth');
 var Config = require('./Config');
-
-function clientSDKFromVersion(version) {
-  let versionRE = /([-a-zA-Z]+)([0-9\.]+)/;
-  let match = version.toLowerCase().match(versionRE);
-  if (match && match.length === 3) {
-    return {
-      sdk: match[1],
-      version: match[2]
-    }
-  }
-}
+var ClientSDK = require('./ClientSDK');
 
 // Checks that the request is authorized for this app and checks user
 // auth too.
@@ -106,7 +96,7 @@ function handleParseHeaders(req, res, next) {
   }
 
   if (info.clientVersion) {
-    info.clientSDK = clientSDKFromVersion(info.clientVersion);
+    info.clientSDK = ClientSDK.fromString(info.clientVersion);
   }
 
   if (fileViaJSON) {
@@ -300,5 +290,4 @@ module.exports = {
   handleParseHeaders: handleParseHeaders,
   enforceMasterKeyAccess: enforceMasterKeyAccess,
   promiseEnforceMasterKeyAccess,
-  clientSDKFromVersion
 };


### PR DESCRIPTION
After a DB operation that was mutated by a beforeSave we'd loop through the new keys in order to set the DB computed values or the original value. 

We strip all operations from the results, as the clients can't interpret it.

For compatible SDK's we reinject the delete ops so the client can safely remove the associated key without fetching again. 


Fixes #1840 
Closes #1940 
Fixes #1606