### PR TITLE
Allow custom error codes with response.error 

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -64,6 +64,23 @@ describe('Cloud Code', () => {
     })
   });
 
+  it('beforeSave rejection with custom error code', function(done) {
+    Parse.Cloud.beforeSave('BeforeSaveFailWithErrorCode', function (req, res) {
+      res.error(999, 'Nope');
+    });
+
+    var obj = new Parse.Object('BeforeSaveFailWithErrorCode');
+    obj.set('foo', 'bar');
+    obj.save().then(function() {
+      fail('Should not have been able to save BeforeSaveFailWithErrorCode class.');
+      done();
+    }, function(error) {
+      expect(error.code).toEqual(999);
+      expect(error.message).toEqual('Nope');
+      done();
+    });
+  });
+
   it('basic beforeSave rejection via promise', function(done) {
     Parse.Cloud.beforeSave('BeforeSaveFailWithPromise', function (req, res) {
       var query = new Parse.Query('Yolo');

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -724,6 +724,36 @@ describe('miscellaneous', function() {
     });
   });
 
+  it('test cloud function error handling with custom error code', (done) => {
+    // Register a function which will fail
+    Parse.Cloud.define('willFail', (req, res) => {
+      res.error(999, 'noway');
+    });
+    Parse.Cloud.run('willFail').then((s) => {
+      fail('Should not have succeeded.');
+      done();
+    }, (e) => {
+      expect(e.code).toEqual(999);
+      expect(e.message).toEqual('noway');
+      done();
+    });
+  });
+
+  it('test cloud function error handling with standard error code', (done) => {
+    // Register a function which will fail
+    Parse.Cloud.define('willFail', (req, res) => {
+      res.error('noway');
+    });
+    Parse.Cloud.run('willFail').then((s) => {
+      fail('Should not have succeeded.');
+      done();
+    }, (e) => {
+      expect(e.code).toEqual(Parse.Error.SCRIPT_FAILED);
+      expect(e.message).toEqual('noway');
+      done();
+    });
+  });
+
   it('test beforeSave/afterSave get installationId', function(done) {
     let triggerTime = 0;
     Parse.Cloud.beforeSave('GameScore', function(req, res) {

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -21,8 +21,12 @@ export class FunctionsRouter extends PromiseRouter {
           }
         });
       },
-      error: function(error) {
-        reject(new Parse.Error(Parse.Error.SCRIPT_FAILED, error));
+      error: function(code, message) {
+        if (!message) {
+          message = code;
+          code = Parse.Error.SCRIPT_FAILED;
+        }
+        reject(new Parse.Error(code, message));
       }
     }
   }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -141,8 +141,12 @@ export function getResponseObject(request, resolve, reject) {
       }
       return resolve(response);
     },
-    error: function(error) {
-      var scriptError = new Parse.Error(Parse.Error.SCRIPT_FAILED, error);
+    error: function(code, message) {
+      if (!message) {
+        message = code;
+        code = Parse.Error.SCRIPT_FAILED;
+      }
+      var scriptError = new Parse.Error(code, message);
       return reject(scriptError);
     }
   }


### PR DESCRIPTION
This fixes ParsePlatform/parse-server#1950.

Previously, `response.error(...)` from Cloud Code or before/after hooks would always use the error code "141" (`Parse.Error.SCRIPT_FAILED`).

This PR updates `response.error` to accept two parameters: an error code and a message. If no error code is passed then the standard "141" will be used.