### PR TITLE
Strip read only fields from serialized beforeSave responses

### DIFF
--- a/spec/ParseHooks.spec.js
+++ b/spec/ParseHooks.spec.js
@@ -387,15 +387,35 @@ describe('Hooks', () => {
      Parse.Hooks.createTrigger("SomeRandomObject", "beforeSave" ,hookServerURL+"/BeforeSaveSome").then(function(){
        const obj = new Parse.Object("SomeRandomObject");
        return obj.save();
-     }).then(function(res){
+     }).then(function(res) {
        expect(triggerCount).toBe(1);
        return res.fetch();
-     }).then(function(res){
+     }).then(function(res) {
        expect(res.get("hello")).toEqual("world");
        done();
      }).fail((err) => {
        console.error(err);
        fail("Should not fail creating a function");
+       done();
+     });
+   });
+
+   it("beforeSave hooks should correctly handle responses containing entire object", (done) => {
+     app.post("/BeforeSaveSome2", function(req, res) {
+       var object = Parse.Object.fromJSON(req.body.object);
+       object.set('hello', "world");
+       res.json({success: object});
+     });
+     Parse.Hooks.createTrigger("SomeRandomObject2", "beforeSave" ,hookServerURL+"/BeforeSaveSome2").then(function(){
+       const obj = new Parse.Object("SomeRandomObject2");
+       return obj.save();
+     }).then(function(res) {
+       return res.save();
+     }).then(function(res) {
+       expect(res.get("hello")).toEqual("world");
+       done();
+     }).fail((err) => {
+       fail(`Should not fail: ${JSON.stringify(err)}`);
        done();
      });
    });

--- a/src/Controllers/HooksController.js
+++ b/src/Controllers/HooksController.js
@@ -205,6 +205,8 @@ function wrapToHTTPRequest(hook, key) {
       if (err) {
         return res.error(err);
       } else if (hook.triggerName === 'beforeSave') {
+        delete result.createdAt;
+        delete result.updatedAt;
         return res.success({object: result});
       } else {
         return res.success(result);


### PR DESCRIPTION
This fixes #1949 and makes parse-server behave like api.parse.com with regards to how response objects for beforeSave hooks are handled.