### PR TITLE
Ensure beforeSave hook response is object before stripping

### DIFF
--- a/src/Controllers/HooksController.js
+++ b/src/Controllers/HooksController.js
@@ -202,11 +202,14 @@ function wrapToHTTPRequest(hook, key) {
           err = body.error;
         }
       }
+
       if (err) {
         return res.error(err);
       } else if (hook.triggerName === 'beforeSave') {
-        delete result.createdAt;
-        delete result.updatedAt;
+        if (typeof result === 'object') {
+          delete result.createdAt;
+          delete result.updatedAt;
+        }
         return res.success({object: result});
       } else {
         return res.success(result);


### PR DESCRIPTION
Technically if someone returns true/false boolean primitives it'll behave just fine if you call delete on them as the primitive values get converted to objects by the interpreter but this is more explicit.