### PR TITLE
Revert "Log objects rather than JSON stringified objects"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ That's it! You are now running a standalone version of Parse Server on your mach
 
 **Using a remote MongoDB?** Pass the  `--databaseURI DATABASE_URI` parameter when starting `parse-server`. Learn more about configuring Parse Server [here](#configuration). For a full list of available options, run `parse-server --help`.
 
+**Want logs to be in placed in other folder?** Pass the `PARSE_SERVER_LOGS_FOLDER` environment variable when starting `parse-server`. Usage :-  `PARSE_SERVER_LOGS_FOLDER='<path-to-logs-folder>' parse-server --appId APPLICATION_ID --masterKey MASTER_KEY`
+
 ### Saving your first object
 
 Now that you're running Parse Server, it is time to save your first object. We'll use the [REST API](https://parse.com/docs/rest/guide), but you can easily do the same using any of the [Parse SDKs](https://parseplatform.github.io/#sdks). Run the following:
@@ -142,18 +144,6 @@ app.listen(1337, function() {
 ```
 
 For a full list of available options, run `parse-server --help`.
-
-## Logging
-
-Parse Server will, by default, will log:
-* to the console
-* daily rotating files as new line delimited JSON
-
-Logs are also be viewable in Parse Dashboard but it only displays the `messages` field of each log entry. For example, with VERBOSE set this will exclude `origin` on each request.
-
-**Want to log each request and response?** Set the `VERBOSE` environment variable when starting `parse-server`. Usage :-  `VERBOSE='1' parse-server --appId APPLICATION_ID --masterKey MASTER_KEY`
-
-**Want logs to be in placed in other folder?** Pass the `PARSE_SERVER_LOGS_FOLDER` environment variable when starting `parse-server`. Usage :-  `PARSE_SERVER_LOGS_FOLDER='<path-to-logs-folder>' parse-server --appId APPLICATION_ID --masterKey MASTER_KEY`
 
 # Documentation
 

--- a/spec/FileLoggerAdapter.spec.js
+++ b/spec/FileLoggerAdapter.spec.js
@@ -62,7 +62,7 @@ describe('verbose logs', () => {
         level: 'verbose'
       });
     }).then((results) => {
-      expect(results[1].body.password).toEqual("********");
+      expect(results[1].message.includes('"password": "********"')).toEqual(true);
       var headers = {
         'X-Parse-Application-Id': 'test',
         'X-Parse-REST-API-Key': 'rest'
@@ -77,7 +77,7 @@ describe('verbose logs', () => {
           size: 100,
           level: 'verbose'
         }).then((results) => {
-          expect(results[1].url.includes('password=********')).toEqual(true);
+          expect(results[1].message.includes('password=********')).toEqual(true);
           done();
         });
       });
@@ -95,7 +95,7 @@ describe('verbose logs', () => {
         level: 'verbose'
       });
     }).then((results) => {
-      expect(results[1].body.password).toEqual("pw");
+      expect(results[1].message.includes('"password": "pw"')).toEqual(true);
       done();
     });
   });

--- a/src/PromiseRouter.js
+++ b/src/PromiseRouter.js
@@ -154,20 +154,15 @@ export default class PromiseRouter {
 // just treat it like it resolved to an error.
 function makeExpressHandler(promiseHandler) {
   return function(req, res, next) {
-    var url = maskSensitiveUrl(req);
     try {
-      log.verbose(`REQUEST for [${req.method}] ${url}`, {
-        method: req.method,
-        url: url,
-        headers: req.headers,
-        body: maskSensitiveBody(req)
-      });
+      log.verbose(req.method, maskSensitiveUrl(req), req.headers,
+                  JSON.stringify(maskSensitiveBody(req), null, 2));
       promiseHandler(req).then((result) => {
         if (!result.response && !result.location && !result.text) {
           log.error('the handler did not include a "response" or a "location" field');
           throw 'control should not get here';
         }
-        log.verbose(`RESPONSE from [${req.method}] ${url}`, {result: result});
+        log.verbose(JSON.stringify(result, null, 2));
 
         var status = result.status || 200;
         res.status(status);
@@ -191,11 +186,11 @@ function makeExpressHandler(promiseHandler) {
         }
         res.json(result.response);
       }, (e) => {
-        log.error(`Error generating response. ${e}`, {error: e});
+        log.verbose('error:', e);
         next(e);
       });
     } catch (e) {
-      log.error(`Error handling request: ${e}`, {error: e});
+      log.verbose('exception:', e);
       next(e);
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
+import winston           from 'winston';
 import ParseServer       from './ParseServer';
-import logger            from './logger';
 import S3Adapter         from 'parse-server-s3-adapter'
 import FileSystemAdapter from 'parse-server-fs-adapter'
 import TestUtils         from './TestUtils';
@@ -16,4 +16,4 @@ _ParseServer.createLiveQueryServer = ParseServer.createLiveQueryServer;
 let GCSAdapter = useExternal('GCSAdapter', 'parse-server-gcs-adapter');
 
 export default ParseServer;
-export { S3Adapter, GCSAdapter, FileSystemAdapter, TestUtils, _ParseServer as ParseServer, logger };
+export { S3Adapter, GCSAdapter, FileSystemAdapter, TestUtils, _ParseServer as ParseServer };


### PR DESCRIPTION
Reverts ParsePlatform/parse-server#1922. That PR has some bugs which are causing issue, and it turns out having the full request and response in the logs is very useful for debugging. I think we need to rethink this, maybe we can log on one line when verbose is not enabled, and log everything when verbose is enabled or something like that.

@TylerBrock @spenthil 