### PR TITLE
Support file objects in the legacy bucket: files.parse.com

### DIFF
--- a/spec/ParseFile.spec.js
+++ b/spec/ParseFile.spec.js
@@ -491,7 +491,7 @@ describe('Parse.File testing', () => {
     });
   });
 
-  it('creates correct url for old files hosted on parse', done => {
+  it('creates correct url for old files hosted on files.parsetfss.com', done => {
     var file = {
       __type: 'File',
       url: 'http://irrelevant.elephant/',
@@ -506,6 +506,26 @@ describe('Parse.File testing', () => {
       var fileAgain = result.get('oldfile');
       expect(fileAgain.url()).toEqual(
         'http://files.parsetfss.com/test/tfss-123.txt'
+      );
+      done();
+    });
+  });
+
+  it('creates correct url for old files hosted on files.parse.com', done => {
+    var file = {
+      __type: 'File',
+      url: 'http://irrelevant.elephant/',
+      name: 'd6e80979-a128-4c57-a167-302f874700dc-123.txt'
+    };
+    var obj = new Parse.Object('OldFileTest');
+    obj.set('oldfile', file);
+    obj.save().then(() => {
+      var query = new Parse.Query('OldFileTest');
+      return query.first();
+    }).then((result) => {
+      var fileAgain = result.get('oldfile');
+      expect(fileAgain.url()).toEqual(
+        'http://files.parse.com/test/d6e80979-a128-4c57-a167-302f874700dc-123.txt'
       );
       done();
     });

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -6,6 +6,8 @@ import { FilesAdapter } from '../Adapters/Files/FilesAdapter';
 import path  from 'path';
 import mime from 'mime';
 
+const legacyFilesRegex = new RegExp("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-.*");
+
 export class FilesController extends AdaptableController {
 
   getFileData(config, filename) {
@@ -59,8 +61,13 @@ export class FilesController extends AdaptableController {
           continue;
         }
         let filename = fileObject['name'];
+        // all filenames starting with "tfss-" should be from files.parsetfss.com
+        // all filenames starting with a "-" seperated UUID should be from files.parse.com
+        // all other filenames have been migrated or created from Parse Server
         if (filename.indexOf('tfss-') === 0) {
           fileObject['url'] = 'http://files.parsetfss.com/' + config.fileKey + '/' + encodeURIComponent(filename);
+        } else if (legacyFilesRegex.test(filename)) {
+          fileObject['url'] = 'http://files.parse.com/' + config.fileKey + '/' + encodeURIComponent(filename);
         } else {
           fileObject['url'] = this.adapter.getFileLocation(config, filename);
         }


### PR DESCRIPTION
At some point in the past, parse.com switched buckets/domain for files from files.parse.com to files.parsetfss.com. We need to support the older version too because Parse Server currently has no way of reaching those older files.

Files in files.parsetfss.com all have filenames starting with the prefix "tfss-"
Files in files.parse.com all have filenames starting with a UUID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee-"
Files in Parse Server are all other files and should have filenames starting with a 32 bit hex followed by an underscore: "aaaaaaaabbbbccccddddeeeeeeeeeeee_"

We should make sure never to change the way Parse Server name files or at least never make it a "-" seperated UUID like files.parse.com has.

This should fix #1521.