### PR TITLE
[hooks] allow hooks to be refreshed after set interval

### DIFF
--- a/src/Controllers/HooksController.js
+++ b/src/Controllers/HooksController.js
@@ -20,9 +20,12 @@ export class HooksController {
     this.database = DatabaseAdapter.getDatabaseConnection(this._applicationId, this._collectionPrefix).WithoutValidation();
   }
 
-  load() {
+  reset() {
     return this._getHooks().then(hooks => {
       hooks = hooks || [];
+      // addHookToTriggers must be synchronous to avoid valid hooks being undefined
+      // for a period of time
+      triggers._unregisterAll();
       hooks.forEach((hook) => {
         this.addHookToTriggers(hook);
       });

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -122,6 +122,7 @@ class ParseServer {
     expireInactiveSessions = true,
     verbose = false,
     revokeSessionOnPasswordReset = true,
+    hooksRefreshIntervalMs = 0,
   }) {
     // Initialize the node client SDK automatically
     Parse.initialize(appId, javascriptKey || 'unused', masterKey);
@@ -210,7 +211,16 @@ class ParseServer {
 
     Config.validate(AppCache.get(appId));
     this.config = AppCache.get(appId);
-    hooksController.load();
+    if (hooksRefreshIntervalMs > 0) {
+      (function repeat() {
+        setTimeout(() => {
+          hooksController.reset();
+          repeat();
+        } , hooksRefreshIntervalMs);
+      })();
+    } else {
+      hooksController.reset();
+    }
   }
 
   get app() {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -216,7 +216,7 @@ class ParseServer {
         setTimeout(() => {
           hooksController.reset();
           repeat();
-        } , hooksRefreshIntervalMs);
+        } , hooksRefreshIntervalMs).unref();
       })();
     } else {
       hooksController.reset();


### PR DESCRIPTION
Hooks configuration can only be processed on a ParseServer restart. This
is far from ideal. A simple configuration of an endpoint or a disabling
of a hook should not require a process of draining the parse server,
cycling it, and the bringing it back up. Simple configurations
changes should take effect more easily.