### PR TITLE
Fix issue when MongoTransform converts object-type field with null values

### DIFF
--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -16,6 +16,15 @@ describe('parseObjectToMongoObjectForCreate', () => {
     done();
   });
 
+  it('an object with null values', (done) => {
+    var input = {objectWithNullValues: {isNull: null, notNull: 3}};
+    var output = transform.parseObjectToMongoObjectForCreate(null, input, {
+      fields: {objectWithNullValues: {type: 'object'}}
+    });
+    jequal(input, output);
+    done();
+  });
+
   it('built-in timestamps', (done) => {
     var input = {
       createdAt: "2015-10-06T21:24:50.332Z",

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -209,7 +209,7 @@ function arrayContains(arr, item) {
 
 // Normalizes a JSON object.
 function normalize(obj) {
-  if (typeof obj !== 'object') {
+  if (obj === null || typeof obj !== 'object') {
     return JSON.stringify(obj);
   }
   if (obj instanceof Array) {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -83,7 +83,7 @@ const transformKeyValueForUpdate = (className, restKey, restValue, parseFormatSc
 }
 
 const transformInteriorValue = restValue => {
-  if (typeof restValue === 'object' && Object.keys(restValue).some(key => key.includes('$') || key.includes('.'))) {
+  if (restValue !== null && typeof restValue === 'object' && Object.keys(restValue).some(key => key.includes('$') || key.includes('.'))) {
     throw new Parse.Error(Parse.Error.INVALID_NESTED_KEY, "Nested keys should not contain the '$' or '.' characters");
   }
   // Handle atomic values


### PR DESCRIPTION
I've been getting gnarly errors when issuing the following request in cURL (to a server running parse-server 2.2.12):

```
➜ Dan@Dans-MacBook-Pro  ~/MTailor/workspace/parse-server git:(MongoTransform-obj-with-null-values) curl -X POST \
-H "X-Parse-Application-Id: <REDACTED>" \
-H "X-Parse-REST-API-Key: <REDACTED>" \
-H "X-Parse-Master-Key: <REDACTED>" \
-H "Content-Type: application/json" \
-d '{ "orderFormObject": {"nest1": null, "nest2": {"blah": 1}}}' \
https://<REDACTED>/parse/classes/OrderItem
{"code":1,"message":"Internal server error."}%
```

The trace looks like this:
```
ESC[31merrorESC[39m: Uncaught internal server error. [TypeError: Cannot convert undefined or null to object] TypeError: Cannot convert undefined or null to object
    at Function.keys (native)
    at transformInteriorValue (/var/app/current/node_modules/parse-server/lib/Adapters/Storage/Mongo/MongoTransform.js:104:100)
    at /var/app/current/node_modules/parse-server/node_modules/lodash/lodash.js:12739:23
    at /var/app/current/node_modules/parse-server/node_modules/lodash/lodash.js:4411:15
    at baseForOwn (/var/app/current/node_modules/parse-server/node_modules/lodash/lodash.js:2654:24)
    at Function.mapValues (/var/app/current/node_modules/parse-server/node_modules/lodash/lodash.js:12738:7)
    at parseObjectKeyValueToMongoObjectKeyValue (/var/app/current/node_modules/parse-server/lib/Adapters/Storage/Mongo/MongoTransform.js:296:28)
    at parseObjectToMongoObjectForCreate (/var/app/current/node_modules/parse-server/lib/Adapters/Storage/Mongo/MongoTransform.js:308:33)
    at MongoStorageAdapter.createObject (/var/app/current/node_modules/parse-server/lib/Adapters/Storage/Mongo/MongoStorageAdapter.js:242:79)
    at /var/app/current/node_modules/parse-server/lib/Controllers/DatabaseController.js:518:29
    at run (/var/app/current/node_modules/parse-server/node_modules/babel-polyfill/node_modules/core-js/modules/es6.promise.js:89:22)
    at /var/app/current/node_modules/parse-server/node_modules/babel-polyfill/node_modules/core-js/modules/es6.promise.js:102:28
    at flush (/var/app/current/node_modules/parse-server/node_modules/babel-polyfill/node_modules/core-js/modules/_microtask.js:18:9)
    at nextTickCallbackWith0Args (node.js:419:9)
    at process._tickDomainCallback (node.js:389:13)
```

This change should fix the issues I've been having.