### PR TITLE
fix getting user roles from cache

### DIFF
--- a/src/Auth.js
+++ b/src/Auth.js
@@ -99,6 +99,7 @@ Auth.prototype._loadRoles = function() {
   return cacheAdapter.role.get(this.user.id).then((cachedRoles) => {
     if (cachedRoles != null) {
       this.fetchedroles = true;
+      this.userRoles = cachedRoles;
       return Promise.resolve(cachedRoles);
     }
 


### PR DESCRIPTION
Hi,

In some cases, DELETE operation can really delete the object only on second try.
On the first try, parse-server trying to get user roles from cache (and it looks like it failed).
On the second, we will create a REST request to obtain roles, and re-cache them, this code is OK.

Here is the a log with VERBOSE=1:
```
parse-v1-1 verbose: DELETE /api/v1/classes/WatcherTask/Bp7JHCWB2c { 'x-real-ip': 'X.X.X.X',
parse-v1-1   'x-nginx-proxy': 'true',
parse-v1-1   'x-forwarded-proto': 'https',
parse-v1-1   connection: 'close',
parse-v1-1   'content-length': '0',
parse-v1-1   'x-parse-os-version': '6.0.1',
parse-v1-1   'x-parse-client-version': 'a1.13.1',
parse-v1-1   'user-agent': 'Parse Android SDK 1.13.1 (XXX/YYY) API Level 23',
parse-v1-1   'x-parse-session-token': 'r:f8e5409b8e61e3884478f24efdcf4d9e',
parse-v1-1   'content-type': 'application/x-www-form-urlencoded',
parse-v1-1   'accept-encoding': 'gzip' } {}
parse-v1-1 auth.userRoles: []
parse-v1-1 DEL: options: {"acl":["*","LogIcQd9Td"]}
parse-v1-1 Mongo where: {"_id":"Bp7JHCWB2c","_wperm":{"$in":[null,"*","LogIcQd9Td"]}}
parse-v1-1 verbose: error: code=101, message=Object not found.
```

And now with this commit included:
```
parse-v1-1 verbose: DELETE /api/v1/classes/WatcherTask/Bp7JHCWB2c { 'x-real-ip': 'X.X.X.X',
parse-v1-1   'x-nginx-proxy': 'true',
parse-v1-1   'x-forwarded-proto': 'https',
parse-v1-1   connection: 'close',
parse-v1-1   'content-length': '0',
parse-v1-1   'x-parse-os-version': '6.0.1',
parse-v1-1   'x-parse-client-version': 'a1.13.1',
parse-v1-1   'user-agent': 'Parse Android SDK 1.13.1 (XXX/YYY) API Level 23',
parse-v1-1   'x-parse-session-token': 'r:f8e5409b8e61e3884478f24efdcf4d9e',
parse-v1-1   'content-type': 'application/x-www-form-urlencoded',
parse-v1-1   'accept-encoding': 'gzip' } {}
parse-v1-1 auth.userRoles: ["role:pt_240d22f4-8065-49f9-b609-18f5f35ed8ab"]
parse-v1-1 DEL: options: {"acl":["*","LogIcQd9Td","role:pt_240d22f4-8065-49f9-b609-18f5f35ed8ab"]}
parse-v1-1 Mongo where: {"_id":"Bp7JHCWB2c","_wperm":{"$in":[null,"*","LogIcQd9Td","role:pt_240d22f4-8065-49f9-b609-18f5f35ed8ab"]}}
parse-v1-1 verbose: {
parse-v1-1   "response": {}
parse-v1-1 }
```
