### PR TITLE
Throw error when push is missing configuration

### DIFF
--- a/spec/Parse.Push.spec.js
+++ b/spec/Parse.Push.spec.js
@@ -144,4 +144,24 @@ describe('Parse.Push', () => {
       });
     });
   });
+
+  it('should throw error if missing push configuration', done => {
+    reconfigureServer({push: null})
+    .then(() => {
+      return Parse.Push.send({
+        where: {
+          deviceType: 'ios'
+        },
+        data: {
+          badge: 'increment',
+          alert: 'Hello world!'
+        }
+      }, {useMasterKey: true})
+    }).then((response) => {
+      fail('should not succeed');
+    }, (err) => {
+      expect(err.code).toEqual(Parse.Error.PUSH_MISCONFIGURED);
+      done();
+    });
+  });
 });

--- a/spec/PushController.spec.js
+++ b/spec/PushController.spec.js
@@ -178,7 +178,7 @@ describe('PushController', () => {
     isMaster: true
    }
 
-   var pushController = new PushController(pushAdapter, Parse.applicationId);
+   var pushController = new PushController(pushAdapter, Parse.applicationId, defaultConfiguration.push);
    Parse.Object.saveAll(installations).then((installations) => {
      return pushController.sendPush(payload, {}, config, auth);
    }).then((result) => {
@@ -226,7 +226,7 @@ describe('PushController', () => {
     isMaster: true
    }
 
-   var pushController = new PushController(pushAdapter, Parse.applicationId);
+   var pushController = new PushController(pushAdapter, Parse.applicationId, defaultConfiguration.push);
    Parse.Object.saveAll(installations).then((installations) => {
      return pushController.sendPush(payload, {}, config, auth);
    }).then((result) => {
@@ -277,7 +277,7 @@ describe('PushController', () => {
     isMaster: true
    }
 
-   var pushController = new PushController(pushAdapter, Parse.applicationId);
+   var pushController = new PushController(pushAdapter, Parse.applicationId, defaultConfiguration.push);
    Parse.Object.saveAll(installations).then(() => {
      return pushController.sendPush(payload, {}, config, auth);
    }).then((result) => {
@@ -342,7 +342,7 @@ describe('PushController', () => {
    var auth = {
     isMaster: true
    }
-   var pushController = new PushController(pushAdapter, Parse.applicationId);
+   var pushController = new PushController(pushAdapter, Parse.applicationId, defaultConfiguration.push);
    pushController.sendPush(payload, where, config, auth).then(() => {
      fail('should not succeed');
      done();
@@ -388,7 +388,7 @@ describe('PushController', () => {
      }
    }
 
-   var pushController = new PushController(pushAdapter, Parse.applicationId);
+   var pushController = new PushController(pushAdapter, Parse.applicationId, defaultConfiguration.push);
    pushController.sendPush(payload, where, config, auth).then((result) => {
       done();
     }).catch((err) => {

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -46,6 +46,10 @@ export class PushController extends AdaptableController {
       throw new Parse.Error(Parse.Error.PUSH_MISCONFIGURED,
                             'Push adapter is not available');
     }
+    if (!this.options) {
+      throw new Parse.Error(Parse.Error.PUSH_MISCONFIGURED,
+                            'Missing push configuration');
+    }
     PushController.validatePushType(where, pushAdapter.getValidPushTypes());
     // Replace the expiration_time with a valid Unix epoch milliseconds time
     body['expiration_time'] = PushController.getExpirationTime(body);

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -177,7 +177,7 @@ class ParseServer {
       return new GridStoreAdapter(databaseURI);
     });
     // Pass the push options too as it works with the default
-    const pushControllerAdapter = loadAdapter(push && push.adapter, ParsePushAdapter, push);
+    const pushControllerAdapter = loadAdapter(push && push.adapter, ParsePushAdapter, push || {});
     const loggerControllerAdapter = loadAdapter(loggerAdapter, FileLoggerAdapter);
     const emailControllerAdapter = loadAdapter(emailAdapter);
     const cacheControllerAdapter = loadAdapter(cacheAdapter, InMemoryCacheAdapter, {appId: appId});
@@ -185,7 +185,7 @@ class ParseServer {
     // We pass the options and the base class for the adatper,
     // Note that passing an instance would work too
     const filesController = new FilesController(filesControllerAdapter, appId);
-    const pushController = new PushController(pushControllerAdapter, appId);
+    const pushController = new PushController(pushControllerAdapter, appId, push);
     const loggerController = new LoggerController(loggerControllerAdapter, appId);
     const userController = new UserController(emailControllerAdapter, appId, { verifyUserEmails });
     const liveQueryController = new LiveQueryController(liveQuery);


### PR DESCRIPTION
Currently, when there are no custom push adapter, default push adapter will be use even without configuration.
```
var server = new ParseServer({
  appId: '...',
  masterKey: '...',
  serverURL: 'http://localhost:1337/parse',
  ...moreOptions
  // Missing `push` here
});
```
This would allow sending push with `{result: true}` but in return is fail status if we look at `_PushStatus`. Therefore, it is better to provide error message (Missing push configuration) before trying to send the push, developer will not feel confuse and can fix the problem easier.