### PR TITLE
Fix Bytes encoding to JSON

### DIFF
--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -802,6 +802,10 @@ const mongoObjectToParseObject = (className, mongoObject, schema) => {
             restObject[key] = GeoPointCoder.databaseToJSON(value);
             break;
           }
+          if (schema.fields[key] && schema.fields[key].type === 'Bytes' && BytesCoder.isValidDatabaseObject(value)) {
+            restObject[key] = BytesCoder.databaseToJSON(value);
+            break;
+          }
         }
         restObject[key] = nestedMongoObjectToNestedParseObject(mongoObject[key]);
       }
@@ -839,12 +843,12 @@ var BytesCoder = {
   databaseToJSON(object) {
     return {
       __type: 'Bytes',
-      base64: object.buffer.toString('base64')
+      base64: object
     };
   },
 
   isValidDatabaseObject(object) {
-    return (object instanceof mongodb.Binary);
+    return (typeof object === 'string');
   },
 
   JSONToDatabase(json) {


### PR DESCRIPTION
This fixes the transmission of Bytes values over REST. Currently Bytes fields are skipped (lines 805-808) and thus end up being sent across as Strings. Once adding those lines, the "isValidDatabaseObject" check is incorrect as Bytes fields are just stored as base64 **strings** on the javascript objects, not mongodb.Binary objects.

This fix is primarily for the ObjectiveC and Java SDKs.