### PR TITLE
Update PostgresStorageAdapter.js

### DIFF
--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -220,13 +220,9 @@ export class PostgresStorageAdapter {
   // this adapter doesn't know about the schema, return a promise that rejects with
   // undefined as the reason.
   getClass(className) {
-    return this._client.query('SELECT * FROM "_SCHEMA" WHERE "className"=$<className>', { className })
-    .then(result => {
-      if (result.length === 1) {
-        return result[0].schema;
-      } else {
+    return this._client.one('SELECT * FROM "_SCHEMA" WHERE "className"=$<className>', { className }, res=>res.schema)
+    .catch(error => {
         throw undefined;
-      }
     });
   }
 


### PR DESCRIPTION
If it really needs to reject with `undefined`, then this is the right way. Usually one just returns the result, let the caller provide the `.catch` ;)

This way real errors can be swallowed, not very good ;)