### PR TITLE
Fix for issue 1605

### DIFF
--- a/src/Auth.js
+++ b/src/Auth.js
@@ -58,7 +58,12 @@ var getAuthForSessionToken = function({ config, sessionToken, installationId } =
     return query.execute().then((response) => {
       var results = response.results;
       if (results.length !== 1 || !results[0]['user']) {
-        return nobody(config);
+        if(!sessionToken) {
+          return nobody(config);
+        } else {
+          throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN,
+            'Session token is expired.');
+        }
       }
 
       var now = new Date(),


### PR DESCRIPTION
According to the guide at https://parse.com/docs/ios/guide#sessions-handling-invalid-session-token-error: "When a device's session token no longer corresponds to a PFSession object on the Parse Cloud, all API requests from that device will fail with 'Error 209: invalid session token'."
However, with the current implementation no error is thrown as expected. Issue 1605 describes this as well. This pull request will throw error 209 if a session token is set but no matching _Session is found.