### PR TITLE
Makes HTTPResponse serializable

### DIFF
--- a/spec/HTTPRequest.spec.js
+++ b/spec/HTTPRequest.spec.js
@@ -252,6 +252,41 @@ describe("httpRequest", () => {
     expect(httpResponse.data).toBeUndefined();
     expect(httpResponse.text).toBeUndefined();
     expect(httpResponse.buffer).toBeUndefined();
-  })
+  });
+
+  it('serialized httpResponse correctly with body string', () => {
+    let httpResponse = new HTTPResponse({}, 'hello');
+    let serialized = JSON.stringify(httpResponse);
+    let result = JSON.parse(serialized);
+    expect(result.text).toBe('hello');
+    expect(result.data).toBe(undefined);
+    expect(result.body).toBe('hello');
+  });
+
+  it('serialized httpResponse correctly with body object', () => {
+    let httpResponse = new HTTPResponse({}, {foo: "bar"});
+    let serialized = JSON.stringify(httpResponse);
+    let result = JSON.parse(serialized);
+    expect(result.text).toEqual('{"foo":"bar"}');
+    expect(result.data).toEqual({foo: 'bar'});
+    expect(result.body).toEqual({foo: 'bar'});
+  });
+
+  it('serialized httpResponse correctly with body buffer string', () => {
+    let httpResponse = new HTTPResponse({}, new Buffer('hello'));
+    let serialized = JSON.stringify(httpResponse);
+    let result = JSON.parse(serialized);
+    expect(result.text).toBe('hello');
+    expect(result.data).toBe(undefined);
+  });
+
+  it('serialized httpResponse correctly with body buffer JSON Object', () => {
+    let json = '{"foo":"bar"}';
+    let httpResponse = new HTTPResponse({}, new Buffer(json));
+    let serialized = JSON.stringify(httpResponse);
+    let result = JSON.parse(serialized);
+    expect(result.text).toEqual('{"foo":"bar"}');
+    expect(result.data).toEqual({foo: 'bar'});
+  });
 
 });

--- a/spec/HTTPRequest.spec.js
+++ b/spec/HTTPRequest.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var httpRequest = require("../src/cloud-code/httpRequest"),
+    HTTPResponse = require('../src/cloud-code/HTTPResponse').default,
     bodyParser = require('body-parser'),
     express = require("express");
 
@@ -244,5 +245,13 @@ describe("httpRequest", () => {
       done();
     })
   });
+
+  it('should not crash with undefined body', () => {
+    let httpResponse = new HTTPResponse({});
+    expect(httpResponse.body).toBeUndefined();
+    expect(httpResponse.data).toBeUndefined();
+    expect(httpResponse.text).toBeUndefined();
+    expect(httpResponse.buffer).toBeUndefined();
+  })
 
 });

--- a/spec/HTTPRequest.spec.js
+++ b/spec/HTTPRequest.spec.js
@@ -264,7 +264,7 @@ describe("httpRequest", () => {
     let result = JSON.parse(serialized);
     expect(result.text).toBe('hello');
     expect(result.data).toBe(undefined);
-    expect(result.body).toBe('hello');
+    expect(result.body).toBe(undefined);
   });
 
   it('serialized httpResponse correctly with body object', () => {
@@ -279,7 +279,7 @@ describe("httpRequest", () => {
 
     expect(result.text).toEqual('{"foo":"bar"}');
     expect(result.data).toEqual({foo: 'bar'});
-    expect(result.body).toEqual({foo: 'bar'});
+    expect(result.body).toEqual(undefined);
   });
 
   it('serialized httpResponse correctly with body buffer string', () => {
@@ -306,7 +306,7 @@ describe("httpRequest", () => {
     let json = '{"foo":"bar"}';
     let httpResponse = new HTTPResponse({}, new Buffer(json));
     let encoded = Parse._encode(httpResponse);
-    let foundData, foundText = false;
+    let foundData, foundText, foundBody = false;
     for(var key in encoded) {
       if (key == 'data') {
         foundData = true;
@@ -314,9 +314,13 @@ describe("httpRequest", () => {
       if (key == 'text') {
         foundText = true;
       }
+      if (key == 'body') {
+        foundBody = true;
+      }
     }
     expect(foundData).toBe(true);
     expect(foundText).toBe(true);
+    expect(foundBody).toBe(false);
   });
 
 });

--- a/spec/HTTPRequest.spec.js
+++ b/spec/HTTPRequest.spec.js
@@ -256,6 +256,10 @@ describe("httpRequest", () => {
 
   it('serialized httpResponse correctly with body string', () => {
     let httpResponse = new HTTPResponse({}, 'hello');
+    expect(httpResponse.text).toBe('hello');
+    expect(httpResponse.data).toBe(undefined);
+    expect(httpResponse.body).toBe('hello');
+
     let serialized = JSON.stringify(httpResponse);
     let result = JSON.parse(serialized);
     expect(result.text).toBe('hello');
@@ -265,8 +269,14 @@ describe("httpRequest", () => {
 
   it('serialized httpResponse correctly with body object', () => {
     let httpResponse = new HTTPResponse({}, {foo: "bar"});
+    let encodedResponse = Parse._encode(httpResponse);
     let serialized = JSON.stringify(httpResponse);
     let result = JSON.parse(serialized);
+    
+    expect(httpResponse.text).toEqual('{"foo":"bar"}');
+    expect(httpResponse.data).toEqual({foo: 'bar'});
+    expect(httpResponse.body).toEqual({foo: 'bar'});
+
     expect(result.text).toEqual('{"foo":"bar"}');
     expect(result.data).toEqual({foo: 'bar'});
     expect(result.body).toEqual({foo: 'bar'});
@@ -274,6 +284,9 @@ describe("httpRequest", () => {
 
   it('serialized httpResponse correctly with body buffer string', () => {
     let httpResponse = new HTTPResponse({}, new Buffer('hello'));
+    expect(httpResponse.text).toBe('hello');
+    expect(httpResponse.data).toBe(undefined);
+
     let serialized = JSON.stringify(httpResponse);
     let result = JSON.parse(serialized);
     expect(result.text).toBe('hello');
@@ -287,6 +300,23 @@ describe("httpRequest", () => {
     let result = JSON.parse(serialized);
     expect(result.text).toEqual('{"foo":"bar"}');
     expect(result.data).toEqual({foo: 'bar'});
+  });
+
+  it('serialized httpResponse with Parse._encode should be allright', () => {
+    let json = '{"foo":"bar"}';
+    let httpResponse = new HTTPResponse({}, new Buffer(json));
+    let encoded = Parse._encode(httpResponse);
+    let foundData, foundText = false;
+    for(var key in encoded) {
+      if (key == 'data') {
+        foundData = true;
+      }
+      if (key == 'text') {
+        foundText = true;
+      }
+    }
+    expect(foundData).toBe(true);
+    expect(foundText).toBe(true);
   });
 
 });

--- a/src/cloud-code/HTTPResponse.js
+++ b/src/cloud-code/HTTPResponse.js
@@ -18,6 +18,8 @@ export default class HTTPResponse {
   get text() {
     if (!this._text && this.buffer) {
       this._text = this.buffer.toString('utf-8');
+    } else if (!this._text && this._data) {
+      this._text = JSON.stringify(this._data);
     }
     return this._text;
   }
@@ -29,5 +31,14 @@ export default class HTTPResponse {
       } catch (e) {}
     }
     return this._data;
+  }
+
+  toJSON() {
+    let plainObject = Object.assign({}, this);
+    plainObject.text = this.text;
+    plainObject.data = this.data;
+    delete plainObject._text;
+    delete plainObject._data;
+    return plainObject;
   }
 }

--- a/src/cloud-code/HTTPResponse.js
+++ b/src/cloud-code/HTTPResponse.js
@@ -1,15 +1,27 @@
 
 export default class HTTPResponse {
-  constructor(response) {
+  constructor(response, body) {
     this.status = response.statusCode;
     this.headers = response.headers;
-    this.buffer = response.body;
     this.cookies = response.headers["set-cookie"];
+    
+    this.body = body;
+    if (typeof body == 'string') {
+      this._text = body;
+    } else if (Buffer.isBuffer(body)) {
+      this.buffer = body;
+    } else if (typeof body == 'object') {
+      this._data = body;
+    }
   }
   
   get text() {
-    return this.buffer.toString('utf-8');
+    if (!this._text && this.buffer) {
+      this._text = this.buffer.toString('utf-8');
+    }
+    return this._text;
   }
+
   get data() {
     if (!this._data) {
       try {

--- a/src/cloud-code/HTTPResponse.js
+++ b/src/cloud-code/HTTPResponse.js
@@ -1,44 +1,46 @@
 
 export default class HTTPResponse {
   constructor(response, body) {
+    let _text, _data;
     this.status = response.statusCode;
     this.headers = response.headers || {};
     this.cookies = this.headers["set-cookie"];
     
     this.body = body;
     if (typeof body == 'string') {
-      this._text = body;
+      _text = body;
     } else if (Buffer.isBuffer(body)) {
       this.buffer = body;
     } else if (typeof body == 'object') {
-      this._data = body;
+      _data = body;
     }
-  }
-  
-  get text() {
-    if (!this._text && this.buffer) {
-      this._text = this.buffer.toString('utf-8');
-    } else if (!this._text && this._data) {
-      this._text = JSON.stringify(this._data);
-    }
-    return this._text;
-  }
 
-  get data() {
-    if (!this._data) {
-      try {
-        this._data = JSON.parse(this.text);
-      } catch (e) {}
+    let getText = () => {
+      if (!_text && this.buffer) {
+          _text = this.buffer.toString('utf-8');
+        } else if (!_text && _data) {
+          _text = JSON.stringify(_data);
+        }
+        return _text; 
     }
-    return this._data;
-  }
 
-  toJSON() {
-    let plainObject = Object.assign({}, this);
-    plainObject.text = this.text;
-    plainObject.data = this.data;
-    delete plainObject._text;
-    delete plainObject._data;
-    return plainObject;
+    let getData = () => {
+      if (!_data) {
+          try {
+              _data = JSON.parse(getText());
+          } catch (e) {}
+        }
+        return _data;
+    }
+
+    Object.defineProperty(this, 'text', {
+      enumerable: true,
+      get: getText
+    });
+
+    Object.defineProperty(this, 'data', {
+      enumerable: true,
+      get: getData
+    });
   }
 }

--- a/src/cloud-code/HTTPResponse.js
+++ b/src/cloud-code/HTTPResponse.js
@@ -16,20 +16,20 @@ export default class HTTPResponse {
 
     let getText = () => {
       if (!_text && this.buffer) {
-          _text = this.buffer.toString('utf-8');
-        } else if (!_text && _data) {
-          _text = JSON.stringify(_data);
-        }
-        return _text; 
+        _text = this.buffer.toString('utf-8');
+      } else if (!_text && _data) {
+        _text = JSON.stringify(_data);
+      }
+      return _text; 
     }
 
     let getData = () => {
       if (!_data) {
-          try {
-              _data = JSON.parse(getText());
-          } catch (e) {}
-        }
-        return _data;
+        try {
+            _data = JSON.parse(getText());
+        } catch (e) {}
+      }
+      return _data;
     }
 
     Object.defineProperty(this, 'body', {

--- a/src/cloud-code/HTTPResponse.js
+++ b/src/cloud-code/HTTPResponse.js
@@ -2,8 +2,8 @@
 export default class HTTPResponse {
   constructor(response, body) {
     this.status = response.statusCode;
-    this.headers = response.headers;
-    this.cookies = response.headers["set-cookie"];
+    this.headers = response.headers || {};
+    this.cookies = this.headers["set-cookie"];
     
     this.body = body;
     if (typeof body == 'string') {

--- a/src/cloud-code/HTTPResponse.js
+++ b/src/cloud-code/HTTPResponse.js
@@ -5,8 +5,7 @@ export default class HTTPResponse {
     this.status = response.statusCode;
     this.headers = response.headers || {};
     this.cookies = this.headers["set-cookie"];
-    
-    this.body = body;
+
     if (typeof body == 'string') {
       _text = body;
     } else if (Buffer.isBuffer(body)) {
@@ -32,6 +31,10 @@ export default class HTTPResponse {
         }
         return _data;
     }
+
+    Object.defineProperty(this, 'body', {
+      get: () => { return body }
+    });
 
     Object.defineProperty(this, 'text', {
       enumerable: true,

--- a/src/cloud-code/httpRequest.js
+++ b/src/cloud-code/httpRequest.js
@@ -62,7 +62,7 @@ module.exports = function(options) {
       }
       return promise.reject(error);
     }
-    let httpResponse = new HTTPResponse(response);
+    let httpResponse = new HTTPResponse(response, body);
 
     // Consider <200 && >= 400 as errors
     if (httpResponse.status < 200 || httpResponse.status >= 400) {


### PR DESCRIPTION
Fixes #2033

response.body don't seem to be set in some cases, and was never specified in the node.js docs.

This change rely on the `body` parameter from the response callback.

Also, the getters have been replaced by ES5 definedProperty calls to make them enumerable so they play nice with serializers.
This change also does a bit of type inference in order to properly handle all body types (string, buffer and JSON)