### PR TITLE
Results invalid session when providing an invalid session token

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1589,7 +1589,7 @@ describe('Parse.User testing', () => {
       bob.setPassword('meower');
       return bob.save();
     }).then(() => {
-      return Parse.User.logIn('bob', 'meower');
+      return Parse.User.logIn('bob', 'meower');  
     }).then((bob) => {
       expect(bob.getUsername()).toEqual('bob');
       done();
@@ -2091,7 +2091,7 @@ describe('Parse.User testing', () => {
       fail('Save should have failed.');
       done();
     }, (e) => {
-      expect(e.code).toEqual(Parse.Error.SESSION_MISSING);
+      expect(e.code).toEqual(Parse.Error.INVALID_SESSION_TOKEN);
       done();
     });
   });
@@ -2118,6 +2118,26 @@ describe('Parse.User testing', () => {
           },
         }, (error, response, body) => {
           expect(body.results[0].expiresAt.__type).toEqual('Date');
+          done();
+        })
+      }
+    });
+  });
+
+  it("invalid session tokens are rejected", (done) => {
+    Parse.User.signUp("asdf", "zxcv", null, {
+      success: function(user) {
+        request.get({
+          url: 'http://localhost:8378/1/classes/AClass',
+          json: true,
+          headers: {
+            'X-Parse-Application-Id': 'test',
+            'X-Parse-Rest-API-Key': 'rest',
+            'X-Parse-Session-Token': 'text'
+          },
+        }, (error, response, body) => {
+          expect(body.code).toBe(209);
+          expect(body.error).toBe('invalid session token');
           done();
         })
       }
@@ -2374,7 +2394,7 @@ describe('Parse.User testing', () => {
         })
         .then(() => obj.fetch())
         .catch(error => {
-          expect(error.code).toEqual(Parse.Error.OBJECT_NOT_FOUND);
+          expect(error.code).toEqual(Parse.Error.INVALID_SESSION_TOKEN);
           done();
         });
       })

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -329,6 +329,14 @@ global.it_exclude_dbs = excluded => {
   }
 }
 
+global.fit_exclude_dbs = excluded => {
+  if (excluded.includes(process.env.PARSE_SERVER_TEST_DB)) {
+    return xit;
+  } else {
+    return fit;
+  }
+}
+
 // LiveQuery test setting
 require('../src/LiveQuery/PLog').logLevel = 'NONE';
 var libraryCache = {};

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -58,7 +58,7 @@ var getAuthForSessionToken = function({ config, sessionToken, installationId } =
     return query.execute().then((response) => {
       var results = response.results;
       if (results.length !== 1 || !results[0]['user']) {
-        return nobody(config);
+        throw new Parse.Error(Parse.Error.INVALID_SESSION_TOKEN, 'invalid session token');
       }
 
       var now = new Date(),

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -130,6 +130,10 @@ function handleParseHeaders(req, res, next) {
     return invalidRequest(req, res);
   }
 
+  if (req.url == "/login") {
+    delete info.sessionToken;
+  }
+
   if (!info.sessionToken) {
     req.auth = new auth.Auth({ config: req.config, installationId: info.installationId, isMaster: false });
     next();
@@ -219,6 +223,9 @@ var allowMethodOverride = function(req, res, next) {
 };
 
 var handleParseErrors = function(err, req, res, next) {
+  log.verbose(req.method, req.originalUrl.toString(), req.headers,
+                  JSON.stringify(req.body, null, 2));
+  log.verbose('error:', err);
   if (err instanceof Parse.Error) {
     var httpStatus;
 

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -223,9 +223,7 @@ var allowMethodOverride = function(req, res, next) {
 };
 
 var handleParseErrors = function(err, req, res, next) {
-  log.verbose(req.method, req.originalUrl.toString(), req.headers,
-                  JSON.stringify(req.body, null, 2));
-  log.verbose('error:', err);
+  // TODO: Add logging as those errors won't make it to the PromiseRouter
   if (err instanceof Parse.Error) {
     var httpStatus;
 


### PR DESCRIPTION
fixes #1605 

Originally, an invalid session token would be let go as a 'nobody' auth, this PR enforces that when an invalid session token is passed, the response should be an error.