### PR TITLE
Fix issue #2134: creating an anonymous user 

### DIFF
--- a/spec/RestCreate.spec.js
+++ b/spec/RestCreate.spec.js
@@ -114,11 +114,10 @@ describe('rest create', () => {
     };
     rest.create(config, auth.nobody(config), '_User', user)
       .then((r) => {
-        expect(Object.keys(r.response).length).toEqual(4);
+        expect(Object.keys(r.response).length).toEqual(3);
         expect(typeof r.response.objectId).toEqual('string');
         expect(typeof r.response.createdAt).toEqual('string');
         expect(typeof r.response.sessionToken).toEqual('string');
-        expect(typeof r.response.username).toEqual('string');
         done();
       });
   });

--- a/spec/RestCreate.spec.js
+++ b/spec/RestCreate.spec.js
@@ -320,11 +320,10 @@ describe('rest create', () => {
 
     rest.create(config, auth.nobody(config), '_User', user)
       .then((r) => {
-        expect(Object.keys(r.response).length).toEqual(4);
+        expect(Object.keys(r.response).length).toEqual(3);
         expect(typeof r.response.objectId).toEqual('string');
         expect(typeof r.response.createdAt).toEqual('string');
         expect(typeof r.response.sessionToken).toEqual('string');
-        expect(typeof r.response.username).toEqual('string');
         return rest.find(config, auth.master(config),
                           '_Session', {sessionToken: r.response.sessionToken});
       })
@@ -356,11 +355,10 @@ describe('rest create', () => {
 
     rest.create(config, auth.nobody(config), '_User', user)
       .then((r) => {
-        expect(Object.keys(r.response).length).toEqual(4);
+        expect(Object.keys(r.response).length).toEqual(3);
         expect(typeof r.response.objectId).toEqual('string');
         expect(typeof r.response.createdAt).toEqual('string');
         expect(typeof r.response.sessionToken).toEqual('string');
-        expect(typeof r.response.username).toEqual('string');
         return rest.find(config, auth.master(config),
                           '_Session', {sessionToken: r.response.sessionToken});
       })
@@ -391,11 +389,10 @@ describe('rest create', () => {
 
     rest.create(config, auth.nobody(config), '_User', user)
       .then((r) => {
-        expect(Object.keys(r.response).length).toEqual(4);
+        expect(Object.keys(r.response).length).toEqual(3);
         expect(typeof r.response.objectId).toEqual('string');
         expect(typeof r.response.createdAt).toEqual('string');
         expect(typeof r.response.sessionToken).toEqual('string');
-        expect(typeof r.response.username).toEqual('string');
         return rest.find(config, auth.master(config),
           '_Session', {sessionToken: r.response.sessionToken});
       })

--- a/spec/RestCreate.spec.js
+++ b/spec/RestCreate.spec.js
@@ -114,10 +114,11 @@ describe('rest create', () => {
     };
     rest.create(config, auth.nobody(config), '_User', user)
       .then((r) => {
-        expect(Object.keys(r.response).length).toEqual(3);
+        expect(Object.keys(r.response).length).toEqual(4);
         expect(typeof r.response.objectId).toEqual('string');
         expect(typeof r.response.createdAt).toEqual('string');
         expect(typeof r.response.sessionToken).toEqual('string');
+        expect(typeof r.response.username).toEqual('string');
         done();
       });
   });
@@ -143,6 +144,7 @@ describe('rest create', () => {
         expect(typeof r.response.objectId).toEqual('string');
         expect(typeof r.response.createdAt).toEqual('string');
         expect(typeof r.response.sessionToken).toEqual('string');
+        expect(typeof r.response.username).toEqual('string');
         return rest.create(config, auth.nobody(config), '_User', data1);
       }).then((r) => {
         expect(typeof r.response.objectId).toEqual('string');
@@ -319,10 +321,11 @@ describe('rest create', () => {
 
     rest.create(config, auth.nobody(config), '_User', user)
       .then((r) => {
-        expect(Object.keys(r.response).length).toEqual(3);
+        expect(Object.keys(r.response).length).toEqual(4);
         expect(typeof r.response.objectId).toEqual('string');
         expect(typeof r.response.createdAt).toEqual('string');
         expect(typeof r.response.sessionToken).toEqual('string');
+        expect(typeof r.response.username).toEqual('string');
         return rest.find(config, auth.master(config),
                           '_Session', {sessionToken: r.response.sessionToken});
       })
@@ -354,10 +357,11 @@ describe('rest create', () => {
 
     rest.create(config, auth.nobody(config), '_User', user)
       .then((r) => {
-        expect(Object.keys(r.response).length).toEqual(3);
+        expect(Object.keys(r.response).length).toEqual(4);
         expect(typeof r.response.objectId).toEqual('string');
         expect(typeof r.response.createdAt).toEqual('string');
         expect(typeof r.response.sessionToken).toEqual('string');
+        expect(typeof r.response.username).toEqual('string');
         return rest.find(config, auth.master(config),
                           '_Session', {sessionToken: r.response.sessionToken});
       })
@@ -388,10 +392,11 @@ describe('rest create', () => {
 
     rest.create(config, auth.nobody(config), '_User', user)
       .then((r) => {
-        expect(Object.keys(r.response).length).toEqual(3);
+        expect(Object.keys(r.response).length).toEqual(4);
         expect(typeof r.response.objectId).toEqual('string');
         expect(typeof r.response.createdAt).toEqual('string');
         expect(typeof r.response.sessionToken).toEqual('string');
+        expect(typeof r.response.username).toEqual('string');
         return rest.find(config, auth.master(config),
           '_Session', {sessionToken: r.response.sessionToken});
       })

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -351,7 +351,7 @@ RestWrite.prototype.transformUser = function() {
     if (!this.data.username) {
       if (!this.query) {
         this.data.username = cryptoUtils.randomString(25);
-        this.hasUserNameGen = true;
+        this.responseShouldHaveUsername = true;
       }
       return;
     }
@@ -792,9 +792,9 @@ RestWrite.prototype.runDatabaseOperation = function() {
       response.objectId = this.data.objectId;
       response.createdAt = this.data.createdAt;
       
-      if (this.hasUserNameGen)
+      if (this.responseShouldHaveUsername) {
         response.username = this.data.username;
-      	
+      }
       if (this.storage.changedByTrigger) {
         Object.keys(this.data).forEach(fieldName => {
           response[fieldName] = response[fieldName] || this.data[fieldName];

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -351,6 +351,7 @@ RestWrite.prototype.transformUser = function() {
     if (!this.data.username) {
       if (!this.query) {
         this.data.username = cryptoUtils.randomString(25);
+        this.hasUserNameGen = true;
       }
       return;
     }
@@ -791,7 +792,7 @@ RestWrite.prototype.runDatabaseOperation = function() {
       response.objectId = this.data.objectId;
       response.createdAt = this.data.createdAt;
       
-      if (!this.query && this.className === '_User' && this.data.username)
+      if (this.hasUserNameGen)
         response.username = this.data.username;
       	
       if (this.storage.changedByTrigger) {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -790,6 +790,10 @@ RestWrite.prototype.runDatabaseOperation = function() {
     .then(response => {
       response.objectId = this.data.objectId;
       response.createdAt = this.data.createdAt;
+      
+      if (!this.query && this.className === '_User' && this.data.username)
+        response.username = this.data.username;
+      	
       if (this.storage.changedByTrigger) {
         Object.keys(this.data).forEach(fieldName => {
           response[fieldName] = response[fieldName] || this.data[fieldName];


### PR DESCRIPTION
It seems to me issue #2134 is a bug (Parse Documentation (https://parse.com/docs/rest/guide#users-linking). Parse server should return the generated username when an anonymous user signs up. This PR is an attempt to resolve the issue. 