### PR TITLE
Stop requiring verifyUserEmails for password reset functionality

### DIFF
--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -238,10 +238,10 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
     });
   });
 
-  it_exclude_dbs(['postgres'])('fails if you include an emailAdapter, set verifyUserEmails to false, dont set a publicServerURL, and try to send a password reset email (regression test for #1649)', done => {
+  it_exclude_dbs(['postgres'])('fails if you include an emailAdapter, set a publicServerURL, but have no appName and send a password reset email', done => {
     reconfigureServer({
-      appName: 'unused',
-      verifyUserEmails: false,
+      appName: undefined,
+      publicServerURL: 'http://localhost:1337/1',
       emailAdapter: MockEmailAdapterWithOptions({
         fromAddress: 'parse@example.com',
         apiKey: 'k',
@@ -278,6 +278,7 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
     }
     reconfigureServer({
       appName: 'unused',
+      publicServerURL: 'http://localhost:1337/1',
       verifyUserEmails: false,
       emailAdapter: emailAdapter,
     })

--- a/src/Config.js
+++ b/src/Config.js
@@ -56,17 +56,17 @@ export class Config {
 
   static validate({
     verifyUserEmails,
+    userController,
     appName,
     publicServerURL,
     revokeSessionOnPasswordReset,
     expireInactiveSessions,
     sessionLength,
   }) {
-    this.validateEmailConfiguration({
-      verifyUserEmails: verifyUserEmails,
-      appName: appName,
-      publicServerURL: publicServerURL
-    })
+    const emailAdapter = userController.adapter;
+    if (verifyUserEmails) {
+      this.validateEmailConfiguration({emailAdapter, appName, publicServerURL});
+    }
 
     if (typeof revokeSessionOnPasswordReset !== 'boolean') {
       throw 'revokeSessionOnPasswordReset must be a boolean value';
@@ -81,13 +81,13 @@ export class Config {
     this.validateSessionConfiguration(sessionLength, expireInactiveSessions);
   }
 
-  static validateEmailConfiguration({verifyUserEmails, appName, publicServerURL}) {
-    if (verifyUserEmails) {
+  static validateEmailConfiguration({emailAdapter, appName, publicServerURL}) {
+    if (emailAdapter) {
       if (typeof appName !== 'string') {
-        throw 'An app name is required when using email verification.';
+        throw 'An app name is required for e-mail verification and password resets.';
       }
       if (typeof publicServerURL !== 'string') {
-        throw 'A public server url is required when using email verification.';
+        throw 'A public server url is required for e-mail verification and password resets.';
       }
     }
   }

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -158,7 +158,7 @@ export class UsersRouter extends ClassesRouter {
   handleResetRequest(req) {
     try {
       Config.validateEmailConfiguration({
-        verifyUserEmails: true, //A bit of a hack, as this isn't the intended purpose of this parameter
+        emailAdapter: req.config.userController,
         appName: req.config.appName,
         publicServerURL: req.config.publicServerURL,
       });


### PR DESCRIPTION
This patch allows password reset to work without requiring `verifyUserEmails` be true.

Currently, parse-server users verifyUserEmails within `Config.validateEmailConfiguration()` as a proxy for determining if an e-mail adapter was provided. That is not so great as verification of user e-mails should not be required for other e-mail based functionality to work.

Additionally this removes a hack and actually fixes the root cause of the bug in #1649 where we must verify that that `appName` is set for e-mail functionality to work. The spirit of the regression test for #1649 should be to check if appName is not set and fail instead of simply checking if verifyUserEmails is true.

Background: Our application uses password reset extensively but has a sign up flow that does not involve e-mail at all. It is imperative to us that password reset work without verifyUserEmails being set to true.
