### PR TITLE
Write all ACL formats and make sure old ACLs in mongodb are overwritten

### DIFF
--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -32,13 +32,20 @@ const transformObjectACL = ({ ACL, ...result }) => {
 
   result._wperm = [];
   result._rperm = [];
+  result._acl = {};
 
   for (let entry in ACL) {
+    let aclObj = {};
     if (ACL[entry].read) {
       result._rperm.push(entry);
+      aclObj.r = true;
     }
     if (ACL[entry].write) {
       result._wperm.push(entry);
+      aclObj.w = true;
+    }
+    if (aclObj.r || aclObj.w) {
+      result._acl[entry] = aclObj;
     }
   }
   return result;


### PR DESCRIPTION
This PR addresses the problem that occurs when pre-existing rows that had ACLs written in the old format when assigned new ACLs and saved.

In this situation, the old format ACLs would be preserved while the new ACLs were written. This behavior is not good, because the old ACLs should be reset. As a result of the old ACLs not being reset, problems would occur, like the parse dashboard displaying `Public Read Write` for a row even when the ACL for that row was updated. 

With this pull request, I make sure to still write the old format properly so that discrepancies between the old and new format ACLs don't exist in the data as a result of updating a row.