### PR TITLE
Improve error message for Parse.Error.INCORRECT_TYPE failure condition

### DIFF
--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -518,7 +518,7 @@ class SchemaController {
         if (!dbTypeMatchesObjectType(expectedType, type)) {
           throw new Parse.Error(
             Parse.Error.INCORRECT_TYPE,
-            `schema mismatch for ${className}.${fieldName}; expected ${expectedType.type || expectedType} but got ${type}`
+            `schema mismatch for ${className}.${fieldName}; expected ${expectedType.type || expectedType} but got ${type.type}`
           );
         }
       }


### PR DESCRIPTION
Currently, the error message looks like the following, which needs improvement.

```schema mismatch for _User.nebulousDataType; expected Number but got [object Object]```