### PR TITLE
Let auth data be updated on login

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -1466,7 +1466,7 @@ describe('Parse.User testing', () => {
     });
   });
 
-  fit_exclude_dbs(['postgres'])("link multiple providers and updates token", (done) => {
+  it_exclude_dbs(['postgres'])("link multiple providers and updates token", (done) => {
     var provider = getMockFacebookProvider();
     var secondProvider = getMockFacebookProviderWithIdToken('8675309', 'jenny_valid_token');
 

--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -907,13 +907,11 @@ describe('Parse.User testing', () => {
     }));
   });
 
-  // Note that this mocks out client-side Facebook action rather than
-  // server-side.
-  var getMockFacebookProvider = function() {
+  var getMockFacebookProviderWithIdToken = function(id, token) {
     return {
       authData: {
-        id: "8675309",
-        access_token: "jenny",
+        id: id,
+        access_token: token,
         expiration_date: new Date().toJSON(),
       },
       shouldError: false,
@@ -951,6 +949,12 @@ describe('Parse.User testing', () => {
         this.restoreAuthentication(null);
       }
     };
+  }
+
+  // Note that this mocks out client-side Facebook action rather than
+  // server-side.
+  var getMockFacebookProvider = function() {
+    return getMockFacebookProviderWithIdToken('8675309', 'jenny');
   };
 
   var getMockMyOauthProvider = function() {
@@ -1022,6 +1026,40 @@ describe('Parse.User testing', () => {
         ok(false, "linking should have worked");
         done();
       }
+    });
+  });
+
+  it_exclude_dbs(['postgres'])("log in with provider and update token", (done) => {
+    var provider = getMockFacebookProvider();
+    var secondProvider = getMockFacebookProviderWithIdToken('8675309', 'jenny_valid_token');
+    var errorHandler = function(err) {
+      fail('should not fail');
+      done();
+    }
+    Parse.User._registerAuthenticationProvider(provider);
+    Parse.User._logInWith("facebook", {
+      success: (model) => {
+        Parse.User._registerAuthenticationProvider(secondProvider);
+        return Parse.User.logOut().then(() => {
+          Parse.User._logInWith("facebook", {
+            success: (model) => {
+              expect(secondProvider.synchronizedAuthToken).toEqual('jenny_valid_token');
+              // Make sure we can login with the new token again
+              Parse.User.logOut().then(() => {
+                Parse.User._logInWith("facebook", {
+                  success: done,
+                  error: errorHandler
+                });
+              });
+            },
+            error: errorHandler
+          });
+        })
+      },
+      error: errorHandler
+    }).catch((err) => {
+      errorHandler(err);
+      done();
     });
   });
 

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -281,23 +281,27 @@ function range(n) {
   return answer;
 }
 
-function mockFacebook() {
+function mockFacebookAuthenticator(id, token) {
   var facebook = {};
   facebook.validateAuthData = function(authData) {
-    if (authData.id === '8675309' && authData.access_token === 'jenny') {
+    if (authData.id === id && authData.access_token.startsWith(token)) {
       return Promise.resolve();
     } else {
       throw undefined;
     }
   };
   facebook.validateAppId = function(appId, authData) {
-    if (authData.access_token === 'jenny') {
+    if (authData.access_token.startsWith(token)) {
       return Promise.resolve();
     } else {
       throw undefined;
     }
   };
   return facebook;
+}
+
+function mockFacebook() {
+  return mockFacebookAuthenticator('8675309', 'jenny');
 }
 
 
@@ -320,6 +324,7 @@ global.jequal = jequal;
 global.range = range;
 global.reconfigureServer = reconfigureServer;
 global.defaultConfiguration = defaultConfiguration;
+global.mockFacebookAuthenticator = mockFacebookAuthenticator;
 
 global.it_exclude_dbs = excluded => {
   if (excluded.includes(process.env.PARSE_SERVER_TEST_DB)) {


### PR DESCRIPTION
This proposal will let user auth data to be updated when a valid token is provided with a different expiration time for the same authData.id.

Fixes #1947
Fixes #1735
Fixes #1455

Probably fixes other issues as well.