### PR TITLE
Adding amazon ses adapter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ You can also use other email adapters contributed by the community such as:
 - [parse-server-postmark-adapter](https://www.npmjs.com/package/parse-server-postmark-adapter)
 - [parse-server-sendgrid-adapter](https://www.npmjs.com/package/parse-server-sendgrid-adapter)
 - [parse-server-mandrill-adapter](https://www.npmjs.com/package/parse-server-mandrill-adapter)
+- [parse-server-simple-ses-adapter](https://www.npmjs.com/package/parse-server-simple-ses-adapter)
 
 ### Using environment variables to configure Parse Server
 


### PR DESCRIPTION
We've been using this parse server amazon SES email adapter and would like to share with the rest of the community.