### PR TITLE
Allow next middleware handle error in handleParseErrors

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -250,6 +250,7 @@ var handleParseErrors = function(err, req, res, next) {
     res.json({code: Parse.Error.INTERNAL_SERVER_ERROR,
               message: 'Internal server error.'});
   }
+  next(err);
 };
 
 function enforceMasterKeyAccess(req, res, next) {


### PR DESCRIPTION
I think it's a good idea to allow next middlewares to handle errors. Fox example I would love to report errors from parse-server to (for example) Rollbar. But unfortunately they're handled in `handleParseErrors` function already (I think `'Uncaught internal server error.'` message is unfortunate in this case...). This would allow me to use another error handler in my application. It won't change a thing in parse-server logic and I (and others) would be pleased to have it.