### PR TITLE
Creates a new sessionToken when updating password

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -2262,7 +2262,9 @@ describe('Parse.User testing', () => {
       req.object.set('foo', 'bar');
       res.success();
     });
-
+    
+    let originalSessionToken;
+    let originalUserId;
     // Simulate anonymous user save
     new Promise((resolve, reject) => {
       request.post({
@@ -2280,6 +2282,8 @@ describe('Parse.User testing', () => {
         }
       });
     }).then((user) => {
+      originalSessionToken = user.sessionToken;
+      originalUserId = user.objectId;
       // Simulate registration
       return new Promise((resolve, reject) => {
         request.put({
@@ -2291,7 +2295,7 @@ describe('Parse.User testing', () => {
           },
           json: {
             authData: {anonymous: null},
-            user: 'user',
+            username: 'user',
             password: 'password',
           }
         }, (err, res, body) => {
@@ -2305,7 +2309,30 @@ describe('Parse.User testing', () => {
     }).then((user) => {
       expect(typeof user).toEqual('object');
       expect(user.authData).toBeUndefined();
-      done();
+      expect(user.sessionToken).not.toBeUndefined();
+      // Session token should have changed
+      expect(user.sessionToken).not.toEqual(originalSessionToken);
+      // test that the sessionToken is valid
+      return new Promise((resolve, reject) => {
+        request.get({
+          url: 'http://localhost:8378/1/users/me',
+          headers: {
+            'X-Parse-Application-Id': Parse.applicationId,
+            'X-Parse-Session-Token': user.sessionToken,
+            'X-Parse-REST-API-Key': 'rest',
+          },
+          json: true
+        }, (err, res, body) => {
+          expect(body.username).toEqual(user.username);
+          expect(body.objectId).toEqual(originalUserId);
+          if (err) {
+            reject(err);
+          } else {
+            resolve(body);
+          }
+          done();
+        });
+      });
     }).catch((err) => {
       fail('no request should fail: ' + JSON.stringify(err));
       done();
@@ -2471,9 +2498,16 @@ describe('Parse.User testing', () => {
           user.set('password', 'password');
           return user.save()
         })
+        .then(() => {
+          // Session token should have been recycled
+          expect(body.sessionToken).not.toEqual(user.getSessionToken());
+        })
         .then(() => obj.fetch())
+        .then((res) => {
+          done();
+        })
         .catch(error => {
-          expect(error.code).toEqual(Parse.Error.INVALID_SESSION_TOKEN);
+          fail('should not fail')
           done();
         });
       })


### PR DESCRIPTION
When upgrading a user from anonymous to username/password the original implementation would force the client to call login in order to generate a session token.

This PR attempts to fix that problem by generating a new session token after clearing the sessions.

Fixes #2252 