### PR TITLE
Adds schema caching capabilities (5s by default)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
   - MONGODB_VERSION=2.6.11
   - MONGODB_VERSION=3.0.8
   - MONGODB_VERSION=3.2.6
-  - MONGODB_VERSION=3.2.6 TEST_SCHEMA_CACHE=3600
 matrix:
   fast_finish: true,
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - MONGODB_VERSION=2.6.11
   - MONGODB_VERSION=3.0.8
   - MONGODB_VERSION=3.2.6
+  - MONGODB_VERSION=3.2.6 TEST_SCHEMA_CACHE=3600
 matrix:
   fast_finish: true,
 branches:

--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -9,8 +9,8 @@ let Parse = require('parse/node').Parse;
 let rest = require('../src/rest');
 let request = require("request");
 
-let config = new Config('test');
-let database = config.database;
+let config;
+let database;
 let defaultColumns = require('../src/Controllers/SchemaController').defaultColumns;
 
 const installationSchema = { fields: Object.assign({}, defaultColumns._Default, defaultColumns._Installation) };
@@ -18,7 +18,8 @@ const installationSchema = { fields: Object.assign({}, defaultColumns._Default, 
 describe('Installations', () => {
 
   beforeEach(() => {
-    config.database.schemaCache.clear();
+    config = new Config('test');
+    database = config.database;
   });
 
   it_exclude_dbs(['postgres'])('creates an android installation with ids', (done) => {

--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -18,7 +18,7 @@ const installationSchema = { fields: Object.assign({}, defaultColumns._Default, 
 describe('Installations', () => {
 
   beforeEach(() => {
-    config.database.schemaCache.reset();
+    config.database.schemaCache.clear();
   });
 
   it_exclude_dbs(['postgres'])('creates an android installation with ids', (done) => {

--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -16,6 +16,11 @@ let defaultColumns = require('../src/Controllers/SchemaController').defaultColum
 const installationSchema = { fields: Object.assign({}, defaultColumns._Default, defaultColumns._Installation) };
 
 describe('Installations', () => {
+
+  beforeEach(() => {
+    config.database.schemaCache.reset();
+  });
+
   it_exclude_dbs(['postgres'])('creates an android installation with ids', (done) => {
     var installId = '12345678-abcd-abcd-abcd-123456789abc';
     var device = 'android';

--- a/spec/PointerPermissions.spec.js
+++ b/spec/PointerPermissions.spec.js
@@ -6,7 +6,7 @@ var Config = require('../src/Config');
 describe('Pointer Permissions', () => {
 
   beforeEach(() => {
-    new Config(Parse.applicationId).database.schemaCache.reset();
+    new Config(Parse.applicationId).database.schemaCache.clear();
   });
 
   it_exclude_dbs(['postgres'])('should work with find', (done) => {

--- a/spec/PointerPermissions.spec.js
+++ b/spec/PointerPermissions.spec.js
@@ -4,6 +4,11 @@ var Schema = require('../src/Controllers/SchemaController');
 var Config = require('../src/Config');
 
 describe('Pointer Permissions', () => {
+
+  beforeEach(() => {
+    new Config(Parse.applicationId).database.schemaCache.reset();
+  });
+
   it_exclude_dbs(['postgres'])('should work with find', (done) => {
     let config = new Config(Parse.applicationId);
     let user = new Parse.User();

--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -9,11 +9,17 @@ var querystring = require('querystring');
 var request = require('request');
 var rp = require('request-promise');
 
-var config = new Config('test');
-let database = config.database;
+var config;
+let database;
 var nobody = auth.nobody(config);
 
 describe('rest query', () => {
+
+  beforeEach(() => {
+    config = new Config('test');
+    database = config.database;
+  });
+
   it('basic query', (done) => {
     rest.create(config, nobody, 'TestObject', {}).then(() => {
       return rest.find(config, nobody, 'TestObject', {});

--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -21,7 +21,7 @@ var hasAllPODobject = () => {
 
 describe('SchemaController', () => {
   beforeEach(() => {
-    config.database.schemaCache.reset();
+    config.database.schemaCache.clear();
   });
 
   it('can validate one object', (done) => {

--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -20,6 +20,10 @@ var hasAllPODobject = () => {
 };
 
 describe('SchemaController', () => {
+  beforeEach(() => {
+    config.database.schemaCache.reset();
+  });
+
   it('can validate one object', (done) => {
     config.database.loadSchema().then((schema) => {
       return schema.validateObject('TestObject', {a: 1, b: 'yo', c: false});

--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -4,7 +4,7 @@ var Config = require('../src/Config');
 var SchemaController = require('../src/Controllers/SchemaController');
 var dd = require('deep-diff');
 
-var config = new Config('test');
+var config;
 
 var hasAllPODobject = () => {
   var obj = new Parse.Object('HasAllPOD');
@@ -21,7 +21,7 @@ var hasAllPODobject = () => {
 
 describe('SchemaController', () => {
   beforeEach(() => {
-    config.database.schemaCache.clear();
+    config = new Config('test');
   });
 
   it('can validate one object', (done) => {

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -60,6 +60,7 @@ var defaultConfiguration = {
       module: path.resolve(__dirname, "myoauth") // relative path as it's run from src
     }
   },
+  schemaCacheTTL: process.env.TEST_SCHEMA_CACHE || 0
 };
 
 let openConnections = {};

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -59,8 +59,7 @@ var defaultConfiguration = {
     myoauth: {
       module: path.resolve(__dirname, "myoauth") // relative path as it's run from src
     }
-  },
-  schemaCacheTTL: process.env.TEST_SCHEMA_CACHE || 0
+  }
 };
 
 let openConnections = {};

--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -118,8 +118,8 @@ var masterKeyHeaders = {
 describe('schemas', () => {
 
   beforeEach(() => {
-     config.database.schemaCache.reset();
-  })
+     config.database.schemaCache.clear();
+  });
 
   it('requires the master key to get all schemas', (done) => {
     request.get({

--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -116,6 +116,11 @@ var masterKeyHeaders = {
 };
 
 describe('schemas', () => {
+
+  beforeEach(() => {
+     config.database.schemaCache.reset();
+  })
+
   it('requires the master key to get all schemas', (done) => {
     request.get({
       url: 'http://localhost:8378/1/schemas',

--- a/src/Config.js
+++ b/src/Config.js
@@ -37,8 +37,11 @@ export class Config {
 
     // Create a new DatabaseController per request
     if (cacheInfo.databaseController) {
-      this.database = new DatabaseController(cacheInfo.databaseController.adapter, cacheInfo.createSchemaCache());
+      const schemaCache = new SchemaCache(cacheInfo.cacheController, cacheInfo.schemaCacheTTL);
+      this.database = new DatabaseController(cacheInfo.databaseController.adapter, schemaCache);
     }
+
+    this.schemaCacheTTL = cacheInfo.schemaCacheTTL;
 
     this.serverURL = cacheInfo.serverURL;
     this.publicServerURL = removeTrailingSlash(cacheInfo.publicServerURL);

--- a/src/Config.js
+++ b/src/Config.js
@@ -37,7 +37,7 @@ export class Config {
 
     // Create a new DatabaseController per request
     if (cacheInfo.databaseController) {
-      this.database = new DatabaseController(cacheInfo.databaseController.adapter, new SchemaCache(cacheInfo.schemaCacheTTL));
+      this.database = new DatabaseController(cacheInfo.databaseController.adapter, cacheInfo.createSchemaCache());
     }
 
     this.serverURL = cacheInfo.serverURL;

--- a/src/Config.js
+++ b/src/Config.js
@@ -37,7 +37,7 @@ export class Config {
 
     // Create a new DatabaseController per request
     if (cacheInfo.databaseController) {
-      this.database = new DatabaseController(cacheInfo.databaseController.adapter, new SchemaCache(applicationId, cacheInfo.schemaCacheTTL));
+      this.database = new DatabaseController(cacheInfo.databaseController.adapter, new SchemaCache(cacheInfo.schemaCacheTTL));
     }
 
     this.serverURL = cacheInfo.serverURL;

--- a/src/Config.js
+++ b/src/Config.js
@@ -3,6 +3,8 @@
 // mount is the URL for the root of the API; includes http, domain, etc.
 
 import AppCache from './cache';
+import SchemaCache from './Controllers/SchemaCache';
+import DatabaseController from './Controllers/DatabaseController';
 
 function removeTrailingSlash(str) {
   if (!str) {
@@ -32,7 +34,11 @@ export class Config {
     this.fileKey = cacheInfo.fileKey;
     this.facebookAppIds = cacheInfo.facebookAppIds;
     this.allowClientClassCreation = cacheInfo.allowClientClassCreation;
-    this.database = cacheInfo.databaseController;
+
+    // Create a new DatabaseController per request
+    if (cacheInfo.databaseController) {
+      this.database = new DatabaseController(cacheInfo.databaseController.adapter, new SchemaCache(applicationId, cacheInfo.schemaCacheTTL));
+    }
 
     this.serverURL = cacheInfo.serverURL;
     this.publicServerURL = removeTrailingSlash(cacheInfo.publicServerURL);

--- a/src/Controllers/CacheController.js
+++ b/src/Controllers/CacheController.js
@@ -13,9 +13,10 @@ function joinKeys(...keys) {
  * eg "Role" or "Session"
  */
 export class SubCache {
-  constructor(prefix, cacheController) {
+  constructor(prefix, cacheController, ttl) {
     this.prefix = prefix;
     this.cache = cacheController;
+    this.ttl = ttl;
   }
 
   get(key) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -8,7 +8,6 @@ var mongodb = require('mongodb');
 var Parse = require('parse/node').Parse;
 
 var SchemaController = require('./SchemaController');
-import SchemaCache from './SchemaCache';
 
 const deepcopy = require('deepcopy');
 

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -7,7 +7,9 @@ import _         from 'lodash';
 var mongodb = require('mongodb');
 var Parse = require('parse/node').Parse;
 
-var SchemaController = require('../Controllers/SchemaController');
+var SchemaController = require('./SchemaController');
+import SchemaCache from './SchemaCache';
+
 const deepcopy = require('deepcopy');
 
 function addWriteACL(query, acl) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -80,9 +80,9 @@ const validateQuery = query => {
   });
 }
 
-function DatabaseController(adapter) {
+function DatabaseController(adapter, schemaCache) {
   this.adapter = adapter;
-
+  this.schemaCache = schemaCache;
   // We don't want a mutable this.schema, because then you could have
   // one request that uses different schemas for different parts of
   // it. Instead, use loadSchema to get a schema.
@@ -107,9 +107,9 @@ DatabaseController.prototype.validateClassName = function(className) {
 };
 
 // Returns a promise for a schemaController.
-DatabaseController.prototype.loadSchema = function() {
+DatabaseController.prototype.loadSchema = function(force = false) {
   if (!this.schemaPromise) {
-    this.schemaPromise = SchemaController.load(this.adapter);
+    this.schemaPromise = SchemaController.load(this.adapter, this.schemaCache, force);
     this.schemaPromise.then(() => delete this.schemaPromise,
                              () => delete this.schemaPromise);
   }
@@ -805,8 +805,8 @@ const untransformObjectACL = ({_rperm, _wperm, ...output}) => {
 }
 
 DatabaseController.prototype.deleteSchema = function(className) {
-  return this.loadSchema()
-  .then(schemaController => schemaController.getOneSchema(className))
+  return this.loadSchema(true)
+  .then(schemaController => schemaController.getOneSchema(className, true))
   .catch(error => {
     if (error === undefined) {
       return { fields: {} };

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -109,9 +109,9 @@ DatabaseController.prototype.validateClassName = function(className) {
 };
 
 // Returns a promise for a schemaController.
-DatabaseController.prototype.loadSchema = function(force = false) {
+DatabaseController.prototype.loadSchema = function(options = {clearCache: false}) {
   if (!this.schemaPromise) {
-    this.schemaPromise = SchemaController.load(this.adapter, this.schemaCache, force);
+    this.schemaPromise = SchemaController.load(this.adapter, this.schemaCache, options);
     this.schemaPromise.then(() => delete this.schemaPromise,
                              () => delete this.schemaPromise);
   }

--- a/src/Controllers/SchemaCache.js
+++ b/src/Controllers/SchemaCache.js
@@ -10,28 +10,28 @@ export default class SchemaCache {
 }
 
   getAllClasses() {
-    if (this.ttl <= 0) {
+    if (!this.ttl) {
       return Promise.resolve(null);
     }
     return this.cache.get(SCHEMA_CACHE_PREFIX+MAIN_SCHEMA);
   }
 
   setAllClasses(schema) {
-    if (this.ttl <= 0) {
+    if (!this.ttl) {
       return Promise.resolve(null);
     }
     this.cache.put(SCHEMA_CACHE_PREFIX+MAIN_SCHEMA, schema, this.ttl);
   }
 
   setOneSchema(className, schema) {
-    if (this.ttl <= 0) {
+    if (!this.ttl) {
       return Promise.resolve(null);
     }
     this.cache.put(SCHEMA_CACHE_PREFIX+className, schema, this.ttl);
   }
 
   getOneSchema(className) {
-    if (this.ttl <= 0) {
+    if (!this.ttl) {
       return Promise.resolve(null);
     }
     return this.cache.get(SCHEMA_CACHE_PREFIX+className);

--- a/src/Controllers/SchemaCache.js
+++ b/src/Controllers/SchemaCache.js
@@ -1,14 +1,12 @@
-import { InMemoryCacheAdapter } from '../Adapters/Cache/InMemoryCacheAdapter';
-
 const CACHED_KEYS = "__CACHED_KEYS";
 const MAIN_SCHEMA = "__MAIN_SCHEMA";
 const SCHEMA_CACHE_PREFIX = "__SCHEMA";
 export default class SchemaCache {
   cache: Object;
 
-  constructor(ttl) {
+  constructor(adapter, ttl) {
     this.ttl = ttl;
-    this.cache = new InMemoryCacheAdapter({ ttl });
+    this.cache = adapter;
 }
 
   getAllClasses() {

--- a/src/Controllers/SchemaCache.js
+++ b/src/Controllers/SchemaCache.js
@@ -1,0 +1,50 @@
+import Parse from 'parse/node';
+import LRU from 'lru-cache';
+
+let MAIN_SCHEMA = "__MAIN_SCHEMA";
+
+export default class SchemaCache {
+  cache: Object;
+
+  constructor(appId: string, timeout: number = 0, maxSize: number = 10000) {
+    this.appId = appId;
+    this.timeout = timeout;
+    this.maxSize = maxSize;
+    this.cache = new LRU({
+      max: maxSize,
+      maxAge: timeout
+    });
+  }
+
+  get() {
+    if (this.timeout <= 0) {
+      return;
+    }
+    return this.cache.get(this.appId+MAIN_SCHEMA);
+  }
+
+  set(schema) {
+    if (this.timeout <= 0) {
+      return;
+    }
+    this.cache.set(this.appId+MAIN_SCHEMA, schema);
+  }
+
+  setOneSchema(className, schema) {
+    if (this.timeout <= 0) {
+      return;
+    }
+     this.cache.set(this.appId+className, schema);
+  }
+
+  getOneSchema(className) {
+    if (this.timeout <= 0) {
+      return;
+    }
+    return this.cache.get(this.appId+className);
+  }
+
+  reset() {
+    this.cache.reset();
+  }
+}

--- a/src/Controllers/SchemaCache.js
+++ b/src/Controllers/SchemaCache.js
@@ -1,6 +1,6 @@
-const CACHED_KEYS = "__CACHED_KEYS";
 const MAIN_SCHEMA = "__MAIN_SCHEMA";
 const SCHEMA_CACHE_PREFIX = "__SCHEMA";
+
 export default class SchemaCache {
   cache: Object;
 

--- a/src/Controllers/SchemaCache.js
+++ b/src/Controllers/SchemaCache.js
@@ -11,28 +11,28 @@ export default class SchemaCache {
 
   getAllClasses() {
     if (this.ttl <= 0) {
-      return;
+      return Promise.resolve(null);
     }
     return this.cache.get(SCHEMA_CACHE_PREFIX+MAIN_SCHEMA);
   }
 
   setAllClasses(schema) {
     if (this.ttl <= 0) {
-      return;
+      return Promise.resolve(null);
     }
     this.cache.put(SCHEMA_CACHE_PREFIX+MAIN_SCHEMA, schema, this.ttl);
   }
 
   setOneSchema(className, schema) {
     if (this.ttl <= 0) {
-      return;
+      return Promise.resolve(null);
     }
     this.cache.put(SCHEMA_CACHE_PREFIX+className, schema, this.ttl);
   }
 
   getOneSchema(className) {
     if (this.ttl <= 0) {
-      return;
+      return Promise.resolve(null);
     }
     return this.cache.get(SCHEMA_CACHE_PREFIX+className);
   }

--- a/src/Controllers/SchemaCache.js
+++ b/src/Controllers/SchemaCache.js
@@ -1,50 +1,46 @@
-import Parse from 'parse/node';
-import LRU from 'lru-cache';
+import { InMemoryCacheAdapter } from '../Adapters/Cache/InMemoryCacheAdapter';
 
-let MAIN_SCHEMA = "__MAIN_SCHEMA";
-
+const CACHED_KEYS = "__CACHED_KEYS";
+const MAIN_SCHEMA = "__MAIN_SCHEMA";
+const SCHEMA_CACHE_PREFIX = "__SCHEMA";
 export default class SchemaCache {
   cache: Object;
 
-  constructor(appId: string, timeout: number = 0, maxSize: number = 10000) {
-    this.appId = appId;
-    this.timeout = timeout;
-    this.maxSize = maxSize;
-    this.cache = new LRU({
-      max: maxSize,
-      maxAge: timeout
-    });
-  }
+  constructor(ttl) {
+    this.ttl = ttl;
+    this.cache = new InMemoryCacheAdapter({ ttl });
+}
 
-  get() {
-    if (this.timeout <= 0) {
+  getAllClasses() {
+    if (this.ttl <= 0) {
       return;
     }
-    return this.cache.get(this.appId+MAIN_SCHEMA);
+    return this.cache.get(SCHEMA_CACHE_PREFIX+MAIN_SCHEMA);
   }
 
-  set(schema) {
-    if (this.timeout <= 0) {
+  setAllClasses(schema) {
+    if (this.ttl <= 0) {
       return;
     }
-    this.cache.set(this.appId+MAIN_SCHEMA, schema);
+    this.cache.put(SCHEMA_CACHE_PREFIX+MAIN_SCHEMA, schema, this.ttl);
   }
 
   setOneSchema(className, schema) {
-    if (this.timeout <= 0) {
+    if (this.ttl <= 0) {
       return;
     }
-     this.cache.set(this.appId+className, schema);
+    this.cache.put(SCHEMA_CACHE_PREFIX+className, schema, this.ttl);
   }
 
   getOneSchema(className) {
-    if (this.timeout <= 0) {
+    if (this.ttl <= 0) {
       return;
     }
-    return this.cache.get(this.appId+className);
+    return this.cache.get(SCHEMA_CACHE_PREFIX+className);
   }
 
-  reset() {
-    this.cache.reset();
+  clear() {
+    // That clears all caches...
+   this.cache.clear();
   }
 }

--- a/src/Controllers/SchemaCache.js
+++ b/src/Controllers/SchemaCache.js
@@ -1,44 +1,68 @@
 const MAIN_SCHEMA = "__MAIN_SCHEMA";
 const SCHEMA_CACHE_PREFIX = "__SCHEMA";
+const ALL_KEYS = "__ALL_KEYS";
+
+import { randomString } from '../cryptoUtils';
 
 export default class SchemaCache {
   cache: Object;
 
-  constructor(adapter, ttl) {
+  constructor(cacheController, ttl = 30) {
     this.ttl = ttl;
-    this.cache = adapter;
-}
+    if (typeof ttl == 'string') {
+      this.ttl = parseInt(ttl);
+    }
+    this.cache = cacheController;
+    this.prefix = SCHEMA_CACHE_PREFIX+randomString(20);
+  }
+
+  put(key, value) {
+    return this.cache.get(this.prefix+ALL_KEYS).then((allKeys) => {
+      allKeys = allKeys || {};
+      allKeys[key] = true;
+      return Promise.all([this.cache.put(this.prefix+ALL_KEYS, allKeys, this.ttl), this.cache.put(key, value, this.ttl)]);
+    });
+  }
 
   getAllClasses() {
     if (!this.ttl) {
       return Promise.resolve(null);
     }
-    return this.cache.get(SCHEMA_CACHE_PREFIX+MAIN_SCHEMA);
+    return this.cache.get(this.prefix+MAIN_SCHEMA);
   }
 
   setAllClasses(schema) {
     if (!this.ttl) {
       return Promise.resolve(null);
     }
-    this.cache.put(SCHEMA_CACHE_PREFIX+MAIN_SCHEMA, schema, this.ttl);
+    return this.put(this.prefix+MAIN_SCHEMA, schema);
   }
 
   setOneSchema(className, schema) {
     if (!this.ttl) {
       return Promise.resolve(null);
     }
-    this.cache.put(SCHEMA_CACHE_PREFIX+className, schema, this.ttl);
+    return this.put(this.prefix+className, schema);
   }
 
   getOneSchema(className) {
     if (!this.ttl) {
       return Promise.resolve(null);
     }
-    return this.cache.get(SCHEMA_CACHE_PREFIX+className);
+    return this.cache.get(this.prefix+className);
   }
 
   clear() {
     // That clears all caches...
-   this.cache.clear();
+    let promise = Promise.resolve();
+    return this.cache.get(this.prefix+ALL_KEYS).then((allKeys) => {
+      if (!allKeys) {
+        return;
+      }
+      let promises = Object.keys(allKeys).map((key) => {
+        return this.cache.del(key);
+      });
+      return Promise.all(promises);
+    });
   }
 }

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -325,8 +325,9 @@ class SchemaController {
       return this._dbAdapter.getAllClasses()
         .then(allSchemas => allSchemas.map(injectDefaultSchema))
         .then(allSchemas => {
-          this._cache.setAllClasses(allSchemas);
-          return allSchemas;
+          return this._cache.setAllClasses(allSchemas).then(() => {
+            return allSchemas;
+          });
         })
     });
   }
@@ -345,8 +346,9 @@ class SchemaController {
       return this._dbAdapter.getClass(className)
       .then(injectDefaultSchema)
       .then((result) => {
-        this._cache.setOneSchema(className, result);
-        return result;
+        return this._cache.setOneSchema(className, result).then(() => {
+          return result;
+        })
       });
     });
   }

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -199,8 +199,7 @@ class ParseServer {
     const userController = new UserController(emailControllerAdapter, appId, { verifyUserEmails });
     const liveQueryController = new LiveQueryController(liveQuery);
     const cacheController = new CacheController(cacheControllerAdapter, appId);
-    const schemaCache = new SchemaCache(appId, schemaCacheTTL);
-    const databaseController = new DatabaseController(databaseAdapter, schemaCache);
+    const databaseController = new DatabaseController(databaseAdapter, new SchemaCache(schemaCacheTTL));
     const hooksController = new HooksController(appId, databaseController, webhookKey);
     const analyticsController = new AnalyticsController(analyticsControllerAdapter);
 
@@ -257,7 +256,6 @@ class ParseServer {
       jsonLogs,
       revokeSessionOnPasswordReset,
       databaseController,
-      schemaCache,
       schemaCacheTTL
     });
 

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -140,7 +140,7 @@ class ParseServer {
     expireInactiveSessions = true,
     verbose = false,
     revokeSessionOnPasswordReset = true,
-    schemaCacheTTL = -1, // -1 = no cache
+    schemaCacheTTL = 0, // 0 = no cache
     __indexBuildCompletionCallbackForTests = () => {},
   }) {
     // Initialize the node client SDK automatically

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -140,7 +140,7 @@ class ParseServer {
     expireInactiveSessions = true,
     verbose = false,
     revokeSessionOnPasswordReset = true,
-    schemaCacheTTL = 0, // 0 = no cache
+    schemaCacheTTL = 5, // cache for 5s
     __indexBuildCompletionCallbackForTests = () => {},
   }) {
     // Initialize the node client SDK automatically
@@ -191,10 +191,6 @@ class ParseServer {
     const cacheControllerAdapter = loadAdapter(cacheAdapter, InMemoryCacheAdapter, {appId: appId});
     const analyticsControllerAdapter = loadAdapter(analyticsAdapter, AnalyticsAdapter);
 
-    const createSchemaCache = function() {
-      let adapter = loadAdapter(cacheAdapter, InMemoryCacheAdapter, {appId: appId, ttl: schemaCacheTTL});
-      return new SchemaCache(adapter, schemaCacheTTL);
-    }
     // We pass the options and the base class for the adatper,
     // Note that passing an instance would work too
     const filesController = new FilesController(filesControllerAdapter, appId);
@@ -203,7 +199,7 @@ class ParseServer {
     const userController = new UserController(emailControllerAdapter, appId, { verifyUserEmails });
     const liveQueryController = new LiveQueryController(liveQuery);
     const cacheController = new CacheController(cacheControllerAdapter, appId);
-    const databaseController = new DatabaseController(databaseAdapter, createSchemaCache());
+    const databaseController = new DatabaseController(databaseAdapter, new SchemaCache(cacheController, schemaCacheTTL));
     const hooksController = new HooksController(appId, databaseController, webhookKey);
     const analyticsController = new AnalyticsController(analyticsControllerAdapter);
 
@@ -260,8 +256,7 @@ class ParseServer {
       jsonLogs,
       revokeSessionOnPasswordReset,
       databaseController,
-      schemaCacheTTL,
-      createSchemaCache
+      schemaCacheTTL
     });
 
     // To maintain compatibility. TODO: Remove in some version that breaks backwards compatability

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -55,6 +55,7 @@ import { UsersRouter }          from './Routers/UsersRouter';
 import { PurgeRouter }          from './Routers/PurgeRouter';
 
 import DatabaseController       from './Controllers/DatabaseController';
+import SchemaCache              from './Controllers/SchemaCache';
 const SchemaController = require('./Controllers/SchemaController');
 import ParsePushAdapter         from 'parse-server-push-adapter';
 import MongoStorageAdapter      from './Adapters/Storage/Mongo/MongoStorageAdapter';
@@ -139,6 +140,7 @@ class ParseServer {
     expireInactiveSessions = true,
     verbose = false,
     revokeSessionOnPasswordReset = true,
+    schemaCacheTTL = -1, // -1 = no cache
     __indexBuildCompletionCallbackForTests = () => {},
   }) {
     // Initialize the node client SDK automatically
@@ -197,7 +199,8 @@ class ParseServer {
     const userController = new UserController(emailControllerAdapter, appId, { verifyUserEmails });
     const liveQueryController = new LiveQueryController(liveQuery);
     const cacheController = new CacheController(cacheControllerAdapter, appId);
-    const databaseController = new DatabaseController(databaseAdapter);
+    const schemaCache = new SchemaCache(appId, schemaCacheTTL);
+    const databaseController = new DatabaseController(databaseAdapter, schemaCache);
     const hooksController = new HooksController(appId, databaseController, webhookKey);
     const analyticsController = new AnalyticsController(analyticsControllerAdapter);
 
@@ -254,6 +257,8 @@ class ParseServer {
       jsonLogs,
       revokeSessionOnPasswordReset,
       databaseController,
+      schemaCache,
+      schemaCacheTTL
     });
 
     // To maintain compatibility. TODO: Remove in some version that breaks backwards compatability

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -191,6 +191,10 @@ class ParseServer {
     const cacheControllerAdapter = loadAdapter(cacheAdapter, InMemoryCacheAdapter, {appId: appId});
     const analyticsControllerAdapter = loadAdapter(analyticsAdapter, AnalyticsAdapter);
 
+    const createSchemaCache = function() {
+      let adapter = loadAdapter(cacheAdapter, InMemoryCacheAdapter, {appId: appId, ttl: schemaCacheTTL});
+      return new SchemaCache(adapter, schemaCacheTTL);
+    }
     // We pass the options and the base class for the adatper,
     // Note that passing an instance would work too
     const filesController = new FilesController(filesControllerAdapter, appId);
@@ -199,7 +203,7 @@ class ParseServer {
     const userController = new UserController(emailControllerAdapter, appId, { verifyUserEmails });
     const liveQueryController = new LiveQueryController(liveQuery);
     const cacheController = new CacheController(cacheControllerAdapter, appId);
-    const databaseController = new DatabaseController(databaseAdapter, new SchemaCache(schemaCacheTTL));
+    const databaseController = new DatabaseController(databaseAdapter, createSchemaCache());
     const hooksController = new HooksController(appId, databaseController, webhookKey);
     const analyticsController = new AnalyticsController(analyticsControllerAdapter);
 
@@ -256,7 +260,8 @@ class ParseServer {
       jsonLogs,
       revokeSessionOnPasswordReset,
       databaseController,
-      schemaCacheTTL
+      schemaCacheTTL,
+      createSchemaCache
     });
 
     // To maintain compatibility. TODO: Remove in some version that breaks backwards compatability

--- a/src/Routers/SchemasRouter.js
+++ b/src/Routers/SchemasRouter.js
@@ -15,14 +15,14 @@ function classNameMismatchResponse(bodyClass, pathClass) {
 }
 
 function getAllSchemas(req) {
-  return req.config.database.loadSchema(true)
+  return req.config.database.loadSchema({ clearCache: true})
   .then(schemaController => schemaController.getAllClasses(true))
   .then(schemas => ({ response: { results: schemas } }));
 }
 
 function getOneSchema(req) {
   const className = req.params.className;
-  return req.config.database.loadSchema(true)
+  return req.config.database.loadSchema({ clearCache: true})
   .then(schemaController => schemaController.getOneSchema(className, true))
   .then(schema => ({ response: schema }))
   .catch(error => {
@@ -46,7 +46,7 @@ function createSchema(req) {
     throw new Parse.Error(135, `POST ${req.path} needs a class name.`);
   }
 
-  return req.config.database.loadSchema(true)
+  return req.config.database.loadSchema({ clearCache: true})
     .then(schema => schema.addClassIfNotExists(className, req.body.fields, req.body.classLevelPermissions))
     .then(schema => ({ response: schema }));
 }
@@ -59,7 +59,7 @@ function modifySchema(req) {
   let submittedFields = req.body.fields || {};
   let className = req.params.className;
 
-  return req.config.database.loadSchema(true)
+  return req.config.database.loadSchema({ clearCache: true})
   .then(schema => schema.updateClass(className, submittedFields, req.body.classLevelPermissions, req.config.database))
   .then(result => ({response: result}));
 }

--- a/src/Routers/SchemasRouter.js
+++ b/src/Routers/SchemasRouter.js
@@ -15,15 +15,15 @@ function classNameMismatchResponse(bodyClass, pathClass) {
 }
 
 function getAllSchemas(req) {
-  return req.config.database.loadSchema()
-  .then(schemaController => schemaController.getAllClasses())
+  return req.config.database.loadSchema(true)
+  .then(schemaController => schemaController.getAllClasses(true))
   .then(schemas => ({ response: { results: schemas } }));
 }
 
 function getOneSchema(req) {
   const className = req.params.className;
-  return req.config.database.loadSchema()
-  .then(schemaController => schemaController.getOneSchema(className))
+  return req.config.database.loadSchema(true)
+  .then(schemaController => schemaController.getOneSchema(className, true))
   .then(schema => ({ response: schema }))
   .catch(error => {
     if (error === undefined) {
@@ -46,7 +46,7 @@ function createSchema(req) {
     throw new Parse.Error(135, `POST ${req.path} needs a class name.`);
   }
 
-  return req.config.database.loadSchema()
+  return req.config.database.loadSchema(true)
     .then(schema => schema.addClassIfNotExists(className, req.body.fields, req.body.classLevelPermissions))
     .then(schema => ({ response: schema }));
 }
@@ -59,7 +59,7 @@ function modifySchema(req) {
   let submittedFields = req.body.fields || {};
   let className = req.params.className;
 
-  return req.config.database.loadSchema()
+  return req.config.database.loadSchema(true)
   .then(schema => schema.updateClass(className, submittedFields, req.body.classLevelPermissions, req.config.database))
   .then(result => ({response: result}));
 }

--- a/src/cli/cli-definitions.js
+++ b/src/cli/cli-definitions.js
@@ -200,7 +200,7 @@ export default {
   },
   "schemaCacheTTL": {
     env: "PARSE_SERVER_SCHEMA_CACHE_TTL",
-    help: "The TTL for caching the schema for optimizing read/write operations. You should put a long TTL when your DB is in production. default to -1; disabled.",
+    help: "The TTL for caching the schema for optimizing read/write operations. You should put a long TTL when your DB is in production. default to 0; disabled.",
     action: numberParser("schemaCacheTTL"),
   }
 };

--- a/src/cli/cli-definitions.js
+++ b/src/cli/cli-definitions.js
@@ -197,5 +197,10 @@ export default {
     env: "PARSE_SERVER_REVOKE_SESSION_ON_PASSWORD_RESET",
     help: "When a user changes their password, either through the reset password email or while logged in, all sessions are revoked if this is true. Set to false if you don't want to revoke sessions.",
     action: booleanParser
+  },
+  "schemaCacheTTL": {
+    env: "PARSE_SERVER_SCHEMA_CACHE_TTL",
+    help: "The TTL for caching the schema for optimizing read/write operations. You should put a long TTL when your DB is in production. default to -1; disabled.",
+    action: numberParser("schemaCacheTTL"),
   }
 };


### PR DESCRIPTION
Adds caching of the schema.

- configure with schemaCacheTTL, or PARSE_SERVER_SCHEMA_CACHE_TTL options.
- 5s by default.
- put 0s or false to disable

A new cache is created for each request, scoped with a prefixed key, so no information is leaked across requests.
This could be further optimized later on.