### PR TITLE
Add function name to the request object - this can help in generic way to log the function calls.

### DIFF
--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -67,7 +67,8 @@ export class FunctionsRouter extends PromiseRouter {
         user: req.auth && req.auth.user,
         installationId: req.info.installationId,
         log: req.config.loggerController && req.config.loggerController.adapter,
-        headers: req.headers
+        headers: req.headers,
+        functionName: req.params.functionName
       };
 
       if (theValidator && typeof theValidator === "function") {


### PR DESCRIPTION
Add function name to the request object - this can help in generic way to log the function calls.