### PR TITLE
Clear the connectionPromise upon close or error

### DIFF
--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -105,7 +105,20 @@ export class MongoStorageAdapter {
     const encodedUri = formatUrl(parseUrl(this._uri));
 
     this.connectionPromise = MongoClient.connect(encodedUri, this._mongoOptions).then(database => {
+      if (!database) {
+        delete this.connectionPromise;
+        return;
+      }
+      database.on('error', (error) => {
+        delete this.connectionPromise;
+      });
+      database.on('close', (error) => {
+        delete this.connectionPromise;
+      });
       this.database = database;
+    }).catch((err) => {
+      delete this.connectionPromise;
+      return Promise.reject(err);
     });
 
     return this.connectionPromise;


### PR DESCRIPTION
Adds handlers on db.close and db.error in order to clear the connection from the server. That prevents the server from being in a fully unusable state after a connection error event and let the forces the driver to create a new connection upon the next call 