### PR TITLE
Fix flaky tests

### DIFF
--- a/spec/RestCreate.spec.js
+++ b/spec/RestCreate.spec.js
@@ -310,7 +310,7 @@ describe('rest create', () => {
     });
   });
 
-  it_exclude_dbs(['postgres'])("test default session length", (done) => {
+  fit_exclude_dbs(['postgres'])("test default session length", (done) => {
     var user = {
       username: 'asdf',
       password: 'zxcv',
@@ -337,7 +337,8 @@ describe('rest create', () => {
         expect(actual.getFullYear()).toEqual(expected.getFullYear());
         expect(actual.getMonth()).toEqual(expected.getMonth());
         expect(actual.getDate()).toEqual(expected.getDate());
-        expect(actual.getMinutes()).toEqual(expected.getMinutes());
+        // less than a minute, if test happen at the wrong time :/
+        expect(actual.getMinutes() - expected.getMinutes() <= 1).toBe(true);
 
         done();
       });

--- a/spec/RestCreate.spec.js
+++ b/spec/RestCreate.spec.js
@@ -310,7 +310,7 @@ describe('rest create', () => {
     });
   });
 
-  fit_exclude_dbs(['postgres'])("test default session length", (done) => {
+  it_exclude_dbs(['postgres'])("test default session length", (done) => {
     var user = {
       username: 'asdf',
       password: 'zxcv',

--- a/spec/RestQuery.spec.js
+++ b/spec/RestQuery.spec.js
@@ -158,7 +158,7 @@ describe('rest query', () => {
     });
   });
 
-  fit('query with wrongly encoded parameter', (done) => {
+  it('query with wrongly encoded parameter', (done) => {
     rest.create(config, nobody, 'TestParameterEncode', {foo: 'bar'}
     ).then(() => {
       return rest.create(config, nobody,


### PR DESCRIPTION
Fixes 2 tests that would sometime fail for no good reason.

[there were open connections after...](https://travis-ci.org/ParsePlatform/parse-server/jobs/145629217)

[rest create test default session length Expected 5 to equal 4.](https://travis-ci.org/ParsePlatform/parse-server/jobs/145506207)