### PR TITLE
Allow usage of analytics adapter

### DIFF
--- a/src/Adapters/Analytics/AnalyticsAdapter.js
+++ b/src/Adapters/Analytics/AnalyticsAdapter.js
@@ -1,0 +1,9 @@
+export class AnalyticsAdapter {
+  post(req) {
+    return Promise.resolve({
+        response: {}
+      });
+  }
+}
+
+export default AnalyticsAdapter;

--- a/src/Adapters/Analytics/AnalyticsAdapter.js
+++ b/src/Adapters/Analytics/AnalyticsAdapter.js
@@ -1,8 +1,10 @@
 export class AnalyticsAdapter {
-  post(req) {
-    return Promise.resolve({
-        response: {}
-      });
+  appOpened(parameters, req) {
+    return Promise.resolve({});
+  }
+
+  trackEvent(eventName, parameters, req) {
+    return Promise.resolve({});
   }
 }
 

--- a/src/Config.js
+++ b/src/Config.js
@@ -39,6 +39,7 @@ export class Config {
     this.preventLoginWithUnverifiedEmail = cacheInfo.preventLoginWithUnverifiedEmail;
     this.appName = cacheInfo.appName;
 
+    this.analyticsController = cacheInfo.analyticsController;
     this.cacheController = cacheInfo.cacheController;
     this.hooksController = cacheInfo.hooksController;
     this.filesController = cacheInfo.filesController;

--- a/src/Controllers/AnalyticsController.js
+++ b/src/Controllers/AnalyticsController.js
@@ -1,0 +1,15 @@
+import AdaptableController from './AdaptableController';
+import { AnalyticsAdapter } from '../Adapters/Analytics/AnalyticsAdapter';
+
+export class AnalyticsController extends AdaptableController {
+  post(req) {
+    var analyticsAdapter = this.adapter;
+    return analyticsAdapter.post(req);
+  }
+
+  expectedAdapterType() {
+    return AnalyticsAdapter;
+  }
+}
+
+export default AnalyticsController;

--- a/src/Controllers/AnalyticsController.js
+++ b/src/Controllers/AnalyticsController.js
@@ -2,9 +2,22 @@ import AdaptableController from './AdaptableController';
 import { AnalyticsAdapter } from '../Adapters/Analytics/AnalyticsAdapter';
 
 export class AnalyticsController extends AdaptableController {
-  post(req) {
-    var analyticsAdapter = this.adapter;
-    return analyticsAdapter.post(req);
+  appOpened(req) {
+    return this.adapter.appOpened(req.body, req).then(
+      function(response) {
+        return { response: response };
+      }).catch((err) => {
+        return { response: {} };
+      });
+  }
+
+  trackEvent(req) {
+    return this.adapter.trackEvent(req.params.eventName, req.body, req).then(
+      function(response) {
+        return { response: response };
+      }).catch((err) => {
+        return { response: {} };
+      });
   }
 
   expectedAdapterType() {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -25,7 +25,9 @@ import { AnalyticsRouter }      from './Routers/AnalyticsRouter';
 import { ClassesRouter }        from './Routers/ClassesRouter';
 import { FeaturesRouter }       from './Routers/FeaturesRouter';
 import { InMemoryCacheAdapter } from './Adapters/Cache/InMemoryCacheAdapter';
+import { AnalyticsController }  from './Controllers/AnalyticsController';
 import { CacheController }      from './Controllers/CacheController';
+import { AnalyticsAdapter }     from './Adapters/Analytics/AnalyticsAdapter';
 import { FileLoggerAdapter }    from './Adapters/Logger/FileLoggerAdapter';
 import { FilesController }      from './Controllers/FilesController';
 import { FilesRouter }          from './Routers/FilesRouter';
@@ -65,6 +67,7 @@ const requiredUserFields = { fields: { ...SchemaController.defaultColumns._Defau
 
 // ParseServer works like a constructor of an express app.
 // The args that we understand are:
+// "analyticsAdapter": an adapter class for analytics
 // "filesAdapter": a class like GridStoreAdapter providing create, get,
 //                 and delete
 // "loggerAdapter": a class like FileLoggerAdapter providing info, error,
@@ -95,6 +98,7 @@ class ParseServer {
     appId = requiredParameter('You must provide an appId!'),
     masterKey = requiredParameter('You must provide a masterKey!'),
     appName,
+    analyticsAdapter = undefined,
     filesAdapter,
     push,
     loggerAdapter,
@@ -137,7 +141,6 @@ class ParseServer {
     // Initialize the node client SDK automatically
     Parse.initialize(appId, javascriptKey || 'unused', masterKey);
     Parse.serverURL = serverURL;
-
     if ((databaseOptions || databaseURI || collectionPrefix !== '') && databaseAdapter) {
       throw 'You cannot specify both a databaseAdapter and a databaseURI/databaseOptions/connectionPrefix.';
     } else if (!databaseAdapter) {
@@ -183,6 +186,7 @@ class ParseServer {
     const loggerControllerAdapter = loadAdapter(loggerAdapter, FileLoggerAdapter);
     const emailControllerAdapter = loadAdapter(emailAdapter);
     const cacheControllerAdapter = loadAdapter(cacheAdapter, InMemoryCacheAdapter, {appId: appId});
+    const analyticsControllerAdapter = loadAdapter(analyticsAdapter, AnalyticsAdapter);
 
     // We pass the options and the base class for the adatper,
     // Note that passing an instance would work too
@@ -194,6 +198,7 @@ class ParseServer {
     const cacheController = new CacheController(cacheControllerAdapter, appId);
     const databaseController = new DatabaseController(databaseAdapter);
     const hooksController = new HooksController(appId, databaseController, webhookKey);
+    const analyticsController = new AnalyticsController(analyticsControllerAdapter);
 
     // TODO: create indexes on first creation of a _User object. Otherwise it's impossible to
     // have a Parse app without it having a _User collection.
@@ -225,6 +230,7 @@ class ParseServer {
       webhookKey: webhookKey,
       fileKey: fileKey,
       facebookAppIds: facebookAppIds,
+      analyticsController: analyticsController,
       cacheController: cacheController,
       filesController: filesController,
       pushController: pushController,

--- a/src/Routers/AnalyticsRouter.js
+++ b/src/Routers/AnalyticsRouter.js
@@ -1,17 +1,15 @@
 // AnalyticsRouter.js
 import PromiseRouter from '../PromiseRouter';
 
-// Returns a promise that resolves to an empty object response
-function ignoreAndSucceed(req) {
-  return Promise.resolve({
-    response: {}
-  });
+function handlePost(req) {
+  const analyticsController = req.config.analyticsController;
+  return analyticsController.sendToAdapter(req);
 }
 
 
 export class AnalyticsRouter extends PromiseRouter {
   mountRoutes() {
-    this.route('POST','/events/AppOpened', ignoreAndSucceed);
-    this.route('POST','/events/:eventName', ignoreAndSucceed);
+    this.route('POST','/events/AppOpened', handlePost);
+    this.route('POST','/events/:eventName', handlePost);
   }
 }

--- a/src/Routers/AnalyticsRouter.js
+++ b/src/Routers/AnalyticsRouter.js
@@ -1,15 +1,20 @@
 // AnalyticsRouter.js
 import PromiseRouter from '../PromiseRouter';
 
-function handlePost(req) {
+function appOpened(req) {
   const analyticsController = req.config.analyticsController;
-  return analyticsController.sendToAdapter(req);
+  return analyticsController.appOpened(req);
+}
+
+function trackEvent(req) {
+  const analyticsController = req.config.analyticsController;
+  return analyticsController.trackEvent(req);
 }
 
 
 export class AnalyticsRouter extends PromiseRouter {
   mountRoutes() {
-    this.route('POST','/events/AppOpened', handlePost);
-    this.route('POST','/events/:eventName', handlePost);
+    this.route('POST','/events/AppOpened', appOpened);
+    this.route('POST','/events/:eventName', trackEvent);
   }
 }


### PR DESCRIPTION
I want to write my own adapter for google analytics, but parse-server in current state just ignores the analytics events, so I decided to write my own implementation of that, using patterns provided for other controllers/adapters/routers. 

As you can see, this PR doesn't change the default behaviour of AnalyticsRouter, so default adapter does exactly the same things like before(that is: nothing), but I think being able to provide my own AnalyticsAdapter is crucial and much easier to implement than monkeypatching the whole server to catch requests.

Please let me know if that satisfies you or if you have any suggestions on how to improve it. To be honest I'd love to see it merged asap, because of deadlines in our project. If you decide to merge it, I'll provide GA adapter when its finished.