### PR TITLE
Update Mongodb client to 2.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lru-cache": "4.0.1",
     "mailgun-js": "0.7.10",
     "mime": "1.3.4",
-    "mongodb": "2.1.18",
+    "mongodb": "2.2.4",
     "multer": "1.1.0",
     "parse": "1.9.0",
     "parse-server-fs-adapter": "1.0.0",

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -65,7 +65,7 @@ describe('server', () => {
         expect(response.statusCode).toEqual(500);
         expect(body.code).toEqual(1);
         expect(body.message).toEqual('Internal server error.');
-        done();
+        reconfigureServer().then(done, done);
       });
     });
   });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -65,6 +65,8 @@ describe('server', () => {
         expect(response.statusCode).toEqual(500);
         expect(body.code).toEqual(1);
         expect(body.message).toEqual('Internal server error.');
+        // Reconfigure with null so the next beforeEach don't fail trying to delete
+        reconfigureServer({ databaseAdapter: null });
         done();
       });
     });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -65,8 +65,6 @@ describe('server', () => {
         expect(response.statusCode).toEqual(500);
         expect(body.code).toEqual(1);
         expect(body.message).toEqual('Internal server error.');
-        // Reconfigure with null so the next beforeEach don't fail trying to delete
-        reconfigureServer({ databaseAdapter: null });
         done();
       });
     });

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -110,7 +110,8 @@ DatabaseController.prototype.validateClassName = function(className) {
 DatabaseController.prototype.loadSchema = function() {
   if (!this.schemaPromise) {
     this.schemaPromise = SchemaController.load(this.adapter);
-    this.schemaPromise.then(() => delete this.schemaPromise);
+    this.schemaPromise.then(() => delete this.schemaPromise,
+                             () => delete this.schemaPromise);
   }
   return this.schemaPromise;
 };


### PR DESCRIPTION
We needed to tweak a bit the test so the next beforeEach won't crash trying to delete all data with a broken connection as the new mongo client will fail.