### PR TITLE
Added Fixes for _PushStatus _SCHEMA Insertion and Ensuring Order for _PushStatus Row Update

### DIFF
--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -93,7 +93,18 @@ export class PushController extends AdaptableController {
       if (!response.results) {
         return Promise.reject({error: 'PushController: no results in query'})
       }
-      pushStatus.setRunning(response.results);
+
+      /*
+       * The following code change ensures the correct order of the update of a particular _PushStatus row
+       * (first from 'pending' to 'running' and only then from 'running' to 'succeeded').
+       * Without this change, the order is not predictable always and cann lead to 'Object not found' error
+       * while updating the _PushStatus row.
+       */
+      let runningPromise = pushStatus.setRunning(response.results);
+      return runningPromise.then(() => {
+        return response;
+      });
+    }).then((response) => {
       return this.sendToAdapter(body, response.results, pushStatus, config);
     }).then((results) => {
       return pushStatus.complete(results);

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -290,6 +290,20 @@ class SchemaController {
       return this.reloadDataPromise;
     }
     this.data = {};
+    
+    /*
+     * This block of code ensures that the schema for volatile classes is always available
+     * and should never be created in _SCHEMA. Without this change, the invocation in DatabaseController
+     * causes the _PushStatus document to be added to _SCHEMA.
+     */ 
+    volatileClasses.forEach(className => {
+      this.data[className] = injectDefaultSchema({
+        className,
+        fields: {},
+        classLevelPermissions: {}
+      });
+    });
+
     this.perms = {};
     this.reloadDataPromise = this.getAllClasses(options)
     .then(allSchemas => {


### PR DESCRIPTION
_PushStatus sometimes gets injected to the _SCHEMA collection, causing:

1. Parse Dashboard through parse.com to stop working.
2. Push notifications sent through parse.com to stop working.

These code changes also ensure that the _PushStatus update during push notification processing is correct (first from 'pending' to 'running' and only then from 'running' to 'succeeded’).