### PR TITLE
Non trivial before save pointer clobber

### DIFF
--- a/spec/ParseUser.spec.js
+++ b/spec/ParseUser.spec.js
@@ -2374,7 +2374,7 @@ describe('Parse.User testing', () => {
           },
           json: true
         }, (err, res, body) => {
-          expect(body.username).toEqual(user.username);
+          expect(body.username).toEqual('user');
           expect(body.objectId).toEqual(originalUserId);
           if (err) {
             reject(err);


### PR DESCRIPTION
When the beforeSave makes changes to the object being saved, the fetched pointer fields on the client gets clobbered to only pointers. 

It is related to https://github.com/ParsePlatform/parse-server/issues/1238
But the beforeSave also makes changes to the object being saved. 