### PR TITLE
Add Content-Length header to HTTP response in FilesRouter

### DIFF
--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -40,6 +40,7 @@ export class FilesRouter {
       res.status(200);
       var contentType = mime.lookup(filename);
       res.set('Content-Type', contentType);
+      res.set('Content-Length', data.length);
       res.end(data);
     }).catch((err) => {
       res.status(404);


### PR DESCRIPTION
Files served by the old Parse.com service always have a Content-Length header attached. This patch adds the same header to files served by the parse-server.