### PR TITLE
Prevent allowCrossDomain middleware from sending headers if they're already sent

### DIFF
--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -206,6 +206,8 @@ function decodeBase64(str) {
 }
 
 var allowCrossDomain = function(req, res, next) {
+  if(res.headersSent) return next();
+  
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
   res.header('Access-Control-Allow-Headers', 'X-Parse-Master-Key, X-Parse-REST-API-Key, X-Parse-Javascript-Key, X-Parse-Application-Id, X-Parse-Client-Version, X-Parse-Session-Token, X-Requested-With, X-Parse-Revocable-Session, Content-Type');


### PR DESCRIPTION
This fix solved the [issue #2410](https://github.com/ParsePlatform/parse-server/issues/2410) for me