### PR TITLE
Fix test:win, introduce coverage:win, fix test on Windows bash

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,10 +69,11 @@
     "dev": "npm run build && node bin/dev",
     "build": "babel src/ -d lib/",
     "pretest": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 mongodb-runner start",
-    "test": "cross-env NODE_ENV=test TESTING=1 babel-node $COVERAGE_OPTION ./node_modules/.bin/jasmine",
-    "test:win": "npm run pretest && cross-env NODE_ENV=test TESTING=1 babel-node ./node_modules/.bin/istanbul cover jasmine && npm run posttest",
+    "test": "cross-env NODE_ENV=test TESTING=1 babel-node $COVERAGE_OPTION ./node_modules/jasmine/bin/jasmine.js",
+    "test:win": "npm run pretest && cross-env NODE_ENV=test TESTING=1 babel-node ./node_modules/jasmine/bin/jasmine.js && npm run posttest",
     "posttest": "mongodb-runner stop",
     "coverage": "cross-env COVERAGE_OPTION='./node_modules/.bin/istanbul cover' npm test",
+    "coverage:win": "npm run pretest && cross-env NODE_ENV=test TESTING=1 babel-node ./node_modules/babel-istanbul/lib/cli.js cover ./node_modules/jasmine/bin/jasmine.js && npm run posttest",
     "start": "node ./bin/parse-server",
     "prepublish": "npm run build"
   },


### PR DESCRIPTION
@flovilmart this reverts a change that you previously reverted which runs jasmine from the js file instead of the .bin/jasmine. If you look in .bin/jasmine it looks to be just be calling jasmine from the full path anyway.
I don't know why Windows bash has an issue with the jasmine sh script but this fixes it. Please let me know if this breaks code coverage for CI.

For developers without access to Windows 10 bash, then test:win should now work although mongodb-runner needs to be pinned at 3.2.0 for that to work due to a bug introduced in 3.2.1. I didn't roll it back here as figured there must be a reason it was increased.

I split out win:test coverage to coverage:win as to speed up testing when not interested in coverage.