### PR TITLE
Handle queries with equalTo on objectId and relation conditions

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -118,6 +118,16 @@ describe('Parse.Query testing', () => {
         expect(cake.id).toBe(cake3.id);
       });
     }).then(function(){
+      var query = new Parse.Query(Cake);
+      // Exclude user1
+      query.notEqualTo("liker", user1);
+      // Only cake1
+      query.equalTo("objectId", cake1.id)
+      // user1 likes cake1 so this should return no results
+      return query.find().then(function(results){
+        equal(results.length, 0);
+      });
+    }).then(function(){
       done();
     })
   });

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -647,11 +647,13 @@ DatabaseController.prototype.addInObjectIdsIds = function(ids = null, query) {
     idsIntersection = intersect(allIds);
   }
 
-  // Need to make sure we don't clobber existing $lt or other constraints on objectId.
-  // Clobbering $eq, $in and shorthand $eq (query.objectId === 'string') constraints
-  // is expected though.
-  if (!('objectId' in query) || typeof query.objectId === 'string') {
+  // Need to make sure we don't clobber existing shorthand $eq constraints on objectId.
+  if (!('objectId' in query)) {
     query.objectId = {};
+  } else if (typeof query.objectId === 'string') {
+    query.objectId = {
+      $eq: query.objectId
+    };
   }
   query.objectId['$in'] = idsIntersection;
 
@@ -670,11 +672,13 @@ DatabaseController.prototype.addNotInObjectIdsIds = function(ids = null, query) 
     idsIntersection = intersect(allIds);
   }
 
-  // Need to make sure we don't clobber existing $lt or other constraints on objectId.
-  // Clobbering $eq, $in and shorthand $eq (query.objectId === 'string') constraints
-  // is expected though.
-  if (!('objectId' in query) || typeof query.objectId === 'string') {
+  // Need to make sure we don't clobber existing shorthand $eq constraints on objectId.
+  if (!('objectId' in query)) {
     query.objectId = {};
+  } else if (typeof query.objectId === 'string') {
+    query.objectId = {
+      $eq: query.objectId
+    };
   }
   query.objectId['$nin'] = idsIntersection;
 


### PR DESCRIPTION
This is done by converting shorthand $eq condition on objectId (ie. `.equalTo('objectId', id)`) to $eq condition instead of clobbering when there are relation conditions.

Tests have been added for this case and now pass.

_([some additional conversation here](https://github.com/ParsePlatform/parse-server/pull/1295/files/6311c9578577a29e5bc163d399b44ae4fd3b1c70..73bca3b64ca082cb970ff2dfc9d2e50a5e6c8810#r73771767))_

