### PR TITLE
Don't add transport when folder is /dev/null. Fix bug with options

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -16,24 +16,28 @@ let currentLogsFolder = LOGS_FOLDER;
 const additionalTransports = [];
 
 function generateTransports(level, options = {}) {
-  let transports = [
-    new (DailyRotateFile)(
-      Object.assign({
-        filename: 'parse-server.info',
-        dirname: currentLogsFolder,
-        name: 'parse-server',
-        level: level
-      }, options)
-    ),
-    new (DailyRotateFile)(
-      Object.assign({
+  let transports = [];
+
+  if (currentLogsFolder !== '/dev/null') {
+    transports = [
+      new (DailyRotateFile)(
+        Object.assign({
+          filename: 'parse-server.info',
+          dirname: currentLogsFolder,
+          name: 'parse-server',
+          level: level
+        }, options)
+      ),
+      new (DailyRotateFile)(
+        Object.assign({
           filename: 'parse-server.err',
           dirname: currentLogsFolder,
           name: 'parse-server-error',
           level: 'error'
-        }
-      ), options)
-  ].concat(additionalTransports);
+        }, options)
+      )
+    ].concat(additionalTransports);
+  }
   if (!process.env.TESTING || process.env.VERBOSE) {
     transports = [
       new (winston.transports.Console)(


### PR DESCRIPTION
Attempting to use /dev/null as a log folder results in the following error:
```
Error: ENOTDIR: not a directory, stat '/dev/null/parse-server.info.2016-08-06'
```
This will prevent that. There is also a misplaced options argument on line 34 of the original file