### PR TITLE
Refactor logging to provide common logger from LoggerAdapter

### DIFF
--- a/spec/AdapterLoader.spec.js
+++ b/spec/AdapterLoader.spec.js
@@ -45,6 +45,19 @@ describe("AdapterLoader", ()=>{
     done();
   });
 
+  it("should instantiate an adapter from npm module", (done) => {
+    var adapter = loadAdapter({
+      module: 'parse-server-fs-adapter'
+    });
+
+    expect(typeof adapter).toBe('object');
+    expect(typeof adapter.createFile).toBe('function');
+    expect(typeof adapter.deleteFile).toBe('function');
+    expect(typeof adapter.getFileData).toBe('function');
+    expect(typeof adapter.getFileLocation).toBe('function');
+    done();
+  });
+
   it("should instantiate an adapter from function/Class", (done) => {
     var adapter = loadAdapter({
       adapter: FilesAdapter

--- a/spec/InstallationsRouter.spec.js
+++ b/spec/InstallationsRouter.spec.js
@@ -5,7 +5,7 @@ var InstallationsRouter = require('../src/Routers/InstallationsRouter').Installa
 
 var config = new Config('test');
 
-describe('InstallationsRouter', () => {
+describe_only_db(['mongo'])('InstallationsRouter', () => {
   it('uses find condition from request.body', (done) => {
     var androidDeviceRequest = {
       'installationId': '12345678-abcd-abcd-abcd-123456789abc',

--- a/spec/InstallationsRouter.spec.js
+++ b/spec/InstallationsRouter.spec.js
@@ -71,6 +71,9 @@ describe('InstallationsRouter', () => {
       var results = res.response.results;
       expect(results.length).toEqual(1);
       done();
+    }).catch((err) => {
+      fail(JSON.stringify(err));
+      done();
     });
   });
 
@@ -171,6 +174,9 @@ describe('InstallationsRouter', () => {
       var response = res.response;
       expect(response.results.length).toEqual(0);
       expect(response.count).toEqual(2);
+      done();
+    }).catch((err) => {
+      fail(JSON.stringify(err));
       done();
     });
   });

--- a/spec/Logger.spec.js
+++ b/spec/Logger.spec.js
@@ -1,4 +1,4 @@
-var logger = require('../src/logger');
+var logging = require('../src/Adapters/Logger/WinstonLogger');
 var winston = require('winston');
 
 class TestTransport extends winston.Transport {
@@ -8,11 +8,15 @@ class TestTransport extends winston.Transport {
 }
 
 describe('Logger', () => {
+  // Test is excluded as will be refactored
   it('should add transport', () => {
-    const testTransport = new (TestTransport)({});
+    const testTransport = new (TestTransport)({
+      name: 'test'
+    });
     spyOn(testTransport, 'log');
-    logger.addTransport(testTransport);
-    logger.logger.info('hi');
+    logging.addTransport(testTransport);
+    logging.logger.info('hi');
     expect(testTransport.log).toHaveBeenCalled();
+    logging.removeTransport(testTransport);
   });
 });

--- a/spec/Logger.spec.js
+++ b/spec/Logger.spec.js
@@ -14,17 +14,18 @@ describe('Logger', () => {
     });
     spyOn(testTransport, 'log');
     logging.addTransport(testTransport);
+    expect(Object.keys(logging.logger.transports).length).toBe(4);
     logging.logger.info('hi');
     expect(testTransport.log).toHaveBeenCalled();
     logging.removeTransport(testTransport);
-    expect(Object.keys(logging.logger.transports).length).toBe(2);
+    expect(Object.keys(logging.logger.transports).length).toBe(3);
   });
 
   it('should have files transports', (done) => {
     reconfigureServer().then(() => {
       let transports = logging.logger.transports;
       let transportKeys = Object.keys(transports);
-      expect(transportKeys.length).toBe(2);
+      expect(transportKeys.length).toBe(3);
       done();
     });
   });
@@ -35,24 +36,23 @@ describe('Logger', () => {
     }).then(() => {
       let transports = logging.logger.transports;
       let transportKeys = Object.keys(transports);
-      expect(transportKeys.length).toBe(0);
+      expect(transportKeys.length).toBe(1);
       done();
     });
   });
 
   it('should enable JSON logs', (done) => {
     // Force console transport
-    process.env.VERBOSE=1;
     reconfigureServer({
       logsFolder: null,
-      jsonLogs: true
+      jsonLogs: true,
+      silent: false
     }).then(() => {
       let spy = spyOn(process.stdout, 'write');
       logging.logger.info('hi', {key: 'value'});
       expect(process.stdout.write).toHaveBeenCalled();
       var firstLog = process.stdout.write.calls.first().args[0];
       expect(firstLog).toEqual(JSON.stringify({key: 'value', level: 'info', message: 'hi' })+'\n');
-      delete process.env.VERBOSE;
       return reconfigureServer({
         jsonLogs: false
       });

--- a/spec/Logger.spec.js
+++ b/spec/Logger.spec.js
@@ -17,46 +17,47 @@ describe('Logger', () => {
     logging.logger.info('hi');
     expect(testTransport.log).toHaveBeenCalled();
     logging.removeTransport(testTransport);
+    expect(Object.keys(logging.logger.transports).length).toBe(2);
   });
 
-  it('should have files transports', (done) => {
-    reconfigureServer().then(() => {
-      let transports = logging.logger.transports;
-      let transportKeys = Object.keys(transports);
-      expect(transportKeys.length).toBe(2);
-      done();
-    });
-  });
+  // xit('should have files transports', (done) => {
+  //   reconfigureServer().then(() => {
+  //     let transports = logging.logger.transports;
+  //     let transportKeys = Object.keys(transports);
+  //     expect(transportKeys.length).toBe(2);
+  //     done();
+  //   });
+  // });
 
-  it('should disable files logs', (done) => {
-    reconfigureServer({
-      logsFolder: null
-    }).then(() => {
-      let transports = logging.logger.transports;
-      let transportKeys = Object.keys(transports);
-      expect(transportKeys.length).toBe(0);
-      done();
-    });
-  });
+  // xit('should disable files logs', (done) => {
+  //   reconfigureServer({
+  //     logsFolder: null
+  //   }).then(() => {
+  //     let transports = logging.logger.transports;
+  //     let transportKeys = Object.keys(transports);
+  //     expect(transportKeys.length).toBe(0);
+  //     done();
+  //   });
+  // });
 
-  xit('should enable JSON logs', (done) => {
-    // Force console transport
-    process.env.VERBOSE=1;
-    reconfigureServer({
-      logsFolder: null,
-      jsonLogs: true
-    }).then(() => {
-      let spy = spyOn(process.stdout, 'write');
-      logging.logger.info('hi', {key: 'value'});
-      expect(process.stdout.write).toHaveBeenCalled();
-      var firstLog = process.stdout.write.calls.first().args[0];
-      expect(firstLog).toEqual(JSON.stringify({key: 'value', level: 'info', message: 'hi' })+'\n');
-      delete process.env.VERBOSE;
-      return reconfigureServer({
-        jsonLogs: false
-      });
-    }).then(() => {
-      done();
-    });
-  });
+  // xit('should enable JSON logs', (done) => {
+  //   // Force console transport
+  //   process.env.VERBOSE=1;
+  //   reconfigureServer({
+  //     logsFolder: null,
+  //     jsonLogs: true
+  //   }).then(() => {
+  //     let spy = spyOn(process.stdout, 'write');
+  //     logging.logger.info('hi', {key: 'value'});
+  //     expect(process.stdout.write).toHaveBeenCalled();
+  //     var firstLog = process.stdout.write.calls.first().args[0];
+  //     expect(firstLog).toEqual(JSON.stringify({key: 'value', level: 'info', message: 'hi' })+'\n');
+  //     delete process.env.VERBOSE;
+  //     return reconfigureServer({
+  //       jsonLogs: false
+  //     });
+  //   }).then(() => {
+  //     done();
+  //   });
+  // });
 });

--- a/spec/Logger.spec.js
+++ b/spec/Logger.spec.js
@@ -39,7 +39,7 @@ describe('Logger', () => {
     });
   });
 
-  it('should enable JSON logs', (done) => {
+  xit('should enable JSON logs', (done) => {
     // Force console transport
     process.env.VERBOSE=1;
     reconfigureServer({

--- a/spec/Logger.spec.js
+++ b/spec/Logger.spec.js
@@ -20,44 +20,44 @@ describe('Logger', () => {
     expect(Object.keys(logging.logger.transports).length).toBe(2);
   });
 
-  // xit('should have files transports', (done) => {
-  //   reconfigureServer().then(() => {
-  //     let transports = logging.logger.transports;
-  //     let transportKeys = Object.keys(transports);
-  //     expect(transportKeys.length).toBe(2);
-  //     done();
-  //   });
-  // });
+  it('should have files transports', (done) => {
+    reconfigureServer().then(() => {
+      let transports = logging.logger.transports;
+      let transportKeys = Object.keys(transports);
+      expect(transportKeys.length).toBe(2);
+      done();
+    });
+  });
 
-  // xit('should disable files logs', (done) => {
-  //   reconfigureServer({
-  //     logsFolder: null
-  //   }).then(() => {
-  //     let transports = logging.logger.transports;
-  //     let transportKeys = Object.keys(transports);
-  //     expect(transportKeys.length).toBe(0);
-  //     done();
-  //   });
-  // });
+  it('should disable files logs', (done) => {
+    reconfigureServer({
+      logsFolder: null
+    }).then(() => {
+      let transports = logging.logger.transports;
+      let transportKeys = Object.keys(transports);
+      expect(transportKeys.length).toBe(0);
+      done();
+    });
+  });
 
-  // xit('should enable JSON logs', (done) => {
-  //   // Force console transport
-  //   process.env.VERBOSE=1;
-  //   reconfigureServer({
-  //     logsFolder: null,
-  //     jsonLogs: true
-  //   }).then(() => {
-  //     let spy = spyOn(process.stdout, 'write');
-  //     logging.logger.info('hi', {key: 'value'});
-  //     expect(process.stdout.write).toHaveBeenCalled();
-  //     var firstLog = process.stdout.write.calls.first().args[0];
-  //     expect(firstLog).toEqual(JSON.stringify({key: 'value', level: 'info', message: 'hi' })+'\n');
-  //     delete process.env.VERBOSE;
-  //     return reconfigureServer({
-  //       jsonLogs: false
-  //     });
-  //   }).then(() => {
-  //     done();
-  //   });
-  // });
+  it('should enable JSON logs', (done) => {
+    // Force console transport
+    process.env.VERBOSE=1;
+    reconfigureServer({
+      logsFolder: null,
+      jsonLogs: true
+    }).then(() => {
+      let spy = spyOn(process.stdout, 'write');
+      logging.logger.info('hi', {key: 'value'});
+      expect(process.stdout.write).toHaveBeenCalled();
+      var firstLog = process.stdout.write.calls.first().args[0];
+      expect(firstLog).toEqual(JSON.stringify({key: 'value', level: 'info', message: 'hi' })+'\n');
+      delete process.env.VERBOSE;
+      return reconfigureServer({
+        jsonLogs: false
+      });
+    }).then(() => {
+      done();
+    });
+  });
 });

--- a/spec/Logger.spec.js
+++ b/spec/Logger.spec.js
@@ -8,7 +8,6 @@ class TestTransport extends winston.Transport {
 }
 
 describe('Logger', () => {
-  // Test is excluded as will be refactored
   it('should add transport', () => {
     const testTransport = new (TestTransport)({
       name: 'test'
@@ -18,5 +17,46 @@ describe('Logger', () => {
     logging.logger.info('hi');
     expect(testTransport.log).toHaveBeenCalled();
     logging.removeTransport(testTransport);
+  });
+
+  it('should have files transports', (done) => {
+    reconfigureServer().then(() => {
+      let transports = logging.logger.transports;
+      let transportKeys = Object.keys(transports);
+      expect(transportKeys.length).toBe(2);
+      done();
+    });
+  });
+
+  it('should disable files logs', (done) => {
+    reconfigureServer({
+      logsFolder: null
+    }).then(() => {
+      let transports = logging.logger.transports;
+      let transportKeys = Object.keys(transports);
+      expect(transportKeys.length).toBe(0);
+      done();
+    });
+  });
+
+  it('should enable JSON logs', (done) => {
+    // Force console transport
+    process.env.VERBOSE=1;
+    reconfigureServer({
+      logsFolder: null,
+      jsonLogs: true
+    }).then(() => {
+      let spy = spyOn(process.stdout, 'write');
+      logging.logger.info('hi', {key: 'value'});
+      expect(process.stdout.write).toHaveBeenCalled();
+      var firstLog = process.stdout.write.calls.first().args[0];
+      expect(firstLog).toEqual(JSON.stringify({key: 'value', level: 'info', message: 'hi' })+'\n');
+      delete process.env.VERBOSE;
+      return reconfigureServer({
+        jsonLogs: false
+      });
+    }).then(() => {
+      done();
+    });
   });
 });

--- a/spec/Subscription.spec.js
+++ b/spec/Subscription.spec.js
@@ -1,10 +1,10 @@
 var Subscription = require('../src/LiveQuery/Subscription').Subscription;
-
+let logger;
 describe('Subscription', function() {
 
   beforeEach(function() {
-    var mockError = jasmine.createSpy('error');
-    jasmine.mockLibrary('../src/LiveQuery/PLog', 'error', mockError);
+    logger = require('../src/logger').logger;
+    spyOn(logger, 'error').and.callThrough();
   });
 
   it('can be initialized', function() {
@@ -62,8 +62,7 @@ describe('Subscription', function() {
     var subscription = new Subscription('className', { key : 'value' }, 'hash');
     subscription.deleteClientSubscription(1, 1);
 
-    var PLog =require('../src/LiveQuery/PLog');
-    expect(PLog.error).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
   });
 
   it('can delete nonexistent request for one client', function() {
@@ -71,8 +70,7 @@ describe('Subscription', function() {
     subscription.addClientSubscription(1, 1);
     subscription.deleteClientSubscription(1, 2);
 
-    var PLog =require('../src/LiveQuery/PLog');
-    expect(PLog.error).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
     expect(subscription.clientRequestIds.size).toBe(1);
     expect(subscription.clientRequestIds.get(1)).toEqual([1]);
   });
@@ -83,8 +81,7 @@ describe('Subscription', function() {
     subscription.addClientSubscription(1, 2);
     subscription.deleteClientSubscription(1, 2);
 
-    var PLog =require('../src/LiveQuery/PLog');
-    expect(PLog.error).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
     expect(subscription.clientRequestIds.size).toBe(1);
     expect(subscription.clientRequestIds.get(1)).toEqual([1]);
   });
@@ -96,8 +93,7 @@ describe('Subscription', function() {
     subscription.deleteClientSubscription(1, 1);
     subscription.deleteClientSubscription(1, 2);
 
-    var PLog =require('../src/LiveQuery/PLog');
-    expect(PLog.error).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
     expect(subscription.clientRequestIds.size).toBe(0);
   });
 
@@ -111,13 +107,8 @@ describe('Subscription', function() {
     subscription.deleteClientSubscription(2, 1);
     subscription.deleteClientSubscription(2, 2);
 
-    var PLog =require('../src/LiveQuery/PLog');
-    expect(PLog.error).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
     expect(subscription.clientRequestIds.size).toBe(1);
     expect(subscription.clientRequestIds.get(1)).toEqual([1]);
-  });
-
-  afterEach(function(){
-    jasmine.restoreLibrary('../src/LiveQuery/PLog', 'error');
   });
 });

--- a/spec/WinstonLoggerAdapter.spec.js
+++ b/spec/WinstonLoggerAdapter.spec.js
@@ -8,7 +8,7 @@ describe('info logs', () => {
 
   it("Verify INFO logs", (done) => {
       var winstonLoggerAdapter = new WinstonLoggerAdapter();
-      winstonLoggerAdapter.info('testing info logs', () => {
+      winstonLoggerAdapter.log('info', 'testing info logs', () => {
         winstonLoggerAdapter.query({
           from: new Date(Date.now() - 500),
           size: 100,
@@ -29,7 +29,7 @@ describe('info logs', () => {
 describe('error logs', () => {
   it("Verify ERROR logs", (done) => {
     var winstonLoggerAdapter = new WinstonLoggerAdapter();
-    winstonLoggerAdapter.error('testing error logs', () => {
+    winstonLoggerAdapter.log('error', 'testing error logs', () => {
       winstonLoggerAdapter.query({
         from: new Date(Date.now() - 500),
         size: 100,

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -352,8 +352,6 @@ global.describe_only_db = db => {
   }
 }
 
-// LiveQuery test setting
-require('../src/LiveQuery/PLog').logLevel = 'NONE';
 var libraryCache = {};
 jasmine.mockLibrary = function(library, name, mock) {
   var original = require(library)[name];

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -45,7 +45,7 @@ var defaultConfiguration = {
   webhookKey: 'hook',
   masterKey: 'test',
   fileKey: 'test',
-  silent: true,
+  silent: !process.env.VERBOSE,
   push: {
     'ios': {
       cert: 'prodCert.pem',

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -45,6 +45,7 @@ var defaultConfiguration = {
   webhookKey: 'hook',
   masterKey: 'test',
   fileKey: 'test',
+  silent: true,
   push: {
     'ios': {
       cert: 'prodCert.pem',

--- a/src/Adapters/Files/GridStoreAdapter.js
+++ b/src/Adapters/Files/GridStoreAdapter.js
@@ -8,14 +8,13 @@
 
 import { MongoClient, GridStore, Db} from 'mongodb';
 import { FilesAdapter }              from './FilesAdapter';
-
-const DefaultMongoURI = 'mongodb://localhost:27017/parse';
+import defaults                      from '../../defaults';
 
 export class GridStoreAdapter extends FilesAdapter {
   _databaseURI: string;
   _connectionPromise: Promise<Db>;
 
-  constructor(mongoDatabaseURI = DefaultMongoURI) {
+  constructor(mongoDatabaseURI = defaults.DefaultMongoURI) {
     super();
     this._databaseURI = mongoDatabaseURI;
     this._connect();

--- a/src/Adapters/Logger/LoggerAdapter.js
+++ b/src/Adapters/Logger/LoggerAdapter.js
@@ -5,13 +5,16 @@
 // Adapter classes must implement the following functions:
 // * info(obj1 [, obj2, .., objN])
 // * error(obj1 [, obj2, .., objN])
-// * query(options, callback)
+// * query(options, callback) /* optional */
+// * configureLogger(options)
 // Default is WinstonLoggerAdapter.js
 
 export class LoggerAdapter {
+  constructor(options) {}
   info() {}
   error() {}
-  query(options, callback) {}
+  warn() {}
+  verbose() {}
 }
 
 export default LoggerAdapter;

--- a/src/Adapters/Logger/LoggerAdapter.js
+++ b/src/Adapters/Logger/LoggerAdapter.js
@@ -4,25 +4,12 @@
 //
 // Adapter classes must implement the following functions:
 // * log() {}
-// * error() {}
-// * warn() {}
-// * info() {}
-// * verbose() {}
-// * debug() {}
-// * silly() {}
 // * query(options, callback) /* optional */
-// * configureLogger(options)
 // Default is WinstonLoggerAdapter.js
 
 export class LoggerAdapter {
   constructor(options) {}
-  log() {}
-  error() {}
-  warn() {}
-  info() {}
-  verbose() {}
-  debug() {}
-  silly() {}
+  log(level, message, /* meta */) {}
 }
 
 export default LoggerAdapter;

--- a/src/Adapters/Logger/LoggerAdapter.js
+++ b/src/Adapters/Logger/LoggerAdapter.js
@@ -3,18 +3,26 @@
 // Allows you to change the logger mechanism
 //
 // Adapter classes must implement the following functions:
-// * info(obj1 [, obj2, .., objN])
-// * error(obj1 [, obj2, .., objN])
+// * log() {}
+// * error() {}
+// * warn() {}
+// * info() {}
+// * verbose() {}
+// * debug() {}
+// * silly() {}
 // * query(options, callback) /* optional */
 // * configureLogger(options)
 // Default is WinstonLoggerAdapter.js
 
 export class LoggerAdapter {
   constructor(options) {}
-  info() {}
+  log() {}
   error() {}
   warn() {}
+  info() {}
   verbose() {}
+  debug() {}
+  silly() {}
 }
 
 export default LoggerAdapter;

--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -1,0 +1,93 @@
+import winston from 'winston';
+import fs from 'fs';
+import path from 'path';
+import DailyRotateFile from 'winston-daily-rotate-file';
+import _ from 'lodash';
+import defaults  from '../../logger';
+
+const logger = new winston.Logger();
+const additionalTransports = [];
+
+function updateTransports(options) {
+  let transports = Object.assign({}, logger.transports);
+  if (options) {
+    if (_.isNull(options.dirname)) {
+      delete transports['parse-server'];
+      delete transports['parse-server-error'];
+    } else if (!_.isUndefined(options.dirname)) {
+      transports['parse-server'] = new (DailyRotateFile)(
+        Object.assign({
+          filename: 'parse-server.info',
+          name: 'parse-server',
+        }, options));
+      transports['parse-server-error'] = new (DailyRotateFile)(
+        Object.assign({
+          filename: 'parse-server.err',
+          name: 'parse-server-error',
+          level: 'error'
+        }, options));
+    }
+
+    if (!process.env.TESTING || process.env.VERBOSE) {
+      transports.console = new (winston.transports.Console)(
+        Object.assign({
+          colorize: true,
+          name: 'console'
+        }, options));
+    }
+  }
+  // Mount the additional transports
+  additionalTransports.forEach((transport) => {
+    transports[transport.name] = transport;
+  });
+  logger.configure({
+    transports: _.values(transports)
+  });
+}
+
+export function configureLogger({
+  logsFolder = defaults.logsFolder,
+  jsonLogs = defaults.jsonLogs,
+  logLevel = winston.level,
+  verbose = defaults.verbose } = {}) {
+
+  if (verbose) {
+    logLevel = 'verbose';
+  }
+
+  winston.level = logLevel;
+  const options = {};
+
+  if (logsFolder) {
+    if (!path.isAbsolute(logsFolder)) {
+      logsFolder = path.resolve(process.cwd(), logsFolder);
+    }
+    try {
+      fs.mkdirSync(logsFolder);
+    } catch (exception) {}
+  }
+  options.dirname = logsFolder;
+  options.level = logLevel;
+  if (jsonLogs) {
+    options.json = true;
+    options.stringify = true;
+  }
+  updateTransports(options);
+}
+
+export function addTransport(transport) {
+  additionalTransports.push(transport);
+  updateTransports();
+}
+
+export function removeTransport(transport) {
+  let transportName = typeof transport == 'string' ? transport : transport.name;
+  let transports = Object.assign({}, logger.transports);
+  delete transports[transportName];
+  logger.configure({
+    transports: _.values(transports)
+  })
+}
+
+export { logger, addTransport, configureLogger, removeTransport };
+export default logger;

--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -11,6 +11,8 @@ const additionalTransports = [];
 function updateTransports(options) {
   let transports = Object.assign({}, logger.transports);
   if (options) {
+    let silent = options.silent;
+    delete options.silent;
     if (_.isNull(options.dirname)) {
       delete transports['parse-server'];
       delete transports['parse-server-error'];
@@ -28,15 +30,12 @@ function updateTransports(options) {
         }, options));
     }
 
-    if (!process.env.TESTING || process.env.VERBOSE) {
-      transports.console = new (winston.transports.Console)(
-        Object.assign({
-          colorize: true,
-          name: 'console'
-        }, options));
-    } else {
-      delete transports['console'];
-    }
+    transports.console = new (winston.transports.Console)(
+      Object.assign({
+        colorize: true,
+        name: 'console',
+        silent
+      }, options));
   }
   // Mount the additional transports
   additionalTransports.forEach((transport) => {
@@ -51,7 +50,8 @@ export function configureLogger({
   logsFolder = defaults.logsFolder,
   jsonLogs = defaults.jsonLogs,
   logLevel = winston.level,
-  verbose = defaults.verbose } = {}) {
+  verbose = defaults.verbose,
+  silent = defaults.silent } = {}) {
 
   if (verbose) {
     logLevel = 'verbose';
@@ -70,6 +70,8 @@ export function configureLogger({
   }
   options.dirname = logsFolder;
   options.level = logLevel;
+  options.silent = silent;
+
   if (jsonLogs) {
     options.json = true;
     options.stringify = true;

--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -14,7 +14,7 @@ function updateTransports(options) {
     if (_.isNull(options.dirname)) {
       delete transports['parse-server'];
       delete transports['parse-server-error'];
-    } else {
+    } else if (!_.isUndefined(options.dirname)) {
       transports['parse-server'] = new (DailyRotateFile)(
         Object.assign({
           filename: 'parse-server.info',

--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -14,7 +14,7 @@ function updateTransports(options) {
     if (_.isNull(options.dirname)) {
       delete transports['parse-server'];
       delete transports['parse-server-error'];
-    } else if (!_.isUndefined(options.dirname)) {
+    } else {
       transports['parse-server'] = new (DailyRotateFile)(
         Object.assign({
           filename: 'parse-server.info',
@@ -34,6 +34,8 @@ function updateTransports(options) {
           colorize: true,
           name: 'console'
         }, options));
+    } else {
+      delete transports['console'];
     }
   }
   // Mount the additional transports
@@ -86,7 +88,10 @@ export function removeTransport(transport) {
   delete transports[transportName];
   logger.configure({
     transports: _.values(transports)
-  })
+  });
+  _.remove(additionalTransports, (transport) => {
+    return transport.name === transportName;
+  });
 }
 
 export { logger, addTransport, configureLogger, removeTransport };

--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import DailyRotateFile from 'winston-daily-rotate-file';
 import _ from 'lodash';
-import defaults  from '../../logger';
+import defaults  from '../../defaults';
 
 const logger = new winston.Logger();
 const additionalTransports = [];

--- a/src/Adapters/Logger/WinstonLoggerAdapter.js
+++ b/src/Adapters/Logger/WinstonLoggerAdapter.js
@@ -15,33 +15,9 @@ export class WinstonLoggerAdapter extends LoggerAdapter {
       configureLogger(options);
     }
   }
-  
-  error() {
-    return logger.error.apply(undefined, arguments);
-  }
-
-  warn() {
-    return logger.warn.apply(undefined, arguments);
-  }
-
-  info() {
-    return logger.info.apply(undefined, arguments);
-  }
-
-  verbose() {
-    return logger.verbose.apply(undefined, arguments);
-  }
-
-  debug() {
-    return logger.debug.apply(undefined, arguments);
-  }
-
-  silly() {
-    return logger.silly.apply(undefined, arguments);
-  }
 
   log() {
-    return logger.log.apply(undefined, arguments);
+    return logger.log.apply(logger, arguments);
   }
 
   addTransport(transport) {

--- a/src/Adapters/Logger/WinstonLoggerAdapter.js
+++ b/src/Adapters/Logger/WinstonLoggerAdapter.js
@@ -15,11 +15,7 @@ export class WinstonLoggerAdapter extends LoggerAdapter {
       configureLogger(options);
     }
   }
-
-  info() {
-    return logger.info.apply(undefined, arguments);
-  }
-
+  
   error() {
     return logger.error.apply(undefined, arguments);
   }
@@ -28,8 +24,20 @@ export class WinstonLoggerAdapter extends LoggerAdapter {
     return logger.warn.apply(undefined, arguments);
   }
 
+  info() {
+    return logger.info.apply(undefined, arguments);
+  }
+
   verbose() {
     return logger.verbose.apply(undefined, arguments);
+  }
+
+  debug() {
+    return logger.debug.apply(undefined, arguments);
+  }
+
+  silly() {
+    return logger.silly.apply(undefined, arguments);
   }
 
   log() {

--- a/src/Adapters/Logger/WinstonLoggerAdapter.js
+++ b/src/Adapters/Logger/WinstonLoggerAdapter.js
@@ -1,63 +1,39 @@
 import { LoggerAdapter } from './LoggerAdapter';
-import { logger, addTransport } from '../../logger';
+import { logger, addTransport, configureLogger } from './WinstonLogger';
 
 const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
-const CACHE_TIME = 1000 * 60;
-
-let currentDate = new Date();
-
-let simpleCache = {
-  timestamp: null,
-  from: null,
-  until: null,
-  order: null,
-  data: [],
-  level: 'info',
-};
 
 // returns Date object rounded to nearest day
 let _getNearestDay = (date) => {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
-// returns Date object of previous day
-let _getPrevDay = (date) => {
-  return new Date(date - MILLISECONDS_IN_A_DAY);
-}
-
-// returns the iso formatted file name
-let _getFileName = () => {
-  return _getNearestDay(currentDate).toISOString()
-}
-
-// check for valid cache when both from and util match.
-// cache valid for up to 1 minute
-let _hasValidCache = (from, until, level) => {
-  if (String(from) === String(simpleCache.from) &&
-    String(until) === String(simpleCache.until) &&
-    new Date() - simpleCache.timestamp < CACHE_TIME &&
-    level === simpleCache.level) {
-    return true;
-  }
-  return false;
-}
-
-// check that log entry has valid time stamp based on query
-let _isValidLogEntry = (from, until, entry) => {
-  var _entry = JSON.parse(entry),
-    timestamp = new Date(_entry.timestamp);
-  return timestamp >= from && timestamp <= until
-    ? true
-    : false
-};
-
 export class WinstonLoggerAdapter extends LoggerAdapter {
+  constructor(options) {
+    super();
+    if (options) {
+      configureLogger(options);
+    }
+  }
+
   info() {
     return logger.info.apply(undefined, arguments);
   }
 
   error() {
     return logger.error.apply(undefined, arguments);
+  }
+
+  warn() {
+    return logger.warn.apply(undefined, arguments);
+  }
+
+  verbose() {
+    return logger.verbose.apply(undefined, arguments);
+  }
+
+  log() {
+    return logger.log.apply(undefined, arguments);
   }
 
   addTransport(transport) {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -17,7 +17,6 @@ let mongodb = require('mongodb');
 let MongoClient = mongodb.MongoClient;
 
 const MongoSchemaCollectionName = '_SCHEMA';
-const DefaultMongoURI = 'mongodb://localhost:27017/parse';
 
 const storageAdapterAllCollections = mongoAdapter => {
   return mongoAdapter.connect()
@@ -86,7 +85,7 @@ export class MongoStorageAdapter {
   database;
 
   constructor({
-    uri = DefaultMongoURI,
+    uri = defaults.DefaultMongoURI,
     collectionPrefix = '',
     mongoOptions = {},
   }) {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -878,6 +878,8 @@ DatabaseController.prototype.addPointerPermissions = function(schema, className,
   }
 }
 
+// TODO: create indexes on first creation of a _User object. Otherwise it's impossible to
+// have a Parse app without it having a _User collection.
 DatabaseController.prototype.performInitizalization = function() {
   const requiredUserFields = { fields: { ...SchemaController.defaultColumns._Default, ...SchemaController.defaultColumns._User } };
 

--- a/src/Controllers/LoggerController.js
+++ b/src/Controllers/LoggerController.js
@@ -60,6 +60,10 @@ export class LoggerController extends AdaptableController {
       throw new Parse.Error(Parse.Error.PUSH_MISCONFIGURED,
         'Logger adapter is not availabe');
     }
+    if (typeof this.adapter.query !== 'function') {
+      throw new Parse.Error(Parse.Error.PUSH_MISCONFIGURED,
+        'Querying logs is not supported with this adapter');
+    }
     options = LoggerController.parseOptions(options);
     return this.adapter.query(options);
   }

--- a/src/Controllers/LoggerController.js
+++ b/src/Controllers/LoggerController.js
@@ -16,7 +16,35 @@ export const LogOrder = {
 }
 
 export class LoggerController extends AdaptableController {
+  
+  log(level, args) {
+    args = [].concat(level, [...args]);
+    this.adapter.log.apply(this.adapter, args);
+  }
 
+  info() {
+    return this.log('info', arguments);
+  }
+  
+  error() {
+    return this.log('error', arguments);
+  }
+
+  warn() {
+    return this.log('warn', arguments);
+  }
+
+  verbose() {
+    return this.log('verbose', arguments);
+  }
+
+  debug() {
+    return this.log('debug', arguments);
+  }
+
+  silly() {
+    return this.log('silly', arguments);
+  }
   // check that date input is valid
   static validDateTime(date) {
     if (!date) {

--- a/src/Controllers/SchemaCache.js
+++ b/src/Controllers/SchemaCache.js
@@ -3,11 +3,12 @@ const SCHEMA_CACHE_PREFIX = "__SCHEMA";
 const ALL_KEYS = "__ALL_KEYS";
 
 import { randomString } from '../cryptoUtils';
+import defaults from '../defaults';
 
 export default class SchemaCache {
   cache: Object;
 
-  constructor(cacheController, ttl = 30) {
+  constructor(cacheController, ttl = defaults.schemaCacheTTL) {
     this.ttl = ttl;
     if (typeof ttl == 'string') {
       this.ttl = parseInt(ttl);

--- a/src/LiveQuery/Client.js
+++ b/src/LiveQuery/Client.js
@@ -1,5 +1,5 @@
-import PLog from './PLog';
 import Parse from 'parse/node';
+import logger from '../logger';
 
 import type { FlattenedObjectData } from './Subscription';
 export type Message = { [attr: string]: any };
@@ -37,7 +37,7 @@ class Client {
   }
 
   static pushResponse(parseWebSocket: any, message: Message): void {
-    PLog.verbose('Push Response : %j', message);
+    logger.verbose('Push Response : %j', message);
     parseWebSocket.send(message);
   }
 

--- a/src/LiveQuery/PLog.js
+++ b/src/LiveQuery/PLog.js
@@ -1,5 +1,0 @@
-import { addGroup } from '../logger';
-
-let PLog = addGroup('parse-live-query-server');
-
-module.exports = PLog;

--- a/src/LiveQuery/ParseCloudCodePublisher.js
+++ b/src/LiveQuery/ParseCloudCodePublisher.js
@@ -1,5 +1,5 @@
 import { ParsePubSub } from './ParsePubSub';
-import PLog from './PLog';
+import logger from '../logger';
 
 class ParseCloudCodePublisher {
   parsePublisher: Object;
@@ -20,7 +20,7 @@ class ParseCloudCodePublisher {
 
   // Request is the request object from cloud code functions. request.object is a ParseObject.
   _onCloudCodeMessage(type: string, request: any): void {
-    PLog.verbose('Raw request from cloud code current : %j | original : %j', request.object, request.original);
+    logger.verbose('Raw request from cloud code current : %j | original : %j', request.object, request.original);
     // We need the full JSON which includes className
     let message = {
       currentParseObject: request.object._toFullJSON()

--- a/src/LiveQuery/ParseWebSocketServer.js
+++ b/src/LiveQuery/ParseWebSocketServer.js
@@ -1,4 +1,4 @@
-import PLog from './PLog';
+import logger from '../logger';
 
 let typeMap = new Map([['disconnect', 'close']]);
 
@@ -9,7 +9,7 @@ export class ParseWebSocketServer {
     let WebSocketServer = require('ws').Server;
     let wss = new WebSocketServer({ server: server });
     wss.on('listening', () => {
-      PLog.log('Parse LiveQuery Server starts running');
+      logger.info('Parse LiveQuery Server starts running');
     });
     wss.on('connection', (ws) => {
       onConnect(new ParseWebSocket(ws));

--- a/src/LiveQuery/SessionTokenCache.js
+++ b/src/LiveQuery/SessionTokenCache.js
@@ -1,6 +1,6 @@
 import Parse from 'parse/node';
 import LRU from 'lru-cache';
-import PLog from './PLog';
+import logger from '../logger';
 
 class SessionTokenCache {
   cache: Object;
@@ -18,16 +18,16 @@ class SessionTokenCache {
     }
     let userId = this.cache.get(sessionToken);
     if (userId) {
-      PLog.verbose('Fetch userId %s of sessionToken %s from Cache', userId, sessionToken);
+      logger.verbose('Fetch userId %s of sessionToken %s from Cache', userId, sessionToken);
       return Parse.Promise.as(userId);
     }
     return Parse.User.become(sessionToken).then((user) => {
-      PLog.verbose('Fetch userId %s of sessionToken %s from Parse', user.id, sessionToken);
+      logger.verbose('Fetch userId %s of sessionToken %s from Parse', user.id, sessionToken);
       let userId = user.id;
       this.cache.set(sessionToken, userId);
       return Parse.Promise.as(userId);
     }, (error) => {
-      PLog.error('Can not fetch userId for sessionToken %j, error %j', sessionToken, error);
+      logger.error('Can not fetch userId for sessionToken %j, error %j', sessionToken, error);
       return Parse.Promise.error(error);
     });
   }

--- a/src/LiveQuery/Subscription.js
+++ b/src/LiveQuery/Subscription.js
@@ -1,5 +1,5 @@
-import {matchesQuery, queryHash} from './QueryTools';
-import PLog from './PLog';
+import {matchesQuery, queryHash}  from './QueryTools';
+import logger from '../logger';
 
 export type FlattenedObjectData = { [attr: string]: any };
 export type QueryData = { [attr: string]: any };
@@ -29,13 +29,13 @@ class Subscription {
   deleteClientSubscription(clientId: number, requestId: number): void {
     let requestIds = this.clientRequestIds.get(clientId);
     if (typeof requestIds === 'undefined') {
-      PLog.error('Can not find client %d to delete', clientId);
+      logger.error('Can not find client %d to delete', clientId);
       return;
     }
 
     let index = requestIds.indexOf(requestId);
     if (index < 0) {
-      PLog.error('Can not find client %d subscription %d to delete', clientId, requestId);
+      logger.error('Can not find client %d subscription %d to delete', clientId, requestId);
       return;
     }
     requestIds.splice(index, 1);

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -157,17 +157,6 @@ class ParseServer {
       throw 'When using an explicit database adapter, you must also use and explicit filesAdapter.';
     }
 
-    if (cloud) {
-      addParseCloud();
-      if (typeof cloud === 'function') {
-        cloud(Parse)
-      } else if (typeof cloud === 'string') {
-        require(path.resolve(process.cwd(), cloud));
-      } else {
-        throw "argument 'cloud' must either be a string or a function";
-      }
-    }
-
     const loggerControllerAdapter = loadAdapter(loggerAdapter, WinstonLoggerAdapter, { jsonLogs, logsFolder, verbose, logLevel, silent });
     const loggerController = new LoggerController(loggerControllerAdapter, appId);
     logging.setLogger(loggerController);
@@ -247,6 +236,17 @@ class ParseServer {
     // Note: Tests will start to fail if any validation happens after this is called.
     if (process.env.TESTING) {
       __indexBuildCompletionCallbackForTests(dbInitPromise);
+    }
+
+    if (cloud) {
+      addParseCloud();
+      if (typeof cloud === 'function') {
+        cloud(Parse)
+      } else if (typeof cloud === 'string') {
+        require(path.resolve(process.cwd(), cloud));
+      } else {
+        throw "argument 'cloud' must either be a string or a function";
+      }
     }
   }
 

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -101,6 +101,7 @@ class ParseServer {
     logsFolder = logging.defaults.logsFolder,
     verbose = logging.defaults.verbose,
     logLevel = logging.defaults.level,
+    silent = logging.defaults.silent,
     databaseURI,
     databaseOptions,
     databaseAdapter,
@@ -173,7 +174,7 @@ class ParseServer {
     // Pass the push options too as it works with the default
     const pushControllerAdapter = loadAdapter(push && push.adapter, ParsePushAdapter, push || {});
 
-    const loggerControllerAdapter = loadAdapter(loggerAdapter, WinstonLoggerAdapter, { jsonLogs, logsFolder, verbose, logLevel });
+    const loggerControllerAdapter = loadAdapter(loggerAdapter, WinstonLoggerAdapter, { jsonLogs, logsFolder, verbose, logLevel, silent });
 
     logging.setLogger(loggerControllerAdapter);
 

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -13,6 +13,7 @@ if (!global._babelPolyfill) {
   require('babel-polyfill');
 }
 
+import defaults                 from './defaults';
 import * as logging             from './logger';
 import AppCache                 from './cache';
 import Config                   from './Config';
@@ -93,15 +94,15 @@ class ParseServer {
     appId = requiredParameter('You must provide an appId!'),
     masterKey = requiredParameter('You must provide a masterKey!'),
     appName,
-    analyticsAdapter = undefined,
+    analyticsAdapter,
     filesAdapter,
     push,
     loggerAdapter,
-    jsonLogs = logging.defaults.jsonLogs,
-    logsFolder = logging.defaults.logsFolder,
-    verbose = logging.defaults.verbose,
-    logLevel = logging.defaults.level,
-    silent = logging.defaults.silent,
+    jsonLogs = defaults.jsonLogs,
+    logsFolder = defaults.logsFolder,
+    verbose = defaults.verbose,
+    logLevel = defaults.level,
+    silent = defaults.silent,
     databaseURI,
     databaseOptions,
     databaseAdapter,
@@ -112,15 +113,15 @@ class ParseServer {
     dotNetKey,
     restAPIKey,
     webhookKey,
-    fileKey = undefined,
+    fileKey,
     facebookAppIds = [],
-    enableAnonymousUsers = true,
-    allowClientClassCreation = true,
+    enableAnonymousUsers = defaults.enableAnonymousUsers,
+    allowClientClassCreation = defaults.allowClientClassCreation,
     oauth = {},
     serverURL = requiredParameter('You must provide a serverURL!'),
-    maxUploadSize = '20mb',
-    verifyUserEmails = false,
-    preventLoginWithUnverifiedEmail = false,
+    maxUploadSize = defaults.maxUploadSize,
+    verifyUserEmails = defaults.verifyUserEmails,
+    preventLoginWithUnverifiedEmail = defaults.preventLoginWithUnverifiedEmail,
     emailVerifyTokenValidityDuration,
     cacheAdapter,
     emailAdapter,
@@ -132,10 +133,10 @@ class ParseServer {
       passwordResetSuccess: undefined
     },
     liveQuery = {},
-    sessionLength = 31536000, // 1 Year in seconds
-    expireInactiveSessions = true,
-    revokeSessionOnPasswordReset = true,
-    schemaCacheTTL = 5, // cache for 5s
+    sessionLength = defaults.sessionLength, // 1 Year in seconds
+    expireInactiveSessions = defaults.expireInactiveSessions,
+    revokeSessionOnPasswordReset = defaults.revokeSessionOnPasswordReset,
+    schemaCacheTTL = defaults.schemaCacheTTL, // cache for 5s
     __indexBuildCompletionCallbackForTests = () => {},
   }) {
     // Initialize the node client SDK automatically

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -168,30 +168,33 @@ class ParseServer {
       }
     }
 
+    const loggerControllerAdapter = loadAdapter(loggerAdapter, WinstonLoggerAdapter, { jsonLogs, logsFolder, verbose, logLevel, silent });
+    const loggerController = new LoggerController(loggerControllerAdapter, appId);
+    logging.setLogger(loggerController);
+
     const filesControllerAdapter = loadAdapter(filesAdapter, () => {
       return new GridStoreAdapter(databaseURI);
     });
+    const filesController = new FilesController(filesControllerAdapter, appId);
+
     // Pass the push options too as it works with the default
     const pushControllerAdapter = loadAdapter(push && push.adapter, ParsePushAdapter, push || {});
-
-    const loggerControllerAdapter = loadAdapter(loggerAdapter, WinstonLoggerAdapter, { jsonLogs, logsFolder, verbose, logLevel, silent });
-    const emailControllerAdapter = loadAdapter(emailAdapter);
-    const cacheControllerAdapter = loadAdapter(cacheAdapter, InMemoryCacheAdapter, {appId: appId});
-    const analyticsControllerAdapter = loadAdapter(analyticsAdapter, AnalyticsAdapter);
-
     // We pass the options and the base class for the adatper,
     // Note that passing an instance would work too
-    const filesController = new FilesController(filesControllerAdapter, appId);
     const pushController = new PushController(pushControllerAdapter, appId, push);
-    const loggerController = new LoggerController(loggerControllerAdapter, appId);
+
+    const emailControllerAdapter = loadAdapter(emailAdapter);
     const userController = new UserController(emailControllerAdapter, appId, { verifyUserEmails });
-    const liveQueryController = new LiveQueryController(liveQuery);
+
+    const cacheControllerAdapter = loadAdapter(cacheAdapter, InMemoryCacheAdapter, {appId: appId});
     const cacheController = new CacheController(cacheControllerAdapter, appId);
-    const databaseController = new DatabaseController(databaseAdapter, new SchemaCache(cacheController, schemaCacheTTL));
-    const hooksController = new HooksController(appId, databaseController, webhookKey);
+
+    const analyticsControllerAdapter = loadAdapter(analyticsAdapter, AnalyticsAdapter);
     const analyticsController = new AnalyticsController(analyticsControllerAdapter);
 
-    logging.setLogger(loggerController);
+    const liveQueryController = new LiveQueryController(liveQuery);
+    const databaseController = new DatabaseController(databaseAdapter, new SchemaCache(cacheController, schemaCacheTTL));
+    const hooksController = new HooksController(appId, databaseController, webhookKey);
 
     const dbInitPromise = databaseController.performInitizalization();
 

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -175,9 +175,6 @@ class ParseServer {
     const pushControllerAdapter = loadAdapter(push && push.adapter, ParsePushAdapter, push || {});
 
     const loggerControllerAdapter = loadAdapter(loggerAdapter, WinstonLoggerAdapter, { jsonLogs, logsFolder, verbose, logLevel, silent });
-
-    logging.setLogger(loggerControllerAdapter);
-
     const emailControllerAdapter = loadAdapter(emailAdapter);
     const cacheControllerAdapter = loadAdapter(cacheAdapter, InMemoryCacheAdapter, {appId: appId});
     const analyticsControllerAdapter = loadAdapter(analyticsAdapter, AnalyticsAdapter);
@@ -194,8 +191,8 @@ class ParseServer {
     const hooksController = new HooksController(appId, databaseController, webhookKey);
     const analyticsController = new AnalyticsController(analyticsControllerAdapter);
 
-    // TODO: create indexes on first creation of a _User object. Otherwise it's impossible to
-    // have a Parse app without it having a _User collection.
+    logging.setLogger(loggerController);
+
     const dbInitPromise = databaseController.performInitizalization();
 
     AppCache.put(appId, {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -103,7 +103,7 @@ class ParseServer {
     verbose = defaults.verbose,
     logLevel = defaults.level,
     silent = defaults.silent,
-    databaseURI,
+    databaseURI = defaults.DefaultMongoURI,
     databaseOptions,
     databaseAdapter,
     cloud,
@@ -142,7 +142,7 @@ class ParseServer {
     // Initialize the node client SDK automatically
     Parse.initialize(appId, javascriptKey || 'unused', masterKey);
     Parse.serverURL = serverURL;
-    if ((databaseOptions || databaseURI || collectionPrefix !== '') && databaseAdapter) {
+    if ((databaseOptions || (databaseURI && databaseURI != defaults.DefaultMongoURI) || collectionPrefix !== '') && databaseAdapter) {
       throw 'You cannot specify both a databaseAdapter and a databaseURI/databaseOptions/connectionPrefix.';
     } else if (!databaseAdapter) {
       databaseAdapter = new MongoStorageAdapter({

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -65,7 +65,7 @@ export class FunctionsRouter extends PromiseRouter {
         master: req.auth && req.auth.isMaster,
         user: req.auth && req.auth.user,
         installationId: req.info.installationId,
-        log: req.config.loggerController && req.config.loggerController.adapter,
+        log: req.config.loggerController,
         headers: req.headers,
         functionName: req.params.functionName
       };

--- a/src/cli/cli-definitions.js
+++ b/src/cli/cli-definitions.js
@@ -193,6 +193,14 @@ export default {
     env: "JSON_LOGS",
     help: "Log as structured JSON objects"
   },
+  "logLevel": {
+    env: "PARSE_SERVER_LOG_LEVEL",
+    help: "Sets the level for logs"
+  },
+  "logsFolder": {
+    env: "PARSE_SERVER_LOGS_FOLDER",
+    help: "Folder for the logs (defaults to './logs')",
+  },
   "revokeSessionOnPasswordReset": {
     env: "PARSE_SERVER_REVOKE_SESSION_ON_PASSWORD_RESET",
     help: "When a user changes their password, either through the reset password email or while logged in, all sessions are revoked if this is true. Set to false if you don't want to revoke sessions.",

--- a/src/cli/cli-definitions.js
+++ b/src/cli/cli-definitions.js
@@ -201,6 +201,9 @@ export default {
     env: "PARSE_SERVER_LOGS_FOLDER",
     help: "Folder for the logs (defaults to './logs')",
   },
+  "silent": {
+    help: "Disables console output",
+  },
   "revokeSessionOnPasswordReset": {
     env: "PARSE_SERVER_REVOKE_SESSION_ON_PASSWORD_RESET",
     help: "When a user changes their password, either through the reset password email or while logged in, all sessions are revoked if this is true. Set to false if you don't want to revoke sessions.",

--- a/src/cli/cli-definitions.js
+++ b/src/cli/cli-definitions.js
@@ -206,7 +206,7 @@ export default {
   },
   "logsFolder": {
     env: "PARSE_SERVER_LOGS_FOLDER",
-    help: "Folder for the logs (defaults to './logs')",
+    help: "Folder for the logs (defaults to './logs'); set to null to disable file based logging",
     action: nullParser
   },
   "silent": {

--- a/src/cli/cli-definitions.js
+++ b/src/cli/cli-definitions.js
@@ -32,6 +32,13 @@ function booleanParser(opt) {
   return false;
 }
 
+function nullParser(opt) {
+  if (opt == 'null') {
+    return null;
+  }
+  return opt;
+}
+
 export default {
   "appId": {
     env: "PARSE_SERVER_APPLICATION_ID",
@@ -200,6 +207,7 @@ export default {
   "logsFolder": {
     env: "PARSE_SERVER_LOGS_FOLDER",
     help: "Folder for the logs (defaults to './logs')",
+    action: nullParser
   },
   "silent": {
     help: "Disables console output",

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -27,5 +27,5 @@ export default {
   sessionLength: 31536000,
   expireInactiveSessions: true,
   revokeSessionOnPasswordReset: true,
-  schemaCacheTTL: 5
+  schemaCacheTTL: 5000 // in ms
 }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,0 +1,30 @@
+let logsFolder = (() => {
+  let folder = './logs/';
+  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
+    folder = './test_logs/'
+  }
+  folder = process.env.PARSE_SERVER_LOGS_FOLDER || folder;
+  return folder;
+})();
+
+let { verbose, level } = (() => {
+  let verbose = process.env.VERBOSE ? true : false;
+  return { verbose, level: verbose ? 'verbose' : undefined }
+})();
+
+export default {
+  jsonLogs: process.env.JSON_LOGS || false,
+  logsFolder,
+  verbose,
+  level,
+  silent: false,
+  enableAnonymousUsers: true,
+  allowClientClassCreation: true,
+  maxUploadSize: '20mb',
+  verifyUserEmails: false,
+  preventLoginWithUnverifiedEmail: false,
+  sessionLength: 31536000,
+  expireInactiveSessions: true,
+  revokeSessionOnPasswordReset: true,
+  schemaCacheTTL: 5
+}

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -13,6 +13,7 @@ let { verbose, level } = (() => {
 })();
 
 export default {
+  DefaultMongoURI: 'mongodb://localhost:27017/parse',
   jsonLogs: process.env.JSON_LOGS || false,
   logsFolder,
   verbose,

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 import ParseServer          from './ParseServer';
-import logger            from './logger';
 import S3Adapter            from 'parse-server-s3-adapter'
 import FileSystemAdapter    from 'parse-server-fs-adapter'
 import InMemoryCacheAdapter from './Adapters/Cache/InMemoryCacheAdapter'
 import TestUtils            from './TestUtils';
-import { useExternal }      from './deprecated'
+import { useExternal }      from './deprecated';
+import { getLogger }        from './logger';
 
 // Factory function
 let _ParseServer = function(options) {
@@ -16,5 +16,9 @@ _ParseServer.createLiveQueryServer = ParseServer.createLiveQueryServer;
 
 let GCSAdapter = useExternal('GCSAdapter', 'parse-server-gcs-adapter');
 
+Object.defineProperty(module.exports, 'logger', {
+  get: getLogger
+});
+
 export default ParseServer;
-export { S3Adapter, GCSAdapter, FileSystemAdapter, InMemoryCacheAdapter, TestUtils, logger, _ParseServer as ParseServer };
+export { S3Adapter, GCSAdapter, FileSystemAdapter, InMemoryCacheAdapter, TestUtils, _ParseServer as ParseServer };

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,104 +1,41 @@
-import winston from 'winston';
-import fs from 'fs';
-import path from 'path';
-import DailyRotateFile from 'winston-daily-rotate-file';
+'use strict';
+let logger;
 
-let LOGS_FOLDER = './logs/';
-
-if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
-  LOGS_FOLDER = './test_logs/'
-}
-
-LOGS_FOLDER = process.env.PARSE_SERVER_LOGS_FOLDER || LOGS_FOLDER;
-const JSON_LOGS = process.env.JSON_LOGS || false;
-
-let currentLogsFolder = LOGS_FOLDER;
-const additionalTransports = [];
-
-function generateTransports(level, options = {}) {
-  let transports = [
-    new (DailyRotateFile)(
-      Object.assign({
-        filename: 'parse-server.info',
-        dirname: currentLogsFolder,
-        name: 'parse-server',
-        level: level
-      }, options)
-    ),
-    new (DailyRotateFile)(
-      Object.assign({
-          filename: 'parse-server.err',
-          dirname: currentLogsFolder,
-          name: 'parse-server-error',
-          level: 'error'
-        }
-      ), options)
-  ].concat(additionalTransports);
-  if (!process.env.TESTING || process.env.VERBOSE) {
-    transports = [
-      new (winston.transports.Console)(
-        Object.assign({
-          colorize: true,
-          level: level
-        }, options)
-      )
-    ].concat(transports);
+let logsFolder = (() => {
+  let folder = './logs/';
+  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
+    folder = './test_logs/'
   }
-  return transports;
+  folder = process.env.PARSE_SERVER_LOGS_FOLDER || folder;
+  return folder;
+})();
+
+let { verbose, level } = (() => {
+  let verbose = process.env.VERBOSE ? true : false;
+  return { verbose, level: verbose ? 'verbose' : undefined }
+})();
+
+export const defaults = {
+  jsonLogs: process.env.JSON_LOGS || false,
+  logsFolder,
+  verbose,
+  level
 }
 
-const logger = new winston.Logger();
-
-export function configureLogger({ logsFolder, jsonLogs, level = winston.level }) {
-  winston.level = level;
-  logsFolder = logsFolder || currentLogsFolder;
-
-  if (!path.isAbsolute(logsFolder)) {
-    logsFolder = path.resolve(process.cwd(), logsFolder);
-  }
-  try {
-    fs.mkdirSync(logsFolder);
-  } catch (exception) {
-    // Ignore, assume the folder already exists
-  }
-  currentLogsFolder = logsFolder;
-
-  const options = {};
-  if (jsonLogs) {
-    options.json = true;
-    options.stringify = true;
-  }
-  const transports = generateTransports(level, options);
-  logger.configure({
-    transports: transports
-  })
+export function setLogger(aLogger) {
+  logger = aLogger;
 }
 
-configureLogger({ logsFolder: LOGS_FOLDER, jsonLogs: JSON_LOGS });
-
-export function addGroup(groupName) {
-  let level = winston.level;
-  let transports = generateTransports().concat(new (DailyRotateFile)({
-    filename: groupName,
-    dirname: currentLogsFolder,
-    name: groupName,
-    level: level
-  }));
-
-  winston.loggers.add(groupName, {
-    transports: transports
-  });
-  return winston.loggers.get(groupName);
+export function getLogger() {
+  return logger;
 }
 
-export function addTransport(transport) {
-  const level = winston.level;
-  additionalTransports.push(transport);
-  const transports = generateTransports(level);
-  logger.configure({
-    transports: transports
-  });
-}
+// for: `import logger from './logger'`
+Object.defineProperty(module.exports, 'default', {
+  get: getLogger
+});
 
-export { logger, addTransport };
-export default logger;
+// for: `import { logger } from './logger'`
+Object.defineProperty(module.exports, 'logger', {
+  get: getLogger
+});

--- a/src/logger.js
+++ b/src/logger.js
@@ -19,7 +19,8 @@ export const defaults = {
   jsonLogs: process.env.JSON_LOGS || false,
   logsFolder,
   verbose,
-  level
+  level,
+  silent: false
 }
 
 export function setLogger(aLogger) {

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,28 +1,6 @@
 'use strict';
 let logger;
 
-let logsFolder = (() => {
-  let folder = './logs/';
-  if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
-    folder = './test_logs/'
-  }
-  folder = process.env.PARSE_SERVER_LOGS_FOLDER || folder;
-  return folder;
-})();
-
-let { verbose, level } = (() => {
-  let verbose = process.env.VERBOSE ? true : false;
-  return { verbose, level: verbose ? 'verbose' : undefined }
-})();
-
-export const defaults = {
-  jsonLogs: process.env.JSON_LOGS || false,
-  logsFolder,
-  verbose,
-  level,
-  silent: false
-}
-
 export function setLogger(aLogger) {
   logger = aLogger;
 }

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -102,7 +102,7 @@ export function getRequestObject(triggerType, auth, parseObject, originalParseOb
     triggerName: triggerType,
     object: parseObject,
     master: false,
-    log: config.loggerController && config.loggerController.adapter
+    log: config.loggerController
   };
 
   if (originalParseObject) {


### PR DESCRIPTION
- Refactors logger into the WinstonLoggerAdapter and WinstonLogger
- Exposes the loggerController, instead of the adapter
- adds `silent` option to silent all console logs (from command line or code)
- adds `logLevel / PARSE_SERVER_LOG_LEVEL` option for setting the log level
- Custom logger adapters will be passed `logLevel, logsFolder, silent, verbose, jsonLogs` options
- Custom loggers don't require the query function anymore to allow fan out loggers
- Custom loggers require only `log` to load properly 
- LoggerController exposes more methods (cf: [winston](https://github.com/winstonjs/winston#logging-levels) and [npm](https://github.com/npm/npmlog/blob/master/log.js)))
