### PR TITLE
Support for validating LinkedIn SDK access_tokens

### DIFF
--- a/src/authDataManager/linkedin.js
+++ b/src/authDataManager/linkedin.js
@@ -4,7 +4,7 @@ var Parse = require('parse/node').Parse;
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData) {
-  return request('people/~:(id)', authData.access_token)
+  return request('people/~:(id)', authData.access_token, authData.is_mobile_sdk)
     .then((data) => {
       if (data && data.id == authData.id) {
         return;
@@ -21,15 +21,21 @@ function validateAppId() {
 }
 
 // A promisey wrapper for api requests
-function request(path, access_token) {
+function request(path, access_token, is_mobile_sdk) {
+  var headers = {
+    'Authorization': 'Bearer ' + access_token,
+    'x-li-format': 'json',
+  }
+
+  if(is_mobile_sdk) {
+    headers['x-li-src'] = 'msdk';
+  }
+
   return new Promise(function(resolve, reject) {
     https.get({
       host: 'api.linkedin.com',
       path: '/v1/' + path,
-      headers: {
-        'Authorization': 'Bearer '+access_token,
-        'x-li-format': 'json'
-      }
+      headers: headers
     }, function(res) {
       var data = '';
       res.on('data', function(chunk) {


### PR DESCRIPTION
When the access_token is obtained through the LinkedIn mobile SDK it needs the `x-li-src: "msdk"` header