### PR TITLE
Syncing afterSave/afterDelete trigger calls (Issue #2489)

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -296,10 +296,10 @@ RestWrite.prototype.handleAuthData = function(authData) {
         // Login with auth data
         delete results[0].password;
         let userResult = results[0];
-        
+
         // need to set the objectId first otherwise location has trailing undefined
         this.data.objectId = userResult.objectId;
-        
+
         // Determine if authData was updated
         let mutatedAuthData = {};
         Object.keys(authData).forEach((provider) => {
@@ -309,7 +309,7 @@ RestWrite.prototype.handleAuthData = function(authData) {
             mutatedAuthData[provider] = providerData;
           }
         });
-        
+
         this.response = {
           response: userResult,
           location: this.location()
@@ -328,7 +328,7 @@ RestWrite.prototype.handleAuthData = function(authData) {
           return this.config.database.update(this.className, {objectId: this.data.objectId}, {authData: mutatedAuthData}, {});
         }
         return;
-        
+
       } else if (this.query && this.query.objectId) {
         // Trying to update auth data but users
         // are different
@@ -476,7 +476,7 @@ RestWrite.prototype.handleFollowup = function() {
     return this.config.database.destroy('_Session', sessionQuery)
     .then(this.handleFollowup.bind(this));
   }
-  
+
   if (this.storage && this.storage['generateNewSession']) {
     delete this.storage['generateNewSession'];
     return this.createSessionToken()
@@ -847,7 +847,7 @@ RestWrite.prototype.runDatabaseOperation = function() {
     .then(response => {
       response.objectId = this.data.objectId;
       response.createdAt = this.data.createdAt;
-      
+
       if (this.responseShouldHaveUsername) {
         response.username = this.data.username;
       }
@@ -895,7 +895,7 @@ RestWrite.prototype.runAfterTrigger = function() {
   this.config.liveQueryController.onAfterSave(updatedObject.className, updatedObject, originalObject);
 
   // Run afterSave trigger
-  triggers.maybeRunTrigger(triggers.Types.afterSave, this.auth, updatedObject, originalObject, this.config);
+  return triggers.maybeRunTrigger(triggers.Types.afterSave, this.auth, updatedObject, originalObject, this.config);
 };
 
 // A helper to figure out what location this operation happens at.
@@ -949,7 +949,7 @@ RestWrite.prototype._updateResponseWithData = function(response, data) {
     let responseValue = response[fieldName];
 
     response[fieldName] = responseValue || dataValue;
-    
+
     // Strips operations from responses
     if (response[fieldName] && response[fieldName].__op) {
       delete response[fieldName];

--- a/src/rest.js
+++ b/src/rest.js
@@ -86,8 +86,7 @@ function del(config, auth, className, objectId, clientSDK) {
       objectId: objectId
     }, options);
   }).then(() => {
-    triggers.maybeRunTrigger(triggers.Types.afterDelete, auth, inflatedObject, null, config);
-    return;
+    return triggers.maybeRunTrigger(triggers.Types.afterDelete, auth, inflatedObject, null, config);    
   });
 }
 

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -214,10 +214,12 @@ export function maybeRunTrigger(triggerType, auth, parseObject, originalParseObj
     //so trigger execution is synced with RestWrite.execute() call.
     //If triggers do not return a promise, they can run async code parallel to the RestWrite.execute() call.
     var triggerPromise = trigger(request, response);
-    if((triggerType === Types.afterSave || triggerType === Types.afterDelete) && triggerPromise && typeof triggerPromise.then === "function")
+    if((triggerType === Types.afterSave || triggerType === Types.afterDelete) && triggerPromise && typeof triggerPromise.then === "function") {}
         return triggerPromise.then(resolve, resolve);
-    else
+    }
+    else {
         return resolve();
+    }
   });
 };
 

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -214,7 +214,7 @@ export function maybeRunTrigger(triggerType, auth, parseObject, originalParseObj
     //so trigger execution is synced with RestWrite.execute() call.
     //If triggers do not return a promise, they can run async code parallel to the RestWrite.execute() call.
     var triggerPromise = trigger(request, response);
-    if((triggerType === Types.afterSave || triggerType === Types.afterDelete) && triggerPromise && typeof triggerPromise.then === "function") {}
+    if((triggerType === Types.afterSave || triggerType === Types.afterDelete) && triggerPromise && typeof triggerPromise.then === "function") {
         return triggerPromise.then(resolve, resolve);
     }
     else {

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -214,11 +214,14 @@ export function maybeRunTrigger(triggerType, auth, parseObject, originalParseObj
     //so trigger execution is synced with RestWrite.execute() call.
     //If triggers do not return a promise, they can run async code parallel to the RestWrite.execute() call.
     var triggerPromise = trigger(request, response);
-    if((triggerType === Types.afterSave || triggerType === Types.afterDelete) && triggerPromise && typeof triggerPromise.then === "function") {
-        return triggerPromise.then(resolve, resolve);
-    }
-    else {
-        return resolve();
+    if(triggerType === Types.afterSave || triggerType === Types.afterDelete)
+    {
+        if(triggerPromise && typeof triggerPromise.then === "function") {
+            return triggerPromise.then(resolve, resolve);
+        }
+        else {
+            return resolve();
+        }
     }
   });
 };

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -158,7 +158,7 @@ function logTrigger(triggerType, className, input) {
     return;
   }
   logger.info(`${triggerType} triggered for ${className}\nInput: ${JSON.stringify(input)}`, {
-    className, 
+    className,
     triggerType,
     input
   });
@@ -166,7 +166,7 @@ function logTrigger(triggerType, className, input) {
 
 function logTriggerSuccess(triggerType, className, input, result) {
   logger.info(`${triggerType} triggered for ${className}\nInput: ${JSON.stringify(input)}\nResult: ${JSON.stringify(result)}`, {
-    className, 
+    className,
     triggerType,
     input,
     result
@@ -175,7 +175,7 @@ function logTriggerSuccess(triggerType, className, input, result) {
 
 function logTriggerError(triggerType, className, input, error) {
   logger.error(`${triggerType} failed for ${className}\nInput: ${JSON.stringify(input)}\Error: ${JSON.stringify(error)}`, {
-    className, 
+    className,
     triggerType,
     input,
     error
@@ -209,7 +209,15 @@ export function maybeRunTrigger(triggerType, auth, parseObject, originalParseObj
     Parse.masterKey = config.masterKey;
     // For the afterSuccess / afterDelete
     logTrigger(triggerType, parseObject.className, parseObject.toJSON());
-    trigger(request, response);
+
+    //AfterSave and afterDelete triggers can return a promise, which if they do, needs to be resolved before this promise is resolved,
+    //so trigger execution is synced with RestWrite.execute() call.
+    //If triggers do not return a promise, they can run async code parallel to the RestWrite.execute() call.
+    var triggerPromise = trigger(request, response);
+    if((triggerType === Types.afterSave || triggerType === Types.afterDelete) && triggerPromise && typeof triggerPromise.then === "function")
+        return triggerPromise.then(resolve, resolve);
+    else
+        return resolve();
   });
 };
 


### PR DESCRIPTION
Implemented syncing afterSave/afterDelete trigger calls with REST request execution flow (Issue 2489). After this change, afterSave and afterDelete triggers CAN return a promise, which needs to be resolved inside a trigger for REST request flow to continue. If trigger doesn't return a promise, request flow continues.