### PR TITLE
Adds bcrypt native binding for better login performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "babel-polyfill": "6.13.0",
-    "bcryptjs": "^2.3.0",
+    "bcryptjs": "2.3.0",
     "body-parser": "1.15.2",
     "commander": "2.9.0",
     "deepcopy": "0.6.3",
@@ -61,7 +61,7 @@
     "jasmine": "2.4.1",
     "mongodb-runner": "3.3.2",
     "nodemon": "1.10.0",
-    "request-promise": "^4.1.1"
+    "request-promise": "4.1.1"
   },
   "scripts": {
     "dev": "npm run build && node bin/dev",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "babel-polyfill": "6.13.0",
-    "bcrypt-nodejs": "0.0.3",
+    "bcryptjs": "^2.3.0",
     "body-parser": "1.15.2",
     "commander": "2.9.0",
     "deepcopy": "0.6.3",
@@ -53,6 +53,7 @@
     "babel-preset-es2015": "6.13.2",
     "babel-preset-stage-0": "6.5.0",
     "babel-register": "6.11.6",
+    "bcrypt-nodejs": "0.0.3",
     "cross-env": "2.0.0",
     "deep-diff": "0.3.4",
     "gaze": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
   },
   "bin": {
     "parse-server": "./bin/parse-server"
+  },
+  "optionalDependencies": {
+    "bcrypt": "0.8.7"
   }
 }

--- a/spec/Auth.spec.js
+++ b/spec/Auth.spec.js
@@ -77,7 +77,18 @@ describe('Auth', () => {
       auth.getUserRoles()
         .then((roles) => expect(roles).toEqual([]))
         .then(() => done());
-    })
+    });
+
+    it('should properly handle bcrypt upgrade', (done) => {
+      var bcryptOriginal = require('bcrypt-nodejs');
+      var bcryptNew = require('bcryptjs');
+      bcryptOriginal.hash('my1Long:password', null, null, function(err, res) {
+        bcryptNew.compare('my1Long:password', res, function(err, res) {
+          expect(res).toBeTruthy();
+          done();
+        })
+      });
+    });
 
   });
 });

--- a/src/password.js
+++ b/src/password.js
@@ -1,10 +1,15 @@
 // Tools for encrypting and decrypting passwords.
 // Basically promise-friendly wrappers for bcrypt.
-var bcrypt = require('bcrypt-nodejs');
+var bcrypt = require('bcryptjs');
+
+try {
+  bcrypt = require('bcrypt');
+} catch(e) {}
+
 // Returns a promise for a hashed password string.
-var hash = function(password) {
+function hash(password) {
   return new Promise(function(fulfill, reject) {
-    bcrypt.hash(password, null, null, function(err, hashedPassword) {
+    bcrypt.hash(password, 10, function(err, hashedPassword) {
       if (err) {
         reject(err);
       } else {
@@ -13,21 +18,6 @@ var hash = function(password) {
     });
   });
 }
-
-try {
-  bcrypt = require('bcrypt');
-  hash = function(password) {
-    return new Promise(function(fulfill, reject) {
-      bcrypt.hash(password, 10,function(err, hashedPassword) {
-        if (err) {
-          reject(err);
-        } else {
-          fulfill(hashedPassword);
-        }
-      });
-    });
-  }
-} catch(e) {}
 
 // Returns a promise for whether this password compares to equal this
 // hashed password.

--- a/src/password.js
+++ b/src/password.js
@@ -1,9 +1,8 @@
 // Tools for encrypting and decrypting passwords.
 // Basically promise-friendly wrappers for bcrypt.
 var bcrypt = require('bcrypt-nodejs');
-
 // Returns a promise for a hashed password string.
-function hash(password) {
+var hash = function(password) {
   return new Promise(function(fulfill, reject) {
     bcrypt.hash(password, null, null, function(err, hashedPassword) {
       if (err) {
@@ -14,6 +13,21 @@ function hash(password) {
     });
   });
 }
+
+try {
+  bcrypt = require('bcrypt');
+  hash = function(password) {
+    return new Promise(function(fulfill, reject) {
+      bcrypt.hash(password, 10,function(err, hashedPassword) {
+        if (err) {
+          reject(err);
+        } else {
+          fulfill(hashedPassword);
+        }
+      });
+    });
+  }
+} catch(e) {}
 
 // Returns a promise for whether this password compares to equal this
 // hashed password.


### PR DESCRIPTION
Fixes #2539 

- Adds optional bcrypt native binding for better performance
- Defaults salt rounds to 10 


> Well... Here are some benchmarks. Ran with `ab -n200 -c100` locally 5 times for each module.

* **Baseline** (immediately fulfill promises in password.js without bcrypt use): 250 req/sec
* **[bcrypt-nodejs](https://github.com/shaneGirish/bcrypt-nodejs)** (current implementation): 5 req/sec
* **[bcryptjs](https://github.com/dcodeIO/bcrypt.js)**: 5 req/sec
* **[twin-bcrypt](https://github.com/fpirsch/twin-bcrypt)**: 5 req/sec
* **[bcrypt](https://github.com/ncb000gt/node.bcrypt.js)** (native bindings): 52 req/sec

