### PR TITLE
Makes sure routes don't overlap and yield a header set error

### DIFF
--- a/src/Controllers/AnalyticsController.js
+++ b/src/Controllers/AnalyticsController.js
@@ -1,6 +1,8 @@
 import AdaptableController from './AdaptableController';
 import { AnalyticsAdapter } from '../Adapters/Analytics/AnalyticsAdapter';
 
+const AppOpenedEventName = 'AppOpened';
+
 export class AnalyticsController extends AdaptableController {
   appOpened(req) {
     return Promise.resolve().then(() => {
@@ -13,8 +15,12 @@ export class AnalyticsController extends AdaptableController {
   }
 
   trackEvent(req) {
+    const eventName = req.params.eventName;
+    if (eventName === AppOpenedEventName) {
+      return this.appOpened(req);
+    }
     return Promise.resolve().then(() => {
-      return this.adapter.trackEvent(req.params.eventName, req.body, req);
+      return this.adapter.trackEvent(eventName, req.body, req);
     }).then((response) => {
       return { response: response || {} };
     }).catch((err) => {

--- a/src/Routers/AnalyticsRouter.js
+++ b/src/Routers/AnalyticsRouter.js
@@ -1,11 +1,6 @@
 // AnalyticsRouter.js
 import PromiseRouter from '../PromiseRouter';
 
-function appOpened(req) {
-  const analyticsController = req.config.analyticsController;
-  return analyticsController.appOpened(req);
-}
-
 function trackEvent(req) {
   const analyticsController = req.config.analyticsController;
   return analyticsController.trackEvent(req);
@@ -14,7 +9,6 @@ function trackEvent(req) {
 
 export class AnalyticsRouter extends PromiseRouter {
   mountRoutes() {
-    this.route('POST','/events/AppOpened', appOpened);
     this.route('POST','/events/:eventName', trackEvent);
   }
 }

--- a/src/Routers/SessionsRouter.js
+++ b/src/Routers/SessionsRouter.js
@@ -11,6 +11,9 @@ export class SessionsRouter extends ClassesRouter {
   }
 
   handleGet(req) {
+    if (req.params.objectId === 'me') {
+      return this.handleMe(req);
+    }
     req.params.className = '_Session';
     return super.handleGet(req);
   }
@@ -49,7 +52,6 @@ export class SessionsRouter extends ClassesRouter {
   }
 
   mountRoutes() {
-    this.route('GET','/sessions/me', req => { return this.handleMe(req); });
     this.route('GET', '/sessions', req => { return this.handleFind(req); });
     this.route('GET', '/sessions/:objectId', req => { return this.handleGet(req); });
     this.route('POST', '/sessions', req => { return this.handleCreate(req); });

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -18,6 +18,9 @@ export class UsersRouter extends ClassesRouter {
   }
 
   handleGet(req) {
+    if (req.params.objectId === 'me') {
+      return this.handleMe(req);
+    }
     req.params.className = '_User';
     return super.handleGet(req);
   }
@@ -198,7 +201,6 @@ export class UsersRouter extends ClassesRouter {
   mountRoutes() {
     this.route('GET', '/users', req => { return this.handleFind(req); });
     this.route('POST', '/users', req => { return this.handleCreate(req); });
-    this.route('GET', '/users/me', req => { return this.handleMe(req); });
     this.route('GET', '/users/:objectId', req => { return this.handleGet(req); });
     this.route('PUT', '/users/:objectId', req => { return this.handleUpdate(req); });
     this.route('DELETE', '/users/:objectId', req => { return this.handleDelete(req); });


### PR DESCRIPTION
Because we call next on each promise resolution, the /me routes would then go into the /:objectId route, this PR makes sure both don't overlap

- Fixes #2520
- Fixes #2362