### PR TITLE
Only allow basic auth credentials with a known appId

### DIFF
--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -26,27 +26,31 @@ describe('server', () => {
   });
 
   it('support http basic authentication with masterkey', done => {
-    request.get({
-      url: 'http://localhost:8378/1/classes/TestObject',
-      headers: {
-      	'Authorization': 'Basic ' + new Buffer('test:' + 'test').toString('base64')
-      }
-    }, (error, response, body) => {
-      expect(response.statusCode).toEqual(200);
-      done();
-    });
+    reconfigureServer({ appId: 'test' }).then(() => {
+      request.get({
+        url: 'http://localhost:8378/1/classes/TestObject',
+        headers: {
+          'Authorization': 'Basic ' + new Buffer('test:' + 'test').toString('base64')
+        }
+      }, (error, response, body) => {
+        expect(response.statusCode).toEqual(200);
+        done();
+      });
+    })
   });
 
   it('support http basic authentication with javascriptKey', done => {
-    request.get({
-      url: 'http://localhost:8378/1/classes/TestObject',
-      headers: {
-      	'Authorization': 'Basic ' + new Buffer('test:javascript-key=' + 'test').toString('base64')
-      }
-    }, (error, response, body) => {
-      expect(response.statusCode).toEqual(200);
-      done();
-    });
+    reconfigureServer({ appId: 'test' }).then(() => {
+      request.get({
+        url: 'http://localhost:8378/1/classes/TestObject',
+        headers: {
+          'Authorization': 'Basic ' + new Buffer('test:javascript-key=' + 'test').toString('base64')
+        }
+      }, (error, response, body) => {
+        expect(response.statusCode).toEqual(200);
+        done();
+      });
+    })
   });
 
   it('fails if database is unreachable', done => {

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -31,9 +31,12 @@ export function handleParseHeaders(req, res, next) {
   var basicAuth = httpAuth(req);
 
   if (basicAuth) {
-    info.appId = basicAuth.appId
-    info.masterKey = basicAuth.masterKey || info.masterKey;
-    info.javascriptKey = basicAuth.javascriptKey || info.javascriptKey;
+    var basicAuthAppId = basicAuth.appId;
+    if (_cache2.default.get(basicAuthAppId)) {
+      info.appId = basicAuthAppId;
+      info.masterKey = basicAuth.masterKey || info.masterKey;
+      info.javascriptKey = basicAuth.javascriptKey || info.javascriptKey;
+    }
   }
 
   if (req.body) {

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -32,7 +32,7 @@ export function handleParseHeaders(req, res, next) {
 
   if (basicAuth) {
     var basicAuthAppId = basicAuth.appId;
-    if (_cache2.default.get(basicAuthAppId)) {
+    if (AppCache.get(basicAuthAppId)) {
       info.appId = basicAuthAppId;
       info.masterKey = basicAuth.masterKey || info.masterKey;
       info.javascriptKey = basicAuth.javascriptKey || info.javascriptKey;


### PR DESCRIPTION
This allows basic auth credentials to be used for the appId, masterKey, and javascriptKey only when the basic auth username is a known appId, otherwise the header or body params will be used for credentials as usual. Addresses issue [#2573](https://github.com/ParsePlatform/parse-server/issues/2573).