### PR TITLE
No need to transform the interior date values

### DIFF
--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -96,6 +96,15 @@ describe('parseObjectToMongoObjectForCreate', () => {
     done();
   });
 
+  it('date in object', (done) => {
+    var inputDate = {__type: 'Date', iso: '2016-08-29T04:46:28.903Z'};
+    var out = transform.parseObjectToMongoObjectForCreate(null, {dateObject: {date:inputDate}},{
+      fields: {dateObject: {type: 'Object'}}
+    });
+    expect(out.dateObject).toEqual({date:inputDate});
+    done();
+  });
+
   it('objectId in a list', (done) => {
     var input = {
       objectId: {'$in': ['one', 'two', 'three']},

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -384,8 +384,6 @@ const transformInteriorAtom = atom => {
     };
   } else if (typeof atom === 'function' || typeof atom === 'symbol') {
     throw new Parse.Error(Parse.Error.INVALID_JSON, `cannot transform value: ${atom}`);
-  } else if (DateCoder.isValidJSON(atom)) {
-    return DateCoder.JSONToDatabase(atom);
   } else if (BytesCoder.isValidJSON(atom)) {
     return BytesCoder.JSONToDatabase(atom);
   } else {


### PR DESCRIPTION
The transformInteriorAtom is being used to transform the nested objects. In case of nested objects we dont need the date object to be converted to the iso string, to make the behavior consistent with the parse.com
