### PR TITLE
Allow specifying variables in your configuration that will be available in cloud code

### DIFF
--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -139,10 +139,12 @@ class ParseServer {
     revokeSessionOnPasswordReset = defaults.revokeSessionOnPasswordReset,
     schemaCacheTTL = defaults.schemaCacheTTL, // cache for 5s
     __indexBuildCompletionCallbackForTests = () => {},
+    cloudCodeVariables // any variables you want to be available in cloud code (via Parse.cloudCodeVariables)
   }) {
     // Initialize the node client SDK automatically
     Parse.initialize(appId, javascriptKey || 'unused', masterKey);
     Parse.serverURL = serverURL;
+    Parse.cloudCodeVariables = cloudCodeVariables;
     if ((databaseOptions || (databaseURI && databaseURI != defaults.DefaultMongoURI) || collectionPrefix !== '') && databaseAdapter) {
       throw 'You cannot specify both a databaseAdapter and a databaseURI/databaseOptions/collectionPrefix.';
     } else if (!databaseAdapter) {

--- a/src/cli/cli-definitions.js
+++ b/src/cli/cli-definitions.js
@@ -225,5 +225,9 @@ export default {
   "cluster": {
     help: "Run with cluster, optionally set the number of processes default to os.cpus().length",
     action: numberParser("cluster"),
+  },
+  "cloudCodeVariables": { 
+    help: "variables that can be used in cloud code via Parse.cloudCodeVariables",
+    action: objectParser
   }
 };


### PR DESCRIPTION
After this change, you can use a configuration like

```
{
    "appId": "myAppId",
    "masterKey": "whatever",
    "databaseURI": "mongodb://localhost:27017/parse",
    "cloud": "./src/cloud-code/main.js",
    "cloudCodeVariables": {
    	"foo": "bar"
    }
}
```

and then, in cloud code, use ```Parse.cloudCodeVariables.foo``` in order to access the value ```bar```.  This is convenient in situations where multiple parse instances are in play and cloud code needs to have some knowledge of how a particular Parse Server is configured.