### PR TITLE
Add NullCacheAdapter

### DIFF
--- a/spec/NullCacheAdapter.spec.js
+++ b/spec/NullCacheAdapter.spec.js
@@ -1,0 +1,37 @@
+var NullCacheAdapter = require('../src/Adapters/Cache/NullCacheAdapter').default;
+
+describe('NullCacheAdapter', function() {
+  var KEY = 'hello';
+  var VALUE = 'world';
+
+  it('should expose promisifyed methods', (done) => {
+    var cache = new NullCacheAdapter({
+      ttl: NaN
+    });
+
+    // Verify all methods return promises.
+    Promise.all([
+      cache.put(KEY, VALUE),
+      cache.del(KEY),
+      cache.get(KEY),
+      cache.clear()
+    ]).then(() => {
+      done();
+    });
+  });
+
+  it('should get/set/clear', (done) => {
+    var cache = new NullCacheAdapter({
+      ttl: NaN
+    });
+
+    cache.put(KEY, VALUE)
+      .then(() => cache.get(KEY))
+      .then((value) => expect(value).toEqual(null))
+      .then(() => cache.clear())
+      .then(() => cache.get(KEY))
+      .then((value) => expect(value).toEqual(null))
+      .then(done);
+  });
+
+});

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -248,6 +248,7 @@ describe('server', () => {
     expect(ParseServer.GCSAdapter).toThrow('GCSAdapter is not provided by parse-server anymore; please install parse-server-gcs-adapter');
     expect(ParseServer.FileSystemAdapter).toThrow();
     expect(ParseServer.InMemoryCacheAdapter).toThrow();
+    expect(ParseServer.NullCacheAdapter).toThrow();
     done();
   });
 

--- a/src/Adapters/Cache/NullCacheAdapter.js
+++ b/src/Adapters/Cache/NullCacheAdapter.js
@@ -1,0 +1,24 @@
+export class NullCacheAdapter {
+
+  constructor(ctx) {
+  }
+
+  get(key) {
+    return new Promise((resolve, _) => {
+      return resolve(null);
+    })
+  }
+
+  put(key, value, ttl) {
+    return Promise.resolve();
+  }
+
+  del(key) {
+    return Promise.resolve();
+  }
+
+  clear() {
+  }
+}
+
+export default NullCacheAdapter;

--- a/src/Adapters/Cache/NullCacheAdapter.js
+++ b/src/Adapters/Cache/NullCacheAdapter.js
@@ -18,6 +18,7 @@ export class NullCacheAdapter {
   }
 
   clear() {
+    return Promise.resolve();
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import ParseServer          from './ParseServer';
 import S3Adapter            from 'parse-server-s3-adapter'
 import FileSystemAdapter    from 'parse-server-fs-adapter'
 import InMemoryCacheAdapter from './Adapters/Cache/InMemoryCacheAdapter'
+import NullCacheAdapter     from './Adapters/Cache/NullCacheAdapter'
 import TestUtils            from './TestUtils';
 import { useExternal }      from './deprecated';
 import { getLogger }        from './logger';
@@ -21,4 +22,4 @@ Object.defineProperty(module.exports, 'logger', {
 });
 
 export default ParseServer;
-export { S3Adapter, GCSAdapter, FileSystemAdapter, InMemoryCacheAdapter, TestUtils, _ParseServer as ParseServer };
+export { S3Adapter, GCSAdapter, FileSystemAdapter, InMemoryCacheAdapter, NullCacheAdapter, TestUtils, _ParseServer as ParseServer };


### PR DESCRIPTION
NullCacheAdapter disables in-memory cache explicitly in order to prevent cache inconsistency between multiple servers.