### PR TITLE
change log level to debug for classes without subscribers (#2594)

### DIFF
--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -108,7 +108,7 @@ class ParseLiveQueryServer {
 
     let classSubscriptions = this.subscriptions.get(className);
     if (typeof classSubscriptions === 'undefined') {
-      logger.error('Can not find subscriptions under this class ' + className);
+      logger.debug('Can not find subscriptions under this class ' + className);
       return;
     }
     for (let subscription of classSubscriptions.values()) {
@@ -153,7 +153,7 @@ class ParseLiveQueryServer {
 
     let classSubscriptions = this.subscriptions.get(className);
     if (typeof classSubscriptions === 'undefined') {
-      logger.error('Can not find subscriptions under this class ' + className);
+      logger.debug('Can not find subscriptions under this class ' + className);
       return;
     }
     for (let subscription of classSubscriptions.values()) {


### PR DESCRIPTION
Changing the log level to debug when a class is being tracked by the Live Query Server, but no client is subscribed to it. 
