### PR TITLE
Tries a new travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+sudo: required
+dist: trusty
 node_js:
 - '4.3'
 - '6.1'


### PR DESCRIPTION
Reduces build times from 5-7 minutes to 3-4 minutes.

> These images are bigger (e.g. 7.5 GB RAM vs 4 GB shared RAM) and aren't sharing the CPU and RAM like on our container-based infrastructure where your builds are currently running. The boot time is slightly higher (20-60s instead of 1-6s)