### PR TITLE
Makes sure we don't duplicate user ACL's keys

### DIFF
--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -1628,4 +1628,41 @@ describe('schemas', () => {
       done();
     });
   });
+
+  it('regression test for #2246', done => {
+    let profile = new Parse.Object('UserProfile');
+    let user = new Parse.User();
+    function initialize() {
+      return user.save({
+        username: 'user',
+        password: 'password'
+      }).then(() => {
+        return profile.save({user}).then(() => {
+        return user.save({
+            userProfile: profile
+          }, {useMasterKey: true});
+        });
+      });
+    }
+
+    initialize().then(() => {
+      return setPermissionsOnClass('UserProfile', {
+        'readUserFields': ['user'],
+        'writeUserFields': ['user']
+      }, true);
+    }).then(() => {
+      return Parse.User.logIn('user', 'password')
+    }).then(() => {
+      let query = new Parse.Query('_User');
+      query.include('userProfile');
+      return query.get(user.id);
+    }).then((user) => {
+      console.log(user.toJSON());
+      expect(user.get('userProfile')).not.toBeUndefined();
+      done();
+    }, (err) => {
+      jfail(err);
+      done();
+    });
+  });
 });

--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -1657,7 +1657,6 @@ describe('schemas', () => {
       query.include('userProfile');
       return query.get(user.id);
     }).then((user) => {
-      console.log(user.toJSON());
       expect(user.get('userProfile')).not.toBeUndefined();
       done();
     }, (err) => {

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -859,6 +859,7 @@ DatabaseController.prototype.addPointerPermissions = function(schema, className,
   // the ACL should have exactly 1 user
   if (perms && perms[field] && perms[field].length > 0) {
     // No user set return undefined
+    // If the length is > 1, that means we didn't dedup users correctly
     if (userACL.length != 1) {
       return;
     }

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -150,7 +150,8 @@ RestQuery.prototype.getUserAndRoleACL = function() {
   }
   return this.auth.getUserRoles().then((roles) => {
     // Concat with the roles to prevent duplications on multiple calls
-    this.findOptions.acl =  this.findOptions.acl.concat(roles);
+    const aclSet = new Set([].concat(this.findOptions.acl, roles));
+    this.findOptions.acl = Array.from(aclSet);
     return Promise.resolve();
   });
 };

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -149,8 +149,8 @@ RestQuery.prototype.getUserAndRoleACL = function() {
     return Promise.resolve();
   }
   return this.auth.getUserRoles().then((roles) => {
-    roles.push(this.auth.user.id);
-    this.findOptions.acl = roles;
+    // Concat with the roles to prevent duplications on multiple calls
+    this.findOptions.acl =  this.findOptions.acl.concat(roles);
     return Promise.resolve();
   });
 };


### PR DESCRIPTION
When using 'include' the userACL would see it's length grow for each subquery.

This fix prevents this behaviour by concatenating the results for the auth.getUserAndRoleACL to the current findOptions.acl.

When the userACL length is > 1 in DatabaseController we also consider it invalid, therefore rendering the query wrong.

Fixes #2246 