### PR TITLE
Run Schema validations after beforeSave #2672

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -954,7 +954,11 @@ it('beforeSave should not affect fetched pointers', done => {
     });
   });
 
-  it('should fully delete objects when using `unset` with beforeSave (regression test for #1840)', done => {
+  /*
+    TODO: fix for Postgres
+    trying to delete a field that doesn't exists doesn't play nice
+   */
+  it_exclude_dbs(['postgres'])('should fully delete objects when using `unset` with beforeSave (regression test for #1840)', done => {
     var TestObject = Parse.Object.extend('TestObject');
     var BeforeSaveObject = Parse.Object.extend('BeforeSaveChanged');
 

--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -96,7 +96,8 @@ const userSchema = {
     "username": {"type": "String"},
     "password": {"type": "String"},
     "email": {"type": "String"},
-    "emailVerified": {"type": "Boolean"}
+    "emailVerified": {"type": "Boolean"},
+    "authData": {"type": "Object"}
   },
   "classLevelPermissions": defaultClassLevelPermissions,
 }
@@ -676,6 +677,7 @@ describe('schemas', () => {
             password: {type: 'String'},
             email: {type: 'String'},
             emailVerified: {type: 'Boolean'},
+            authData: {type: 'Object'},
             newField: {type: 'String'},
             ACL: {type: 'ACL'}
           },
@@ -696,6 +698,7 @@ describe('schemas', () => {
               password: {type: 'String'},
               email: {type: 'String'},
               emailVerified: {type: 'Boolean'},
+              authData: {type: 'Object'},
               newField: {type: 'String'},
               ACL: {type: 'ACL'}
             },

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -31,6 +31,7 @@ const defaultColumns = Object.freeze({
     "password":      {type:'String'},
     "email":         {type:'String'},
     "emailVerified": {type:'Boolean'},
+    "authData":      {type:'Object'}
   },
   // The additional default columns for the _Installation collection (in addition to DefaultCols)
   _Installation: {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -63,8 +63,6 @@ RestWrite.prototype.execute = function() {
   }).then(() => {
     return this.validateClientClassCreation();
   }).then(() => {
-    return this.validateSchema();
-  }).then(() => {
     return this.handleInstallation();
   }).then(() => {
     return this.handleSession();
@@ -72,6 +70,8 @@ RestWrite.prototype.execute = function() {
     return this.validateAuthData();
   }).then(() => {
     return this.runBeforeTrigger();
+  }).then(() => {
+    return this.validateSchema();
   }).then(() => {
     return this.setRequiredFieldsIfNeeded();
   }).then(() => {
@@ -176,7 +176,6 @@ RestWrite.prototype.runBeforeTrigger = function() {
       if (this.query && this.query.objectId) {
         delete this.data.objectId
       }
-      return this.validateSchema();
     }
   });
 };


### PR DESCRIPTION
This proposal will run the schemaValidation after the beforeSave so rejected beforeSave would have no side effects on the schema (adding a key for example) as described in #2672 

Fixes #2672 