### PR TITLE
Correct check for undefined variable

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -262,7 +262,7 @@ RestWrite.prototype.findUsersWithAuthData = function(authData) {
     memo.push(query);
     return memo;
   }, []).filter((q) => {
-    return typeof q !== undefined;
+    return typeof q !== 'undefined';
   });
 
   let findPromise = Promise.resolve([]);


### PR DESCRIPTION
The code was comparing the result of `typeof` with a variable named `undefined`.

As typeof returns a string it should compare to `'undefined'`