### PR TITLE
Ensure _acl is updated when _rperm and _wperm updated

### DIFF
--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -221,7 +221,7 @@ describe('parseObjectToMongoObjectForCreate', () => {
     done();
   });
 
-  it('writes the old ACL format in addition to rperm and wperm', (done) => {
+  it('writes the old ACL format in addition to rperm and wperm on create', (done) => {
     var input = {
       _rperm: ['*'],
       _wperm: ['Kevin'],
@@ -229,10 +229,29 @@ describe('parseObjectToMongoObjectForCreate', () => {
 
     var output = transform.parseObjectToMongoObjectForCreate(null, input, { fields: {} });
     expect(typeof output._acl).toEqual('object');
-    expect(output._acl["Kevin"].w).toBeTruthy();
-    expect(output._acl["Kevin"].r).toBeUndefined();
+    expect(output._acl['Kevin'].w).toBeTruthy();
+    expect(output._acl['Kevin'].r).toBeUndefined();
+    expect(output._rperm).toEqual(input._rperm);
+    expect(output._wperm).toEqual(input._wperm);
     done();
-  })
+  });
+
+  it('writes the old ACL format in addition to rperm and wperm on update', (done) => {
+    var input = {
+      _rperm: ['*'],
+      _wperm: ['Kevin']
+    };
+
+    var output = transform.transformUpdate(null, input, { fields: {} });
+    var set = output.$set;
+    expect(typeof set).toEqual('object');
+    expect(typeof set._acl).toEqual('object');
+    expect(set._acl['Kevin'].w).toBeTruthy();
+    expect(set._acl['Kevin'].r).toBeUndefined();
+    expect(set._rperm).toEqual(input._rperm);
+    expect(set._wperm).toEqual(input._wperm);
+    done();
+  });
 
   it('untransforms from _rperm and _wperm to ACL', (done) => {
     var input = {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -331,7 +331,7 @@ const parseObjectToMongoObjectForCreate = (className, restCreate, schema) => {
 const transformUpdate = (className, restUpdate, parseFormatSchema) => {
   let mongoUpdate = {};
   let acl = addLegacyACL(restUpdate);
-  if (acl) {
+  if (acl._rperm || acl._wperm || acl._acl) {
     mongoUpdate.$set = {};
     if (acl._rperm) {
       mongoUpdate.$set._rperm = acl._rperm;

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -330,11 +330,18 @@ const parseObjectToMongoObjectForCreate = (className, restCreate, schema) => {
 // Main exposed method to help update old objects.
 const transformUpdate = (className, restUpdate, parseFormatSchema) => {
   let mongoUpdate = {};
-  let legacyACL = addLegacyACL(restUpdate)._acl;
-  if (legacyACL) {
-    mongoUpdate.$set = {
-      _acl: legacyACL
-    };
+  let acl = addLegacyACL(restUpdate);
+  if (acl) {
+    mongoUpdate.$set = {};
+    if (acl._rperm) {
+      mongoUpdate.$set._rperm = acl._rperm;
+    }
+    if (acl._wperm) {
+      mongoUpdate.$set._wperm = acl._wperm;
+    }
+    if (acl._acl) {
+      mongoUpdate.$set._acl = acl._acl;
+    }
   }
   for (var restKey in restUpdate) {
     var out = transformKeyValueForUpdate(className, restKey, restUpdate[restKey], parseFormatSchema);

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -330,18 +330,11 @@ const parseObjectToMongoObjectForCreate = (className, restCreate, schema) => {
 // Main exposed method to help update old objects.
 const transformUpdate = (className, restUpdate, parseFormatSchema) => {
   let mongoUpdate = {};
-  let acl = addLegacyACL(restUpdate)._acl;
-  if (acl) {
-    mongoUpdate.$set = {};
-    if (acl._rperm) {
-      mongoUpdate.$set._rperm = acl._rperm;
-    }
-    if (acl._wperm) {
-      mongoUpdate.$set._wperm = acl._wperm;
-    }
-    if (acl._acl) {
-      mongoUpdate.$set._acl = acl._acl;
-    }
+  let legacyACL = addLegacyACL(restUpdate)._acl;
+  if (legacyACL) {
+    mongoUpdate.$set = {
+      _acl: legacyACL
+    };
   }
   for (var restKey in restUpdate) {
     var out = transformKeyValueForUpdate(className, restKey, restUpdate[restKey], parseFormatSchema);


### PR DESCRIPTION
This should fix the bug introduced here: https://github.com/ParsePlatform/parse-server/pull/2021/files#diff-82f0219ca721372e8f2bdbc45c83bbdcR303

Updated existing test and added new test.

@drew-gross can you take a look please?

