### PR TITLE
 Saved filename fixed so that clients display it correctly #2415

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "mime": "1.3.4",
     "mongodb": "2.2.9",
     "multer": "1.2.0",
+    "node-uuid": "^1.4.7",
     "parse": "1.9.1",
     "parse-server-fs-adapter": "1.0.1",
     "parse-server-push-adapter": "1.1.0",

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -26,7 +26,11 @@ export class FilesController extends AdaptableController {
       contentType = mime.lookup(filename);
     }
 
-    filename = randomHexString(32) + '_' + filename;
+    // increased the random string length to 36 so that it is the same length as an UUID with dashes.
+    // This makes file name property extraction for display in clients such as Parse Dashboard to work correctly.
+    // We can not use an UUID with dashes here because it is already used for files.parse.com hosted files and
+    // expandFilesInObject method below uses this distinction to construct the correct url for the file.
+    filename = randomHexString(36) + '_' + filename;
 
     var location = this.adapter.getFileLocation(config, filename);
     return this.adapter.createFile(filename, data, contentType).then(() => {

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -5,6 +5,7 @@ import AdaptableController from './AdaptableController';
 import { FilesAdapter } from '../Adapters/Files/FilesAdapter';
 import path  from 'path';
 import mime from 'mime';
+import uuid from 'node-uuid';
 
 const legacyFilesRegex = new RegExp("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-.*");
 
@@ -26,11 +27,7 @@ export class FilesController extends AdaptableController {
       contentType = mime.lookup(filename);
     }
 
-    // increased the random string length to 36 so that it is the same length as an UUID with dashes.
-    // This makes file name property extraction for display in clients such as Parse Dashboard to work correctly.
-    // We can not use an UUID with dashes here because it is already used for files.parse.com hosted files and
-    // expandFilesInObject method below uses this distinction to construct the correct url for the file.
-    filename = randomHexString(36) + '_' + filename;
+    filename = uuid.v4() + '_' + filename;
 
     var location = this.adapter.getFileLocation(config, filename);
     return this.adapter.createFile(filename, data, contentType).then(() => {


### PR DESCRIPTION
The fix: 
The saved filename is changed to the following format: UUID_originalfilename

The names of files hosted in files.parse.com have the following format:   UUID-originalfilename

The character that follows the UUID in the filenames (underscore and dash) is what allows the expandFilesInObject method to distinguish between Parse Server created/migrated files from files hosted on files.parse.com and generate the correct file URL.