### PR TITLE
Revert "Removes runtime dependency babel-polyfill"

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
+    "babel-polyfill": "6.13.0",
     "bcryptjs": "2.3.0",
     "body-parser": "1.15.2",
     "commander": "2.9.0",

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -99,7 +99,7 @@ const transformKeyValueForUpdate = (className, restKey, restValue, parseFormatSc
 }
 
 const transformInteriorValue = restValue => {
-  if (restValue !== null && typeof restValue === 'object' && Object.keys(restValue).some(key => key.indexOf('$') >= 0 || key.indexOf('.') >= 0)) {
+  if (restValue !== null && typeof restValue === 'object' && Object.keys(restValue).some(key => key.includes('$') || key.includes('.'))) {
     throw new Parse.Error(Parse.Error.INVALID_NESTED_KEY, "Nested keys should not contain the '$' or '.' characters");
   }
   // Handle atomic values
@@ -293,7 +293,7 @@ const parseObjectKeyValueToMongoObjectKeyValue = (restKey, restValue, schema) =>
   }
 
   // Handle normal objects by recursing
-  if (Object.keys(restValue).some(key => key.indexOf('$') >= 0 || key.indexOf('.') >= 0)) {
+  if (Object.keys(restValue).some(key => key.includes('$') || key.includes('.'))) {
     throw new Parse.Error(Parse.Error.INVALID_NESTED_KEY, "Nested keys should not contain the '$' or '.' characters");
   }
   value = _.mapValues(restValue, transformInteriorValue);

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -415,7 +415,7 @@ export class PostgresStorageAdapter {
       return toParseSchema(schema)
     })
     .catch((err) => {
-      if (err.code === PostgresUniqueIndexViolationError && err.detail.indexOf(className) >= 0) {
+      if (err.code === PostgresUniqueIndexViolationError && err.detail.includes(className)) {
         throw new Parse.Error(Parse.Error.INVALID_CLASS_NAME, `Class ${className} already exists.`)
       }
       throw err;
@@ -445,7 +445,7 @@ export class PostgresStorageAdapter {
         relations.push(fieldName)
         return;
       }
-      if (['_rperm', '_wperm'].indexOf(fieldName) >=0 ) {
+      if (['_rperm', '_wperm'].includes(fieldName)) {
         parseType.contents = { type: 'String' };
       }
       valuesArray.push(fieldName);
@@ -678,7 +678,7 @@ export class PostgresStorageAdapter {
           valuesArray.push(object[fieldName].objectId);
           break;
         case 'Array':
-          if (['_rperm', '_wperm'].indexOf(fieldName) >= 0) {
+          if (['_rperm', '_wperm'].includes(fieldName)) {
             valuesArray.push(object[fieldName]);
           } else {
             valuesArray.push(JSON.stringify(object[fieldName]));
@@ -707,7 +707,7 @@ export class PostgresStorageAdapter {
     let initialValues = valuesArray.map((val, index) => {
       let termination = '';
       let fieldName = columnsArray[index];
-      if (['_rperm','_wperm'].indexOf(fieldName) >= 0) {
+      if (['_rperm','_wperm'].includes(fieldName)) {
         termination = '::text[]';
       } else if (schema.fields[fieldName] && schema.fields[fieldName].type === 'Array') {
         termination = '::jsonb';
@@ -1031,9 +1031,9 @@ export class PostgresStorageAdapter {
     const qs = `ALTER TABLE $1:name ADD CONSTRAINT $2:name UNIQUE (${constraintPatterns.join(',')})`;
     return this._client.none(qs,[className, constraintName, ...fieldNames])
     .catch(error => {
-      if (error.code === PostgresDuplicateRelationError && error.message.indexOf(constraintName) >= 0) {
+      if (error.code === PostgresDuplicateRelationError && error.message.includes(constraintName)) {
         // Index already exists. Ignore error.
-      } else if (error.code === PostgresUniqueIndexViolationError && error.message.indexOf(constraintName) >= 0) {
+      } else if (error.code === PostgresUniqueIndexViolationError && error.message.includes(constraintName)) {
         // Cast the error into the proper parse error
         throw new Parse.Error(Parse.Error.DUPLICATE_VALUE, 'A duplicate value for a field with unique values was provided');
       } else {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -9,6 +9,10 @@ var batch = require('./batch'),
     path = require('path'),
     authDataManager = require('./authDataManager');
 
+if (!global._babelPolyfill) {
+  require('babel-polyfill');
+}
+
 import defaults                 from './defaults';
 import * as logging             from './logger';
 import AppCache                 from './cache';


### PR DESCRIPTION
Reverts ParsePlatform/parse-server#2692

It needs more work as many other things are polyfilled

Fixes #2727

Also, the tests have the polyfill injected for whatever reason so we can't know at test time if the generated lib is compatible...