### PR TITLE
Lookup for email in username field to match docs if email is undefined

### DIFF
--- a/spec/MockEmailAdapterWithOptions.js
+++ b/spec/MockEmailAdapterWithOptions.js
@@ -17,6 +17,5 @@ module.exports = options => {
 		adapter.sendVerificationEmail = options.sendVerificationEmail;
 	}
 
-
 	return adapter;
 }

--- a/spec/MockEmailAdapterWithOptions.js
+++ b/spec/MockEmailAdapterWithOptions.js
@@ -2,9 +2,21 @@ module.exports = options => {
 	if (!options) {
 		throw "Options were not provided"
 	}
-	return {
+	let adapter = {
 		sendVerificationEmail: () => Promise.resolve(),
     sendPasswordResetEmail: () => Promise.resolve(),
     sendMail: () => Promise.resolve()
+	};
+	if (options.sendMail) {
+		adapter.sendMail = options.sendMail
 	}
+	if (options.sendPasswordResetEmail) {
+		adapter.sendPasswordResetEmail = options.sendPasswordResetEmail
+	}
+	if (options.sendVerificationEmail) {
+		adapter.sendVerificationEmail = options.sendVerificationEmail;
+	}
+
+
+	return adapter;
 }

--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -484,12 +484,16 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
       fromAddress: 'parse@example.com',
       apiKey: 'k',
       domain: 'd',
-      sendPasswordResetEmail: function(options) {
-        expect(options.user.get('username').toEqual('testValidConfig@parse.com'));
+      sendMail: function(options) {
+        expect(options.to).toEqual('testValidConfig@parse.com');
         return Promise.resolve();
       }
     });
-    spyOn(adapter, 'sendPasswordResetEmail').and.callThrough();
+
+    // delete that handler to force using the default
+    delete adapter.sendPasswordResetEmail;
+
+    spyOn(adapter, 'sendMail').and.callThrough();
     reconfigureServer({
       appName: 'coolapp',
       publicServerURL: 'http://localhost:1337/1',
@@ -502,7 +506,7 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
       user.signUp(null)
       .then(user => Parse.User.requestPasswordReset("testValidConfig@parse.com"))
       .then(result => {
-        expect(adapter.sendPasswordResetEmail).toHaveBeenCalled();
+        expect(adapter.sendMail).toHaveBeenCalled();
         done();
       }, error => {
         done(error);

--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -479,6 +479,41 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
     });
   });
 
+  it('succeeds sending a password reset username if appName, publicServerURL, and email adapter are prodvided', done => {
+    let adapter = MockEmailAdapterWithOptions({
+      fromAddress: 'parse@example.com',
+      apiKey: 'k',
+      domain: 'd',
+      sendPasswordResetEmail: function(options) {
+        expect(options.user.get('username').toEqual('testValidConfig@parse.com'));
+        return Promise.resolve();
+      }
+    });
+    spyOn(adapter, 'sendPasswordResetEmail').and.callThrough();
+    reconfigureServer({
+      appName: 'coolapp',
+      publicServerURL: 'http://localhost:1337/1',
+      emailAdapter: adapter
+    })
+    .then(() => {
+      let user = new Parse.User();
+      user.setPassword("asdf");
+      user.setUsername("testValidConfig@parse.com");
+      user.signUp(null)
+      .then(user => Parse.User.requestPasswordReset("testValidConfig@parse.com"))
+      .then(result => {
+        expect(adapter.sendPasswordResetEmail).toHaveBeenCalled();
+        done();
+      }, error => {
+        done(error);
+      });
+    })
+    .catch(error => {
+      fail(JSON.stringify(error));
+      done();
+    });
+  });
+
   it('does not send verification email if email verification is disabled', done => {
     var emailAdapter = {
       sendVerificationEmail: () => Promise.resolve(),

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -125,7 +125,7 @@ export class UserController extends AdaptableController {
   }
 
   setPasswordResetToken(email) {
-    return this.config.database.update('_User', { $or: [{email}, {username: email, email: undefined}] }, { _perishable_token: randomString(25) }, {}, true)
+    return this.config.database.update('_User', { $or: [{email}, {username: email, email: {$exists: false}}] }, { _perishable_token: randomString(25) }, {}, true)
   }
 
   sendPasswordResetEmail(email) {

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -125,7 +125,7 @@ export class UserController extends AdaptableController {
   }
 
   setPasswordResetToken(email) {
-    return this.config.database.update('_User', { email }, { _perishable_token: randomString(25) }, {}, true)
+    return this.config.database.update('_User', { $or: [{email}, {username: email, email: undefined}] }, { _perishable_token: randomString(25) }, {}, true)
   }
 
   sendPasswordResetEmail(email) {

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -181,7 +181,7 @@ export class UserController extends AdaptableController {
         "You requested to reset your password for " + appName + ".\n\n" +
         "" +
         "Click here to reset it:\n" + link;
-    let to = user.get("email");
+    let to = user.get("email") || user.get('username');
     let subject =  'Password Reset for ' + appName;
     return { text, to, subject };
   }


### PR DESCRIPTION
Fixes #2502

When the email is not set on the user, the docs expressively says that the server should lookup in the username field. 

This PR propose that change.

Note that the adapters should adapt to that change if implementing `sendPasswordResetEmail`, and lookup in the username field is email is not set.

If the adapter like parse-server-simple-mailgun-adapter only implements `sendMail` no change is required.