### PR TITLE
Support for nested `.select()` calls

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -2597,6 +2597,46 @@ describe('Parse.Query testing', () => {
     });
   });
 
+  it('select nested keys 2 level (issue #1567)', function(done) {
+    var Foobar = new Parse.Object('Foobar');
+    var BarBaz = new Parse.Object('Barbaz');
+    var Bazoo = new Parse.Object('Bazoo');
+
+    Bazoo.set('some', 'thing');
+    Bazoo.set('otherSome', 'value');
+    Bazoo.save().then(() => {
+      BarBaz.set('key', 'value');
+      BarBaz.set('otherKey', 'value');
+      BarBaz.set('bazoo', Bazoo);
+      return BarBaz.save();
+    }).then(() => {
+      Foobar.set('foo', 'bar');
+      Foobar.set('fizz', 'buzz');
+      Foobar.set('barBaz', BarBaz);
+      return Foobar.save();
+    }).then(function(savedFoobar){
+      var foobarQuery = new Parse.Query('Foobar');
+      foobarQuery.include('barBaz');
+      foobarQuery.include('barBaz.bazoo');
+      foobarQuery.select(['fizz', 'barBaz.key', 'barBaz.bazoo.some']);
+      foobarQuery.get(savedFoobar.id,{
+        success: function(foobarObj){
+          equal(foobarObj.get('fizz'), 'buzz');
+          equal(foobarObj.get('foo'), undefined);
+          if (foobarObj.has('barBaz')) {
+            equal(foobarObj.get('barBaz').get('key'), 'value');
+            equal(foobarObj.get('barBaz').get('otherKey'), undefined);
+            equal(foobarObj.get('barBaz').get('bazoo').get('some'), 'thing');
+            equal(foobarObj.get('barBaz').get('bazoo').get('otherSome'), undefined);
+          } else {
+            fail('barBaz should be set');
+          }
+          done();
+        }
+      });
+    });
+  });
+
   it('properly handles nested ors', function(done) {
     var objects = [];
     while(objects.length != 4) {

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -2567,6 +2567,35 @@ describe('Parse.Query testing', () => {
     })
   });
 
+  it('select nested keys (issue #1567)', function(done) {
+    var BarBaz = new Parse.Object('Barbaz');
+    BarBaz.set('key', 'value');
+    BarBaz.set('otherKey', 'value');
+    var Foobar = new Parse.Object('Foobar');
+    Foobar.set('foo', 'bar');
+    Foobar.set('fizz', 'buzz');
+    Foobar.set('barBaz', BarBaz);
+    Foobar.save({
+      success: function(savedFoobar){
+        var foobarQuery = new Parse.Query('Foobar');
+        foobarQuery.select(['fizz', 'barBaz.key']);
+        foobarQuery.get(savedFoobar.id,{
+          success: function(foobarObj){
+            equal(foobarObj.get('fizz'), 'buzz');
+            equal(foobarObj.get('foo'), undefined);
+            if (foobarObj.has('barBaz')) {
+              equal(foobarObj.get('barBaz').get('key'), 'value');
+              equal(foobarObj.get('barBaz').get('otherKey'), undefined);
+            } else {
+              fail('barBaz should be set');
+            }
+            done();
+          }
+        });
+      }
+    })
+  });
+
   it('properly handles nested ors', function(done) {
     var objects = [];
     while(objects.length != 4) {

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -2568,32 +2568,33 @@ describe('Parse.Query testing', () => {
   });
 
   it('select nested keys (issue #1567)', function(done) {
+    var Foobar = new Parse.Object('Foobar');
     var BarBaz = new Parse.Object('Barbaz');
     BarBaz.set('key', 'value');
     BarBaz.set('otherKey', 'value');
-    var Foobar = new Parse.Object('Foobar');
-    Foobar.set('foo', 'bar');
-    Foobar.set('fizz', 'buzz');
-    Foobar.set('barBaz', BarBaz);
-    Foobar.save({
-      success: function(savedFoobar){
-        var foobarQuery = new Parse.Query('Foobar');
-        foobarQuery.select(['fizz', 'barBaz.key']);
-        foobarQuery.get(savedFoobar.id,{
-          success: function(foobarObj){
-            equal(foobarObj.get('fizz'), 'buzz');
-            equal(foobarObj.get('foo'), undefined);
-            if (foobarObj.has('barBaz')) {
-              equal(foobarObj.get('barBaz').get('key'), 'value');
-              equal(foobarObj.get('barBaz').get('otherKey'), undefined);
-            } else {
-              fail('barBaz should be set');
-            }
-            done();
+    BarBaz.save().then(() => {
+      Foobar.set('foo', 'bar');
+      Foobar.set('fizz', 'buzz');
+      Foobar.set('barBaz', BarBaz);
+      return Foobar.save();
+    }).then(function(savedFoobar){
+      var foobarQuery = new Parse.Query('Foobar');
+      foobarQuery.include('barBaz');
+      foobarQuery.select(['fizz', 'barBaz.key']);
+      foobarQuery.get(savedFoobar.id,{
+        success: function(foobarObj){
+          equal(foobarObj.get('fizz'), 'buzz');
+          equal(foobarObj.get('foo'), undefined);
+          if (foobarObj.has('barBaz')) {
+            equal(foobarObj.get('barBaz').get('key'), 'value');
+            equal(foobarObj.get('barBaz').get('otherKey'), undefined);
+          } else {
+            fail('barBaz should be set');
           }
-        });
-      }
-    })
+          done();
+        }
+      });
+    });
   });
 
   it('properly handles nested ors', function(done) {

--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -13,8 +13,8 @@ export default class MongoCollection {
   // none, then build the geoindex.
   // This could be improved a lot but it's not clear if that's a good
   // idea. Or even if this behavior is a good idea.
-  find(query, { skip, limit, sort } = {}) {
-    return this._rawFind(query, { skip, limit, sort })
+  find(query, { skip, limit, sort, keys } = {}) {
+    return this._rawFind(query, { skip, limit, sort, keys })
       .catch(error => {
         // Check for "no geoindex" error
         if (error.code != 17007 && !error.message.match(/unable to find index for .geoNear/)) {
@@ -30,14 +30,18 @@ export default class MongoCollection {
         index[key] = '2d';
         return this._mongoCollection.createIndex(index)
           // Retry, but just once.
-          .then(() => this._rawFind(query, { skip, limit, sort }));
+          .then(() => this._rawFind(query, { skip, limit, sort, keys }));
       });
   }
 
-  _rawFind(query, { skip, limit, sort } = {}) {
-    return this._mongoCollection
+  _rawFind(query, { skip, limit, sort, keys } = {}) {
+    let findOperation = this._mongoCollection
       .find(query, { skip, limit, sort })
-      .toArray();
+
+    if (keys) {
+      findOperation = findOperation.project(keys);
+    }
+    return findOperation.toArray();
   }
 
   count(query, { skip, limit, sort } = {}) {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -320,12 +320,16 @@ export class MongoStorageAdapter {
   }
 
   // Executes a find. Accepts: className, query in Parse format, and { skip, limit, sort }.
-  find(className, schema, query, { skip, limit, sort }) {
+  find(className, schema, query, { skip, limit, sort, keys }) {
     schema = convertParseSchemaToMongoSchema(schema);
     let mongoWhere = transformWhere(className, query, schema);
     let mongoSort = _.mapKeys(sort, (value, fieldName) => transformKey(className, fieldName, schema));
+    let mongoKeys = _.reduce(keys, (memo, key) => {
+      memo[transformKey(className, key, schema)] = 1;
+      return memo;
+    }, {});
     return this._adaptiveCollection(className)
-    .then(collection => collection.find(mongoWhere, { skip, limit, sort: mongoSort }))
+    .then(collection => collection.find(mongoWhere, { skip, limit, sort: mongoSort, keys: mongoKeys }))
     .then(objects => objects.map(object => mongoObjectToParseObject(className, object, schema)))
   }
 

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -11,8 +11,10 @@ const transformKey = (className, fieldName, schema) => {
     case 'updatedAt': return '_updated_at';
     case 'sessionToken': return '_session_token';
   }
-
+  
   if (schema.fields[fieldName] && schema.fields[fieldName].__type == 'Pointer') {
+    fieldName = '_p_' + fieldName;
+  } else if (schema.fields[fieldName] && schema.fields[fieldName].type == 'Pointer') {
     fieldName = '_p_' + fieldName;
   }
 

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -921,8 +921,8 @@ export class PostgresStorageAdapter {
     });
   }
 
-  find(className, schema, query, { skip, limit, sort }) {
-    debug('find', className, query, {skip, limit, sort});
+  find(className, schema, query, { skip, limit, sort, keys }) {
+    debug('find', className, query, {skip, limit, sort, keys });
     const hasLimit = limit !== undefined;
     const hasSkip = skip !== undefined;
     let values = [className];
@@ -954,7 +954,15 @@ export class PostgresStorageAdapter {
       sortPattern = `ORDER BY ${where.sorts.join(',')}`;
     }
 
-    const qs = `SELECT * FROM $1:name ${wherePattern} ${sortPattern} ${limitPattern} ${skipPattern}`;
+    let columns = '*';
+    if (keys) {
+      columns = keys.map((key, index) => {
+        return `$${index+values.length+1}:name`;
+      }).join(',');
+      values = values.concat(keys);
+    }
+
+    const qs = `SELECT ${columns} FROM $1:name ${wherePattern} ${sortPattern} ${limitPattern} ${skipPattern}`;
     debug(qs, values);
     return this._client.any(qs, values)
     .catch((err) => {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -956,6 +956,10 @@ export class PostgresStorageAdapter {
 
     let columns = '*';
     if (keys) {
+      // Exclude empty keys
+      keys = keys.filter((key) => {
+        return key.length > 0;
+      });
       columns = keys.map((key, index) => {
         return `$${index+values.length+1}:name`;
       }).join(',');

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -711,6 +711,7 @@ DatabaseController.prototype.find = function(className, query, {
   acl,
   sort = {},
   count,
+  keys
 } = {}) {
   let isMaster = acl === undefined;
   let aclGroup = acl || [];
@@ -779,7 +780,7 @@ DatabaseController.prototype.find = function(className, query, {
           if (!classExists) {
             return [];
           } else {
-            return this.adapter.find(className, schema, query, { skip, limit, sort })
+            return this.adapter.find(className, schema, query, { skip, limit, sort, keys })
             .then(objects => objects.map(object => {
               object = untransformObjectACL(object);
               return filterSensitiveData(isMaster, aclGroup, className, object)

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -489,17 +489,18 @@ function includePath(config, auth, response, path, restOptions = {}) {
   let includeRestOptions = {};
   if (restOptions.keys) {
     let keys = new Set(restOptions.keys.split(','));
-    includeRestOptions.keys = Array.from(keys).reduce((memo, key) => {
+    let keySet = Array.from(keys).reduce((set, key) => {
       let keyPath = key.split('.');
       let i=0;
       for (i; i<path.length; i++) {
         if (path[i] != keyPath[i]) {
-          return memo;
+          return set;
         }
       }
-      memo.push(keyPath[i]);
-      return memo;
-    }, []).join(',');
+      set.add(keyPath[i]);
+      return set;
+    }, new Set());
+    includeRestOptions.keys = Array.from(keySet).join(',');
   }
 
   let queryPromises = Object.keys(pointersHash).map((className) => {


### PR DESCRIPTION
- Handle `keys` property in RestQuery when it contains nesting. 
- Support multiple level of nesting and inclusion

Fixes #1567