### PR TITLE
Move password masking out of logging clients where possible

### DIFF
--- a/spec/WinstonLoggerAdapter.spec.js
+++ b/spec/WinstonLoggerAdapter.spec.js
@@ -97,20 +97,4 @@ describe('verbose logs', () => {
       done();
     })
   });
-
-  it("should not mask information in non _User class", (done) => {
-    let obj = new Parse.Object('users');
-    obj.set('password', 'pw');
-    obj.save().then(() => {
-      let winstonLoggerAdapter = new WinstonLoggerAdapter();
-      return winstonLoggerAdapter.query({
-        from: new Date(Date.now() - 500),
-        size: 100,
-        level: 'verbose'
-      });
-    }).then((results) => {
-      expect(results[1].body.password).toEqual("pw");
-      done();
-    });
-  });
 });

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -125,10 +125,10 @@ export class FunctionsRouter extends PromiseRouter {
 
       return new Promise(function (resolve, reject) {
         const userString = (req.auth && req.auth.user) ? req.auth.user.id : undefined;
-        const cleanInput = logger.cleanAndTruncateLogMessage(JSON.stringify(params));
+        const cleanInput = logger.truncateLogMessage(JSON.stringify(params));
         var response = FunctionsRouter.createResponseObject((result) => {
           try {
-            const cleanResult = logger.cleanAndTruncateLogMessage(JSON.stringify(result.response.result));
+            const cleanResult = logger.truncateLogMessage(JSON.stringify(result.response.result));
             logger.info(`Ran cloud function ${functionName} for user ${userString} `
               + `with:\n  Input: ${cleanInput }\n  Result: ${cleanResult }`, {
               functionName,

--- a/src/triggers.js
+++ b/src/triggers.js
@@ -212,7 +212,7 @@ function userIdForLog(auth) {
 }
 
 function logTriggerAfterHook(triggerType, className, input, auth) {
-  const cleanInput = logger.cleanAndTruncateLogMessage(JSON.stringify(input));
+  const cleanInput = logger.truncateLogMessage(JSON.stringify(input));
   logger.info(`${triggerType} triggered for ${className} for user ${userIdForLog(auth)}:\n  Input: ${cleanInput}`, {
     className,
     triggerType,
@@ -221,8 +221,8 @@ function logTriggerAfterHook(triggerType, className, input, auth) {
 }
 
 function logTriggerSuccessBeforeHook(triggerType, className, input, result, auth) {
-  const cleanInput = logger.cleanAndTruncateLogMessage(JSON.stringify(input));
-  const cleanResult = logger.cleanAndTruncateLogMessage(JSON.stringify(result));
+  const cleanInput = logger.truncateLogMessage(JSON.stringify(input));
+  const cleanResult = logger.truncateLogMessage(JSON.stringify(result));
   logger.info(`${triggerType} triggered for ${className} for user ${userIdForLog(auth)}:\n  Input: ${cleanInput}\n  Result: ${cleanResult}`, {
     className,
     triggerType,
@@ -231,7 +231,7 @@ function logTriggerSuccessBeforeHook(triggerType, className, input, result, auth
 }
 
 function logTriggerErrorBeforeHook(triggerType, className, input, auth, error) {
-  const cleanInput = logger.cleanAndTruncateLogMessage(JSON.stringify(input));
+  const cleanInput = logger.truncateLogMessage(JSON.stringify(input));
   logger.error(`${triggerType} failed for ${className} for user ${userIdForLog(auth)}:\n  Input: ${cleanInput}\n  Error: ${JSON.stringify(error)}`, {
     className,
     triggerType,


### PR DESCRIPTION
Move password masking functionality into LoggerController.

The is a more aggresive approach to masking password string in the logs.

Cleaning the url is still in the PromiseRouter because picking it out of the log string
would be fragile.

This will cause more log messages to be scanned for password strings, and may cause a password
string to be obsfucated that is not neccesarily part of parse internals -- but i think that is
still a good thing....

see: #2755 & #2680