### PR TITLE
Properly handle select/include pairs #2786

### DIFF
--- a/spec/ParseObject.spec.js
+++ b/spec/ParseObject.spec.js
@@ -1955,4 +1955,34 @@ describe('Parse.Object testing', () => {
       done();
     })
   });
+
+  it('should handle select and include #2786', (done) => {
+    let score = new Parse.Object("GameScore");
+    let player = new Parse.Object("Player");
+    score.set({
+      "score": 1234
+    });
+
+    score.save().then(() => {
+      player.set("gameScore", score);
+      player.set("other", "value");
+      return player.save();
+    }).then(() => {
+      let query = new Parse.Query("Player");
+      query.include("gameScore");
+      query.select("gameScore");
+      return query.find();
+    }).then((res) => {
+      let obj = res[0];
+      let gameScore = obj.get("gameScore");
+      let other = obj.get("other");
+      expect(other).toBeUndefined();
+      expect(gameScore).not.toBeUndefined();
+      expect(gameScore.get("score")).toBe(1234);
+      done();
+    }).catch(err => {
+      jfail(err);
+      done();
+    })
+  });
 });

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -488,7 +488,6 @@ function includePath(config, auth, response, path, restOptions = {}) {
       pointersHash[className].add(pointer.objectId);
     }
   }
-
   let includeRestOptions = {};
   if (restOptions.keys) {
     let keys = new Set(restOptions.keys.split(','));
@@ -500,10 +499,14 @@ function includePath(config, auth, response, path, restOptions = {}) {
           return set;
         }
       }
-      set.add(keyPath[i]);
+      if (i < keyPath.length) {
+        set.add(keyPath[i]);
+      }
       return set;
     }, new Set());
-    includeRestOptions.keys = Array.from(keySet).join(',');
+    if (keySet.size > 0) {
+      includeRestOptions.keys = Array.from(keySet).join(',');
+    }
   }
 
   let queryPromises = Object.keys(pointersHash).map((className) => {


### PR DESCRIPTION
This PR provides a fix for a nasty side effect introduced in 2.2.22 causing included object not to be properly included. 


Fixes #2786 