### PR TITLE
Fixes #2780

### DIFF
--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -929,6 +929,29 @@ describe('Installations', () => {
     });
   });
 
+  it('should properly handle installation save #2780', done => {
+    let installId = '12345678-abcd-abcd-abcd-123456789abc';
+    let device = 'android';
+    let input = {
+      'installationId': installId,
+      'deviceType': device
+    };
+    rest.create(config, auth.nobody(config), '_Installation', input).then(() => {
+      let query = new Parse.Query(Parse.Installation);
+      query.equalTo('installationId', installId);
+      query.first({useMasterKey: true}).then((installation) => {
+        return installation.save({
+          key: 'value'
+        }, {useMasterKey: true});
+      }).then(() => {
+        done();
+      }, (err) => {
+        jfail(err)
+        done();
+      });
+    });
+  });
+
   // TODO: Look at additional tests from installation_collection_test.go:882
   // TODO: Do we need to support _tombstone disabling of installations?
   // TODO: Test deletion, badge increments

--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -952,6 +952,32 @@ describe('Installations', () => {
     });
   });
 
+  it('should properly reject updating installationId', done => {
+    let installId = '12345678-abcd-abcd-abcd-123456789abc';
+    let device = 'android';
+    let input = {
+      'installationId': installId,
+      'deviceType': device
+    };
+    rest.create(config, auth.nobody(config), '_Installation', input).then(() => {
+      let query = new Parse.Query(Parse.Installation);
+      query.equalTo('installationId', installId);
+      query.first({useMasterKey: true}).then((installation) => {
+        return installation.save({
+          key: 'value',
+          installationId: '22222222-abcd-abcd-abcd-123456789abc'
+        }, {useMasterKey: true});
+      }).then(() => {
+        fail('should not succeed');
+        done();
+      }, (err) => {
+        expect(err.code).toBe(136);
+        expect(err.message).toBe('installationId may not be changed in this operation');
+        done();
+      });
+    });
+  });
+
   // TODO: Look at additional tests from installation_collection_test.go:882
   // TODO: Do we need to support _tombstone disabling of installations?
   // TODO: Test deletion, badge increments

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -639,8 +639,8 @@ RestWrite.prototype.handleInstallation = function() {
         throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND,
                                 'Object not found for update.');
       }
-      if (installationId && objectIdMatch.installationId &&
-          installationId !== objectIdMatch.installationId) {
+      if (this.data.installationId && objectIdMatch.installationId &&
+          this.data.installationId !== objectIdMatch.installationId) {
           throw new Parse.Error(136,
                                 'installationId may not be changed in this ' +
                                 'operation');


### PR DESCRIPTION
Makes sure we use data.installationId to prevent an updating it if it's passed.