### PR TITLE
Revert #2705

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "mime": "1.3.4",
     "mongodb": "2.2.10",
     "multer": "1.2.0",
-    "node-uuid": "^1.4.7",
     "parse": "1.9.2",
     "parse-server-fs-adapter": "1.0.1",
     "parse-server-push-adapter": "1.1.0",

--- a/src/Controllers/FilesController.js
+++ b/src/Controllers/FilesController.js
@@ -5,7 +5,6 @@ import AdaptableController from './AdaptableController';
 import { FilesAdapter } from '../Adapters/Files/FilesAdapter';
 import path  from 'path';
 import mime from 'mime';
-import uuid from 'node-uuid';
 
 const legacyFilesRegex = new RegExp("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-.*");
 
@@ -27,7 +26,7 @@ export class FilesController extends AdaptableController {
       contentType = mime.lookup(filename);
     }
 
-    filename = uuid.v4() + '_' + filename;
+    filename = randomHexString(32) + '_' + filename;
 
     var location = this.adapter.getFileLocation(config, filename);
     return this.adapter.createFile(filename, data, contentType).then(() => {


### PR DESCRIPTION
We should not use legacy filename format when uploading files by parse-server.

The change in filename format by #2705 causes a bug.
Because the filename prefixed by `require('node-uuid').v4()` passes the test here:
https://github.com/ParsePlatform/parse-server/pull/2001/files#diff-a5627093ba7dcdc8b5392f04905d1cafR69.
As a result all urls that point to user-owned storage are overwritten to a non-exist url that starts with `http://files.parse.com/`.

I know that reverting #2705 causes another problem. But it's less critical than this bug.