### PR TITLE
Use the Postgres Adapter with a Postgres URI

### DIFF
--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -7,6 +7,7 @@ var batch = require('./batch'),
     multer = require('multer'),
     Parse = require('parse/node').Parse,
     path = require('path'),
+    url = require('url'),
     authDataManager = require('./authDataManager');
 
 import defaults                 from './defaults';
@@ -54,6 +55,7 @@ import DatabaseController       from './Controllers/DatabaseController';
 import SchemaCache              from './Controllers/SchemaCache';
 import ParsePushAdapter         from 'parse-server-push-adapter';
 import MongoStorageAdapter      from './Adapters/Storage/Mongo/MongoStorageAdapter';
+import PostgresStorageAdapter   from './Adapters/Storage/Postgres/PostgresStorageAdapter';
 
 import { ParseServerRESTController } from './ParseServerRESTController';
 // Mutate the Parse object to add the Cloud Code handlers
@@ -145,11 +147,7 @@ class ParseServer {
     if ((databaseOptions || (databaseURI && databaseURI != defaults.DefaultMongoURI) || collectionPrefix !== '') && databaseAdapter) {
       throw 'You cannot specify both a databaseAdapter and a databaseURI/databaseOptions/collectionPrefix.';
     } else if (!databaseAdapter) {
-      databaseAdapter = new MongoStorageAdapter({
-        uri: databaseURI,
-        collectionPrefix,
-        mongoOptions: databaseOptions,
-      });
+      databaseAdapter = this.getDatabaseAdapter(databaseURI, collectionPrefix, databaseOptions)
     } else {
       databaseAdapter = loadAdapter(databaseAdapter)
     }
@@ -249,6 +247,24 @@ class ParseServer {
       } else {
         throw "argument 'cloud' must either be a string or a function";
       }
+    }
+  }
+
+  getDatabaseAdapter(databaseURI, collectionPrefix, databaseOptions) {
+    const parsedURI = url.parse(databaseURI);
+    const protocol = parsedURI.protocol ? parsedURI.protocol.toLowerCase() : null;
+    switch (protocol) {
+      case 'postgres:':
+        return new PostgresStorageAdapter({
+          uri: databaseURI,
+          collectionPrefix
+        });
+      default:
+        return new MongoStorageAdapter({
+          uri: databaseURI,
+          collectionPrefix,
+          mongoOptions: databaseOptions,
+        });
     }
   }
 

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -251,8 +251,11 @@ class ParseServer {
   }
 
   getDatabaseAdapter(databaseURI, collectionPrefix, databaseOptions) {
-    const parsedURI = url.parse(databaseURI);
-    const protocol = parsedURI.protocol ? parsedURI.protocol.toLowerCase() : null;
+    let protocol;
+    try{
+      const parsedURI = url.parse(databaseURI);
+      protocol = parsedURI.protocol ? parsedURI.protocol.toLowerCase() : null;
+    }catch(e){}
     switch (protocol) {
       case 'postgres:':
         return new PostgresStorageAdapter({


### PR DESCRIPTION
This PR gets Parse Server to use the Postgres adapter if the `--databaseURI` supplied is of the form `postgres://...`.