### PR TITLE
Adds validation for id_token and access_token

### DIFF
--- a/src/authDataManager/google.js
+++ b/src/authDataManager/google.js
@@ -26,7 +26,7 @@ function validateAuthToken(id, token) {
     });
 }
 
-// Returns a promise that fulfills iff this user id is valid.
+// Returns a promise that fulfills if this user id is valid.
 function validateAuthData(authData) {
   if (authData.id_token) {
     return validateIdToken(authData.id, authData.id_token); 
@@ -41,7 +41,7 @@ function validateAuthData(authData) {
   }
 }
 
-// Returns a promise that fulfills iff this app id is valid.
+// Returns a promise that fulfills if this app id is valid.
 function validateAppId() {
   return Promise.resolve();
 }

--- a/src/authDataManager/google.js
+++ b/src/authDataManager/google.js
@@ -2,17 +2,43 @@
 var https = require('https');
 var Parse = require('parse/node').Parse;
 
-// Returns a promise that fulfills iff this user id is valid.
-function validateAuthData(authData) {
-  return request("tokeninfo?id_token="+authData.access_token)
+function validateIdToken(id, token) {
+  return request("tokeninfo?id_token="+token)
     .then((response) => {
-      if (response && response.sub == authData.id) {
+      if (response && response.sub == id) {
         return;
       }
       throw new Parse.Error(
         Parse.Error.OBJECT_NOT_FOUND,
         'Google auth is invalid for this user.');
     });
+}
+
+function validateAuthToken(id, token) {
+  return request("tokeninfo?access_token="+token)
+    .then((response) => {
+      if (response && response.user_id == id) {
+        return;
+      }
+      throw new Parse.Error(
+        Parse.Error.OBJECT_NOT_FOUND,
+        'Google auth is invalid for this user.');
+    });
+}
+
+// Returns a promise that fulfills iff this user id is valid.
+function validateAuthData(authData) {
+  if (authData.id_token) {
+    return validateIdToken(authData.id, authData.id_token); 
+  } else {
+    return validateAuthToken(authData.id, authData.access_token).then(() => {
+      // Validation with auth token worked
+      return;
+    }, () => {
+      // Try with the id_token param
+      return validateIdToken(authData.id, authData.access_token);
+    });
+  }
 }
 
 // Returns a promise that fulfills iff this app id is valid.


### PR DESCRIPTION
For google oauth, let client specify id_token to use id_token validation.

access_token validation will try both authentications.

Fixes: #2290