### PR TITLE
Vkontakte Auth: Change users.get to secure.checkToken

### DIFF
--- a/src/authDataManager/vkontakte.js
+++ b/src/authDataManager/vkontakte.js
@@ -5,13 +5,20 @@ var https = require('https');
 var Parse = require('parse/node').Parse;
 
 // Returns a promise that fulfills iff this user id is valid.
-function validateAuthData(authData) {
-  return request("users.get?v=V&access_token=" + authData.access_token).then(function (response) {
-    if (response && response.response && response.response[0].uid == authData.id) {
-      return;
-    }
-    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is invalid for this user.');
-  });
+function validateAuthData(authData, params) {
+  return request("oauth.vk.com", "access_token?client_id=" + params.appIds + "&client_secret=" + params.appSecret + "&v=5.59&grant_type=client_credentials")
+    .then(function (response) {
+      if (response && response && response.access_token) {
+        return request("api.vk.com", "method/secure.checkToken?token=" + authData.access_token + "&client_secret=" + params.appSecret + "&access_token=" + response.access_token)
+        .then(function (response) {
+          if (response && response.response && response.response.user_id == authData.id) {
+            return ;
+          }
+          throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is invalid for this user.');
+        });
+      }
+      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is disabled for app.');
+    });
 }
 
 // Returns a promise that fulfills iff this app id is valid.
@@ -20,9 +27,9 @@ function validateAppId() {
 }
 
 // A promisey wrapper for api requests
-function request(path) {
+function request(host,path) {
   return new Promise(function (resolve, reject) {
-    https.get("https://api.vk.com/method/" + path, function (res) {
+    https.get("https://"+host + "/" + path, function (res) {
       var data = '';
       res.on('data', function (chunk) {
         data += chunk;

--- a/src/authDataManager/vkontakte.js
+++ b/src/authDataManager/vkontakte.js
@@ -4,25 +4,33 @@
 
 var https = require('https');
 var Parse = require('parse/node').Parse;
+var logger = require('../logger').default;
 
 // Returns a promise that fulfills iff this user id is valid.
-function validateAuthData(authData, params) {
-  if (!params || !params.appIds || !params.appIds.length || !params.appSecret || !params.appSecret.length ) {
-      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is not configured. Missing appIds or appSecret.');
-  }
-  return request("oauth.vk.com", "access_token?client_id=" + params.appIds + "&client_secret=" + params.appSecret + "&v=5.59&grant_type=client_credentials").then(function (response) {
-    console.log(response)
+function validateAuthData(authData, params) {  
+  return vkOAuth2Request(params).then(function (response) {
     if (response && response && response.access_token) {
       return request("api.vk.com", "method/secure.checkToken?token=" + authData.access_token + "&client_secret=" + params.appSecret + "&access_token=" + response.access_token).then(function (response) {
-        console.log(response)
         if (response && response.response && response.response.user_id == authData.id) {
           return;
         }
         throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is invalid for this user.');
       });
     }
+    logger.error('Vk Auth', 'Vk appIds or appSecret is incorrect.');
     throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk appIds or appSecret is incorrect.');
   });
+}
+
+function vkOAuth2Request(params) {
+  var promise = new Parse.Promise();
+  return promise.then(function(){
+    if (!params || !params.appIds || !params.appIds.length || !params.appSecret || !params.appSecret.length ) {
+      logger.error('Vk Auth', 'Vk auth is not configured. Missing appIds or appSecret.');
+      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is not configured. Missing appIds or appSecret.');
+    }
+    return request("oauth.vk.com", "access_token?client_id=" + params.appIds + "&client_secret=" + params.appSecret + "&v=5.59&grant_type=client_credentials")
+  })
 }
 
 // Returns a promise that fulfills iff this app id is valid.

--- a/src/authDataManager/vkontakte.js
+++ b/src/authDataManager/vkontakte.js
@@ -1,24 +1,28 @@
 'use strict';
 
 // Helper functions for accessing the vkontakte API.
+
 var https = require('https');
 var Parse = require('parse/node').Parse;
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData, params) {
-  return request("oauth.vk.com", "access_token?client_id=" + params.appIds + "&client_secret=" + params.appSecret + "&v=5.59&grant_type=client_credentials")
-    .then(function (response) {
-      if (response && response && response.access_token) {
-        return request("api.vk.com", "method/secure.checkToken?token=" + authData.access_token + "&client_secret=" + params.appSecret + "&access_token=" + response.access_token)
-        .then(function (response) {
-          if (response && response.response && response.response.user_id == authData.id) {
-            return ;
-          }
-          throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is invalid for this user.');
-        });
-      }
-      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is disabled for app.');
-    });
+  if (!params || !params.appIds || !params.appIds.length || !params.appSecret || !params.appSecret.length ) {
+      throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is not configured. Missing appIds or appSecret.');
+  }
+  return request("oauth.vk.com", "access_token?client_id=" + params.appIds + "&client_secret=" + params.appSecret + "&v=5.59&grant_type=client_credentials").then(function (response) {
+    console.log(response)
+    if (response && response && response.access_token) {
+      return request("api.vk.com", "method/secure.checkToken?token=" + authData.access_token + "&client_secret=" + params.appSecret + "&access_token=" + response.access_token).then(function (response) {
+        console.log(response)
+        if (response && response.response && response.response.user_id == authData.id) {
+          return;
+        }
+        throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is invalid for this user.');
+      });
+    }
+    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk appIds or appSecret is incorrect.');
+  });
 }
 
 // Returns a promise that fulfills iff this app id is valid.
@@ -27,9 +31,9 @@ function validateAppId() {
 }
 
 // A promisey wrapper for api requests
-function request(host,path) {
+function request(host, path) {
   return new Promise(function (resolve, reject) {
-    https.get("https://"+host + "/" + path, function (res) {
+    https.get("https://" + host + "/" + path, function (res) {
       var data = '';
       res.on('data', function (chunk) {
         data += chunk;


### PR DESCRIPTION
You can't get user info by client token due vk restrictions for standalone app. Current code did work, and always get error in production. (User authorization failed: access_token was given to another ip address.) You must check token via secure.checkToken.
https://vk.com/dev/secure.checkToken

To enable client token verification, you mast set appIds and appSecret parameter in oauth dictionary:
```
oauth: {
        vkontakte: {
            appIds: "1",
            appSecret: "abcdefghijklmn"
        } 
    },
```