### PR TITLE
Fix multiple use of notEqualTo

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -128,6 +128,22 @@ describe('Parse.Query testing', () => {
         equal(results.length, 0);
       });
     }).then(function(){
+      var query = new Parse.Query(Cake);
+      query.notEqualTo("hater", user2);
+      query.notEqualTo("liker", user2);
+      // user2 doesn't like any cake so this should be 0
+      return query.find().then(function(results){
+        equal(results.length, 0);
+      });
+    }).then(function(){
+      var query = new Parse.Query(Cake);
+      query.equalTo("hater", user);
+      query.equalTo("liker", user);
+      // user doesn't hate any cake so this should be 0
+      return query.find().then(function(results){
+        equal(results.length, 0);
+      });
+    }).then(function(){
       done();
     }).catch((err) => {
       jfail(err);

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -676,17 +676,12 @@ DatabaseController.prototype.addInObjectIdsIds = function(ids = null, query) {
   return query;
 }
 
-DatabaseController.prototype.addNotInObjectIdsIds = function(ids = null, query) {
-  let idsFromNin = query.objectId && query.objectId['$nin'] ? query.objectId['$nin'] : null;
-  let allIds = [idsFromNin, ids].filter(list => list !== null);
-  let totalLength = allIds.reduce((memo, list) => memo + list.length, 0);
+DatabaseController.prototype.addNotInObjectIdsIds = function(ids = [], query) {
+  let idsFromNin = query.objectId && query.objectId['$nin'] ? query.objectId['$nin'] : [];
+  let allIds = [...idsFromNin,...ids].filter(list => list !== null);
 
-  let idsIntersection = [];
-  if (totalLength > 125) {
-    idsIntersection = intersect.big(allIds);
-  } else {
-    idsIntersection = intersect(allIds);
-  }
+  // make a set and spread to remove duplicates
+  allIds = [...new Set(allIds)];
 
   // Need to make sure we don't clobber existing shorthand $eq constraints on objectId.
   if (!('objectId' in query)) {
@@ -696,8 +691,8 @@ DatabaseController.prototype.addNotInObjectIdsIds = function(ids = null, query) 
       $eq: query.objectId
     };
   }
-  query.objectId['$nin'] = idsIntersection;
 
+  query.objectId['$nin'] = allIds;
   return query;
 }
 


### PR DESCRIPTION
Multiple `$nin` conditions should not the intersect of objectIds. Instead it should use the union of all objectIds for `$nin`.

Fixes #1596.