### PR TITLE
Fix error when updating installation with useMasterKey

### DIFF
--- a/spec/ParseInstallation.spec.js
+++ b/spec/ParseInstallation.spec.js
@@ -906,6 +906,29 @@ describe('Installations', () => {
     });
   });
 
+  it('allows you to update installation with masterKey', done => {
+    let installId = '12345678-abcd-abcd-abcd-123456789abc';
+    let device = 'android';
+    let input = {
+      'installationId': installId,
+      'deviceType': device
+    };
+    rest.create(config, auth.nobody(config), '_Installation', input)
+    .then(createResult => {
+      let installationObj = Parse.Installation.createWithoutData(createResult.response.objectId);
+      installationObj.set('customField', 'custom value');
+      return installationObj.save(null, {useMasterKey: true});
+    }).then(updateResult => {
+      expect(updateResult).not.toBeUndefined();
+      expect(updateResult.get('customField')).toEqual('custom value');
+      done();
+    }).catch(error => {
+      console.log(error);
+      fail('failed');
+      done();
+    });
+  });
+
   // TODO: Look at additional tests from installation_collection_test.go:882
   // TODO: Do we need to support _tombstone disabling of installations?
   // TODO: Test deletion, badge increments

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -578,8 +578,12 @@ RestWrite.prototype.handleInstallation = function() {
     this.data.installationId = this.data.installationId.toLowerCase();
   }
 
-  // If data.installationId is not set, we can lookup in the auth
-  let installationId = this.data.installationId || this.auth.installationId;
+  let installationId = this.data.installationId;
+
+  // If data.installationId is not set and we're not master, we can lookup in auth
+  if (!installationId && !this.auth.isMaster) {
+    installationId = this.auth.installationId;
+  }
 
   if (installationId) {
     installationId = installationId.toLowerCase();


### PR DESCRIPTION
When using `useMasterKey` the `auth.installationId` should not be used from the request. Otherwise, errors will be thrown when installation object being edited is not the same as `auth.installationId`.

Fixes #2887.