### PR TITLE
Adds ability to run livequery server on different port (appengine)

### DIFF
--- a/src/cli/definitions/parse-server.js
+++ b/src/cli/definitions/parse-server.js
@@ -199,7 +199,7 @@ export default {
     help: "Run with cluster, optionally set the number of processes default to os.cpus().length",
     action: numberOrBoolParser("cluster")
   },
-   "liveQuery.classNames": {
+   "liveQuery": {
     help: "parse-server's LiveQuery configuration object",
     action: objectParser
   },
@@ -213,6 +213,10 @@ export default {
   "startLiveQueryServer": {
     help: "Starts the liveQuery server",
     action: booleanParser
+  },
+  "liveQueryPort": {
+    help: 'Specific port to start the live query server',
+    action: numberParser("liveQueryPort")
   },
   "liveQueryServerOptions": {
     help: "Live query server configuration options (will start the liveQuery server)",

--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -35,7 +35,13 @@ function startServer(options, callback) {
 
   var server = app.listen(options.port, callback);
   if (options.startLiveQueryServer || options.liveQueryServerOptions) {
-    ParseServer.createLiveQueryServer(server, options.liveQueryServerOptions);
+    let liveQueryServer = server;
+    if (options.liveQueryPort) {
+      liveQueryServer = express().listen(options.liveQueryPort, function() {
+        console.log('ParseLiveQuery listening on '+options.liveQueryPort);
+      });
+    }
+    ParseServer.createLiveQueryServer(liveQueryServer, options.liveQueryServerOptions);
   }
   var handleShutdown = function() {
     console.log('Termination signal received. Shutting down.');

--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -37,8 +37,8 @@ function startServer(options, callback) {
   if (options.startLiveQueryServer || options.liveQueryServerOptions) {
     let liveQueryServer = server;
     if (options.liveQueryPort) {
-      liveQueryServer = express().listen(options.liveQueryPort, function() {
-        console.log('ParseLiveQuery listening on '+options.liveQueryPort);
+      liveQueryServer = express().listen(options.liveQueryPort, () => {
+        console.log('ParseLiveQuery listening on ' + options.liveQueryPort);
       });
     }
     ParseServer.createLiveQueryServer(liveQueryServer, options.liveQueryServerOptions);


### PR DESCRIPTION
AppEngine should run the live query server on a different port, this let just do that from the CLI