### PR TITLE
Add role based ACL checks to LiveQuery

### DIFF
--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -834,6 +834,64 @@ describe('ParseLiveQueryServer', function() {
     });
   });
 
+  it('won\'t match ACL that doesn\'t have any roles', function(done){
+
+    var parseLiveQueryServer = new ParseLiveQueryServer(10, 10, {});
+    var acl = new Parse.ACL();
+    acl.setPublicReadAccess(false);
+    var client = {
+      getSubscriptionInfo: jasmine.createSpy('getSubscriptionInfo').and.returnValue({
+        sessionToken: 'sessionToken'
+      })
+    };
+    var requestId = 0;
+
+    parseLiveQueryServer._matchesACL(acl, client, requestId).then(function(isMatched) {
+      expect(isMatched).toBe(false);
+      done();
+    });
+
+  });
+
+  it('won\'t match ACL with role when there is no user', function(done){
+
+    var parseLiveQueryServer = new ParseLiveQueryServer(10, 10, {});
+    var acl = new Parse.ACL();
+    acl.setPublicReadAccess(false);
+    acl.setRoleReadAccess("livequery", true);
+    var client = {
+      getSubscriptionInfo: jasmine.createSpy('getSubscriptionInfo').and.returnValue({
+      })
+    };
+    var requestId = 0;
+
+    parseLiveQueryServer._matchesACL(acl, client, requestId).then(function(isMatched) {
+      expect(isMatched).toBe(false);
+      done();
+    });
+
+  });
+
+  it('can match ACL with role based read access', function(done){
+
+    var parseLiveQueryServer = new ParseLiveQueryServer(10, 10, {});
+    var acl = new Parse.ACL();
+    acl.setPublicReadAccess(false);
+    acl.setRoleReadAccess("livequery", true);
+    var client = {
+      getSubscriptionInfo: jasmine.createSpy('getSubscriptionInfo').and.returnValue({
+        sessionToken: 'sessionToken'
+      })
+    };
+    var requestId = 0;
+
+    parseLiveQueryServer._matchesACL(acl, client, requestId).then(function(isMatched) {
+      expect(isMatched).toBe(true);
+      done();
+    });
+
+  });
+
   it('can validate key when valid key is provided', function() {
     var parseLiveQueryServer = new ParseLiveQueryServer({}, {
       keyPairs: {

--- a/spec/ParseLiveQueryServer.spec.js
+++ b/spec/ParseLiveQueryServer.spec.js
@@ -834,7 +834,7 @@ describe('ParseLiveQueryServer', function() {
     });
   });
 
-  it('won\'t match ACL that doesn\'t have any roles', function(done){
+  it('won\'t match ACL that doesn\'t have public read or any roles', function(done){
 
     var parseLiveQueryServer = new ParseLiveQueryServer(10, 10, {});
     var acl = new Parse.ACL();
@@ -853,7 +853,7 @@ describe('ParseLiveQueryServer', function() {
 
   });
 
-  it('won\'t match ACL with role when there is no user', function(done){
+  it('won\'t match non-public ACL with role when there is no user', function(done){
 
     var parseLiveQueryServer = new ParseLiveQueryServer(10, 10, {});
     var acl = new Parse.ACL();
@@ -872,18 +872,70 @@ describe('ParseLiveQueryServer', function() {
 
   });
 
-  it('can match ACL with role based read access', function(done){
+  it('won\'t match ACL with role based read access set to false', function(done){
 
     var parseLiveQueryServer = new ParseLiveQueryServer(10, 10, {});
     var acl = new Parse.ACL();
     acl.setPublicReadAccess(false);
-    acl.setRoleReadAccess("livequery", true);
+    acl.setRoleReadAccess("liveQueryRead", false);
     var client = {
       getSubscriptionInfo: jasmine.createSpy('getSubscriptionInfo').and.returnValue({
         sessionToken: 'sessionToken'
       })
     };
     var requestId = 0;
+
+    spyOn(Parse, "Query").and.callFake(function(){
+      return {
+        equalTo(relation, value) {
+          // Nothing to do here
+        },
+        find() {
+          //Return a role with the name "liveQueryRead" as that is what was set on the ACL
+          var liveQueryRole = new Parse.Role();
+          liveQueryRole.set('name', 'liveQueryRead');
+          return [
+            liveQueryRole
+          ];
+        }
+      }
+    });
+      
+    parseLiveQueryServer._matchesACL(acl, client, requestId).then(function(isMatched) {
+      expect(isMatched).toBe(false);
+      done();
+    });
+
+  });
+
+  it('will match ACL with role based read access set to true', function(done){
+
+    var parseLiveQueryServer = new ParseLiveQueryServer(10, 10, {});
+    var acl = new Parse.ACL();
+    acl.setPublicReadAccess(false);
+    acl.setRoleReadAccess("liveQueryRead", true);
+    var client = {
+      getSubscriptionInfo: jasmine.createSpy('getSubscriptionInfo').and.returnValue({
+        sessionToken: 'sessionToken'
+      })
+    };
+    var requestId = 0;
+
+    spyOn(Parse, "Query").and.callFake(function(){
+      return {
+        equalTo(relation, value) {
+          // Nothing to do here
+        },
+        find() {
+          //Return a role with the name "liveQueryRead" as that is what was set on the ACL
+          var liveQueryRole = new Parse.Role();
+          liveQueryRole.set('name', 'liveQueryRead');
+          return [
+            liveQueryRole
+          ];
+        }
+      }
+    });
 
     parseLiveQueryServer._matchesACL(acl, client, requestId).then(function(isMatched) {
       expect(isMatched).toBe(true);

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -350,7 +350,7 @@ class ParseLiveQueryServer {
         _this.sessionTokenCache.getUserId(subscriptionSessionToken)
         .then(function(userId){
 
-            // Bail with no user if there is no user id
+            // Pass along a null if there is no user id
             if(!userId) {
                 return Parse.Promise.as(null);
             }
@@ -364,7 +364,7 @@ class ParseLiveQueryServer {
         })
         .then(function(user){
 
-            // Bail with no roles if no user
+            // Pass along an empty array (of roles) if no user
             if(!user) {
                 return Parse.Promise.as([]);
             }
@@ -383,7 +383,6 @@ class ParseLiveQueryServer {
                     return resolve(true);
                 }
             }
-
             resolve(false);
         })
         .catch(function(error){


### PR DESCRIPTION
LiveQuery is not working for objects that have a role based ACL set.  This renders LiveQuery unusable in a wide range of authorization scenarios.  Developers will expect live query to work with role based ACLs and not just public or user based ACLs.  This pull request adds support for ACL role checks to the server.