### PR TITLE
Proposal for tracking Pushes

### DIFF
--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -93,6 +93,10 @@ export class PushController extends AdaptableController {
       if (!response.results) {
         return Promise.reject({error: 'PushController: no results in query'})
       }
+      return response;
+    }).then((response) => {
+      return this.starTracking(response.results, pushStatus);
+    }).then((response) => {
       pushStatus.setRunning(response.results);
       return this.sendToAdapter(body, response.results, pushStatus, config);
     }).then((results) => {
@@ -102,6 +106,16 @@ export class PushController extends AdaptableController {
         throw err;
       });
     });
+  }
+
+  startTracking(installations, pushStatus) {
+    // todo: insert a Push object per installation, with timestamp, and pushStatus.objectId
+    return Promise.resolve();
+  }
+
+  updateTracking(installations, pushStatus, results) {
+    // todo, find and update each of the Push objects with their result
+    return Promise.resolve();
   }
 
   sendToAdapter(body, installations, pushStatus, config) {

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -100,7 +100,9 @@ export class PushController extends AdaptableController {
       pushStatus.setRunning(response.results);
       return this.sendToAdapter(body, response.results, pushStatus, config);
     }).then((results) => {
-      return pushStatus.complete(results);
+      return pushStatus.complete(results).then(() => {
+        return updateTracking(response.results, results, pushStatus);
+      };
     }).catch((err) => {
       return pushStatus.fail(err).then(() => {
         throw err;

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -95,29 +95,15 @@ export class PushController extends AdaptableController {
       }
       return response;
     }).then((response) => {
-      return this.starTracking(response.results, pushStatus);
-    }).then((response) => {
       pushStatus.setRunning(response.results);
       return this.sendToAdapter(body, response.results, pushStatus, config);
     }).then((results) => {
-      return pushStatus.complete(results).then(() => {
-        return updateTracking(response.results, results, pushStatus);
-      };
+      return pushStatus.complete(results);
     }).catch((err) => {
       return pushStatus.fail(err).then(() => {
         throw err;
       });
     });
-  }
-
-  startTracking(installations, pushStatus) {
-    // todo: insert a Push object per installation, with timestamp, and pushStatus.objectId
-    return Promise.resolve();
-  }
-
-  updateTracking(installations, pushStatus, results) {
-    // todo, find and update each of the Push objects with their result
-    return Promise.resolve();
   }
 
   sendToAdapter(body, installations, pushStatus, config) {

--- a/src/Controllers/PushController.js
+++ b/src/Controllers/PushController.js
@@ -93,8 +93,6 @@ export class PushController extends AdaptableController {
       if (!response.results) {
         return Promise.reject({error: 'PushController: no results in query'})
       }
-      return response;
-    }).then((response) => {
       pushStatus.setRunning(response.results);
       return this.sendToAdapter(body, response.results, pushStatus, config);
     }).then((results) => {

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -58,11 +58,7 @@ function statusHandler(className, database) {
           className: "_Installation",
           objectId: installation.objectId,
         },
-        pushStatus: {
-          __type: 'Pointer',
-          className: className,
-          objectId: pushStatusObjectId,
-        }
+        pushStatus: pushStatusObjectId
       };
       return createPush(push);
     });

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -47,8 +47,8 @@ function statusHandler(className, database) {
 
   function insertPushes(installations, pushStatusObjectId) {
     // Insert a Push object for each installation we're pushing to
+    let now = new Date();
     let promises = _.map(installations, installation => {
-      let now = new Date();
       let pushObjectId = newObjectId();
       let push = {
         pushObjectId,

--- a/src/StatusHandler.js
+++ b/src/StatusHandler.js
@@ -51,12 +51,12 @@ function statusHandler(className, database) {
     let promises = _.map(installations, installation => {
       let pushObjectId = newObjectId();
       let push = {
-        pushObjectId,
+        objectId: pushObjectId,
         createdAt: now,
         installation: {
           __type: 'Pointer',
           className: "_Installation",
-          objectId: installation.id,
+          objectId: installation.objectId,
         },
         pushStatus: {
           __type: 'Pointer',


### PR DESCRIPTION
This PR is totally incomplete.  Its an early proposal

Goal: add new push tracking capabilities to parse-server, specifically: track pushes and their status at the device level.

Objectives:

1)  Enable queries through the existing Parse API 
- Which installations was a given PushStatus sent to
- What was the result of the push sending for each installation (support may vary by adapter and route)
- Find failed Pushes
- Find installations with failed pushes

2) Enable visibility in the Dashboard
- See recent Push objects
- Filter Push objects to ones that failed
- Filter Push objects by PushStatus
- Filter Push objects by installation

3) Work with all push adapters and destinations

Proposed implementation:
- New public object `Push`
- A `Push` object is created per installation before sending to the PushAdapter
- After PushAdapter returns, any results can be updated on the Push object

Possible future extensions:
- Add a Rest API method to track push opens, will update openedDt on the Push object
- Push adapters can add more extensive tracking, eg hook into GCM delivery reports and the Push object can be updated