### PR TITLE
Do not run find when responding to count

### DIFF
--- a/spec/InstallationsRouter.spec.js
+++ b/spec/InstallationsRouter.spec.js
@@ -143,7 +143,7 @@ describe('InstallationsRouter', () => {
     .then(() => router.handleFind(request))
     .then((res) => {
       var response = res.response;
-      expect(response.results.length).toEqual(2);
+      expect(response.results.length).toEqual(0);
       expect(response.count).toEqual(2);
       done();
     })

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -388,7 +388,7 @@ RestQuery.prototype.replaceDontSelect = function() {
 // Returns a promise for whether it was successful.
 // Populates this.response with an object that only has 'results'.
 RestQuery.prototype.runFind = function(options = {}) {
-  if (this.findOptions.limit === 0) {
+  if (this.findOptions.limit === 0 || this.doCount) {
     this.response = {results: []};
     return Promise.resolve();
   }


### PR DESCRIPTION
I'm not sure if this is expected behavior but when the count option is provided to restQuery we probably do not want to incur the cost of first running the find, throwing the results away, then finally running the count. We should probably just run the count.