### PR TITLE
Disambiguate /users/me route (fixes #2933)

### DIFF
--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -212,7 +212,7 @@ export class UsersRouter extends ClassesRouter {
     this.route('GET', '/users', req => { return this.handleFind(req); });
     this.route('POST', '/users', req => { return this.handleCreate(req); });
     this.route('GET', '/users/me', req => { return this.handleMe(req); });
-    this.route('GET', '/users/:objectId', req => { return this.handleGet(req); });
+    this.route('GET', '/users/:objectId((?!me$)[^\/]+)', req => { return this.handleGet(req); });
     this.route('PUT', '/users/:objectId', req => { return this.handleUpdate(req); });
     this.route('DELETE', '/users/:objectId', req => { return this.handleDelete(req); });
     this.route('GET', '/login', req => { return this.handleLogIn(req); });


### PR DESCRIPTION
This makes sure that `me` doesn't match for `:objectId` at the route level.