### PR TITLE
Don't require all keys to be configured to enable key checks (#2816)

### DIFF
--- a/spec/Middlewares.spec.js
+++ b/spec/Middlewares.spec.js
@@ -17,6 +17,7 @@ describe('middlewares', () => {
                 return fakeReq.headers[key.toLowerCase()]
             }
         };
+        fakeRes = jasmine.createSpyObj('fakeRes', ['end', 'status']);
         AppCache.put(fakeReq.body._ApplicationId, {});
     });
 
@@ -32,6 +33,60 @@ describe('middlewares', () => {
             expect(fakeReq.headers['content-type']).toEqual(contentType);
             expect(fakeReq.body._ContentType).toEqual(undefined);
             done()
+        });
+    });
+
+    it('should give invalid response when any configured key is missing', () => {
+        AppCache.put(fakeReq.body._ApplicationId, {
+            masterKey: 'masterKey',
+            restAPIKey: 'restAPIKey'
+        });
+        middlewares.handleParseHeaders(fakeReq, fakeRes);
+        expect(fakeRes.status).toHaveBeenCalledWith(403);
+    });
+
+    it('should give invalid response when any configured key is supplied but incorrect', () => {
+        AppCache.put(fakeReq.body._ApplicationId, {
+            masterKey: 'masterKey',
+            restAPIKey: 'restAPIKey'
+        });
+        fakeReq.headers['x-parse-rest-api-key'] = 'wrongKey';
+        middlewares.handleParseHeaders(fakeReq, fakeRes);
+        expect(fakeRes.status).toHaveBeenCalledWith(403);
+    });
+
+    it('should succeed when all configured keys supplied', (done) => {
+        AppCache.put(fakeReq.body._ApplicationId, {
+            masterKey: 'masterKey',
+            restAPIKey: 'restAPIKey'
+        });
+        fakeReq.headers['x-parse-rest-api-key'] = 'restAPIKey';
+        middlewares.handleParseHeaders(fakeReq, fakeRes, () => {
+            expect(fakeRes.status).not.toHaveBeenCalled();
+            done();
+        });
+    });
+
+    it('should succeed when no keys are configured and none supplied', (done) => {
+        AppCache.put(fakeReq.body._ApplicationId, {
+            masterKey: 'masterKey'
+        });
+        middlewares.handleParseHeaders(fakeReq, fakeRes, () => {
+            expect(fakeRes.status).not.toHaveBeenCalled();
+            done();
+        });
+    });
+
+    it('should succeed when keys are configured and extra keys supplied', (done) => {
+        AppCache.put(fakeReq.body._ApplicationId, {
+            masterKey: 'masterKey',
+            restAPIKey: 'restAPIKey'
+        });
+        fakeReq.headers['x-parse-rest-api-key'] = 'restAPIKey';
+        fakeReq.headers['x-parse-client-key'] = 'clientKey';
+        middlewares.handleParseHeaders(fakeReq, fakeRes, () => {
+            expect(fakeRes.status).not.toHaveBeenCalled();
+            done();
         });
     });
 

--- a/spec/Middlewares.spec.js
+++ b/spec/Middlewares.spec.js
@@ -36,7 +36,7 @@ describe('middlewares', () => {
         });
     });
 
-    it('should give invalid response when any configured key is missing', () => {
+    it('should give invalid response when keys are configured but no key supplied', () => {
         AppCache.put(fakeReq.body._ApplicationId, {
             masterKey: 'masterKey',
             restAPIKey: 'restAPIKey'
@@ -45,7 +45,7 @@ describe('middlewares', () => {
         expect(fakeRes.status).toHaveBeenCalledWith(403);
     });
 
-    it('should give invalid response when any configured key is supplied but incorrect', () => {
+    it('should give invalid response when keys are configured but supplied key is incorrect', () => {
         AppCache.put(fakeReq.body._ApplicationId, {
             masterKey: 'masterKey',
             restAPIKey: 'restAPIKey'
@@ -55,8 +55,20 @@ describe('middlewares', () => {
         expect(fakeRes.status).toHaveBeenCalledWith(403);
     });
 
-    it('should succeed when all configured keys supplied', (done) => {
+    it('should give invalid response when keys are configured but different key is supplied', () => {
         AppCache.put(fakeReq.body._ApplicationId, {
+            masterKey: 'masterKey',
+            restAPIKey: 'restAPIKey'
+        });
+        fakeReq.headers['x-parse-client-key'] = 'clientKey';
+        middlewares.handleParseHeaders(fakeReq, fakeRes);
+        expect(fakeRes.status).toHaveBeenCalledWith(403);
+    });
+
+
+    it('should succeed when any one of the configured keys supplied', (done) => {
+        AppCache.put(fakeReq.body._ApplicationId, {
+            clientKey: 'clientKey',
             masterKey: 'masterKey',
             restAPIKey: 'restAPIKey'
         });
@@ -71,19 +83,6 @@ describe('middlewares', () => {
         AppCache.put(fakeReq.body._ApplicationId, {
             masterKey: 'masterKey'
         });
-        middlewares.handleParseHeaders(fakeReq, fakeRes, () => {
-            expect(fakeRes.status).not.toHaveBeenCalled();
-            done();
-        });
-    });
-
-    it('should succeed when keys are configured and extra keys supplied', (done) => {
-        AppCache.put(fakeReq.body._ApplicationId, {
-            masterKey: 'masterKey',
-            restAPIKey: 'restAPIKey'
-        });
-        fakeReq.headers['x-parse-rest-api-key'] = 'restAPIKey';
-        fakeReq.headers['x-parse-client-key'] = 'clientKey';
         middlewares.handleParseHeaders(fakeReq, fakeRes, () => {
             expect(fakeRes.status).not.toHaveBeenCalled();
             done();

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -120,11 +120,11 @@ export function handleParseHeaders(req, res, next) {
 
   // Client keys are not required in parse-server, but if any have been configured in the server, validate them
   //  to preserve original behavior.
-  let keys = ["clientKey", "javascriptKey", "dotNetKey", "restAPIKey"];
-  var oneKeyConfigured = keys.some(function(key) {
+  const keys = ["clientKey", "javascriptKey", "dotNetKey", "restAPIKey"];
+  const oneKeyConfigured = keys.some(function(key) {
     return req.config[key];
   });
-  var oneKeyMatches = keys.some(function(key){
+  const oneKeyMatches = keys.some(function(key){
     return req.config[key] && info[key] == req.config[key];
   });
 

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -121,11 +121,14 @@ export function handleParseHeaders(req, res, next) {
   // Client keys are not required in parse-server, but if any have been configured in the server, validate them
   //  to preserve original behavior.
   let keys = ["clientKey", "javascriptKey", "dotNetKey", "restAPIKey"];
-  var keyMismatch = keys.some(function(key){
-    return req.config[key] && info[key] !== req.config[key];
+  var oneKeyConfigured = keys.some(function(key) {
+    return req.config[key];
+  });
+  var oneKeyMatches = keys.some(function(key){
+    return req.config[key] && info[key] == req.config[key];
   });
 
-  if (keyMismatch) {
+  if (oneKeyConfigured && !oneKeyMatches) {
     return invalidRequest(req, res);
   }
 

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -121,19 +121,11 @@ export function handleParseHeaders(req, res, next) {
   // Client keys are not required in parse-server, but if any have been configured in the server, validate them
   //  to preserve original behavior.
   let keys = ["clientKey", "javascriptKey", "dotNetKey", "restAPIKey"];
+  var keyMismatch = keys.some(function(key){
+    return req.config[key] && info[key] !== req.config[key];
+  });
 
-  // We do it with mismatching keys to support no-keys config
-  var keyMismatch = keys.reduce(function(mismatch, key){
-
-    // check if set in the config and compare
-    if (req.config[key] && info[key] !== req.config[key]) {
-      mismatch++;
-    }
-    return mismatch;
-  }, 0);
-
-  // All keys mismatch
-  if (keyMismatch == keys.length) {
+  if (keyMismatch) {
     return invalidRequest(req, res);
   }
 


### PR DESCRIPTION
Added a few tests to try to be descriptive about how we expect keys to behave.
Tried to make the key checking algorithm clear - could be optimised by looping just once but we are only iterating up to 4 times.