### PR TITLE
Add option to freeze schema cache to prevent clearing between requests

### DIFF
--- a/spec/SchemaCache.spec.js
+++ b/spec/SchemaCache.spec.js
@@ -3,35 +3,88 @@ var InMemoryCacheAdapter = require('../src/Adapters/Cache/InMemoryCacheAdapter')
 var SchemaCache = require('../src/Controllers/SchemaCache').default;
 
 describe('SchemaCache', () => {
-	var schemaCache;
+  var cacheController;
+  var schemaCache;
 
-	beforeEach(() => {
-		var cacheAdapter = new InMemoryCacheAdapter({});
-		var cacheController = new CacheController(cacheAdapter, 'appId');
-		schemaCache = new SchemaCache(cacheController);
-	});
+  beforeEach(() => {
+    var cacheAdapter = new InMemoryCacheAdapter({});
+    cacheController = new CacheController(cacheAdapter, 'appId');
+    schemaCache = new SchemaCache(cacheController);
+  });
 
-	it('can retrieve a single schema after all schemas stored', (done) => {
-		var allSchemas = [{
-			className: 'Class1'
-		}, {
-			className: 'Class2'
-		}];
-		schemaCache.setAllClasses(allSchemas);
-		schemaCache.getOneSchema('Class2').then((schema) => {
-			expect(schema).not.toBeNull();
-			done();
-		});
-	});
+  it('can retrieve a single schema after all schemas stored', (done) => {
+    const allSchemas = [{
+      className: 'Class1'
+    }, {
+      className: 'Class2'
+    }];
+    schemaCache.setAllClasses(allSchemas).then(() => {
+      return schemaCache.getOneSchema('Class2');
+    }).then((schema) => {
+      expect(schema).not.toBeNull();
+      done();
+    });
+  });
 
-	it('does not return all schemas after a single schema is stored', (done) => {
-		var schema = {
-			className: 'Class1'
-		};
-		schemaCache.setOneSchema('Class1', schema);
-		schemaCache.getAllClasses().then((allSchemas) => {
-			expect(allSchemas).toBeNull();
-			done();
-		});
-	});
+  it('does not return all schemas after a single schema is stored', (done) => {
+    const schema = {
+      className: 'Class1'
+    };
+    schemaCache.setOneSchema(schema.className, schema).then(() => {
+      return schemaCache.getAllClasses();
+    }).then((allSchemas) => {
+      expect(allSchemas).toBeNull();
+      done();
+    });
+  });
+
+  it('clears the cache when not frozen', (done) => {
+    const allSchemas = [{
+      className: 'Class1'
+    }, {
+      className: 'Class2'
+    }];
+    schemaCache.setAllClasses(allSchemas).then(() => {
+      const oneSchema = {
+        className: 'Class3'
+      };
+      return schemaCache.setOneSchema(oneSchema.className, oneSchema);
+    }).then(() => {
+      return schemaCache.clear()
+    }).then(() => {
+      return schemaCache.getAllClasses();
+    }).then((cachedSchemas) => {
+      expect(cachedSchemas).toBeNull();
+      return schemaCache.getOneSchema('Class3');
+    }).then((cachedSchema) => {
+      expect(cachedSchema).toBeNull();
+      done();
+    });
+  });
+
+  it('does not clear the cache when frozen', (done) => {
+    schemaCache = new SchemaCache(cacheController, 5000, true);
+    const allSchemas = [{
+      className: 'Class1'
+    }, {
+      className: 'Class2'
+    }];
+
+    schemaCache.setAllClasses(allSchemas).then(() => {
+      const oneSchema = {
+        className: 'Class3'
+      };
+      return schemaCache.setOneSchema(oneSchema.className, oneSchema);
+    }).then(() => {
+      return schemaCache.clear();
+    }).then(() => {
+      return schemaCache.getAllClasses();
+    }).then((allSchemas) => {
+      expect(allSchemas).not.toBeNull();
+      return schemaCache.getOneSchema('Class3');
+    }).then((oneSchema) => {
+      expect(oneSchema).not.toBeNull();
+      done();
+    });
+  });
 });

--- a/spec/SchemaCache.spec.js
+++ b/spec/SchemaCache.spec.js
@@ -45,19 +45,11 @@ describe('SchemaCache', () => {
       className: 'Class2'
     }];
     schemaCache.setAllClasses(allSchemas).then(() => {
-      const oneSchema = {
-        className: 'Class3'
-      };
-      return schemaCache.setOneSchema(oneSchema.className, oneSchema);
-    }).then(() => {
       return schemaCache.clear()
     }).then(() => {
       return schemaCache.getAllClasses();
     }).then((cachedSchemas) => {
       expect(cachedSchemas).toBeNull();
-      return schemaCache.getOneSchema('Class3');
-    }).then((cachedSchema) => {
-      expect(cachedSchema).toBeNull();
       done();
     });
   });
@@ -71,19 +63,27 @@ describe('SchemaCache', () => {
     }];
 
     schemaCache.setAllClasses(allSchemas).then(() => {
-      const oneSchema = {
-        className: 'Class3'
-      };
-      return schemaCache.setOneSchema(oneSchema.className, oneSchema);
-    }).then(() => {
       return schemaCache.clear();
     }).then(() => {
       return schemaCache.getAllClasses();
     }).then((allSchemas) => {
       expect(allSchemas).not.toBeNull();
-      return schemaCache.getOneSchema('Class3');
-    }).then((oneSchema) => {
-      expect(oneSchema).not.toBeNull();
+      done();
+    });
+  });
+
+  it('does not override TTL setting', (done) => {
+    schemaCache = new SchemaCache(cacheController, 0, true);
+    const allSchemas = [{
+      className: 'Class1'
+    }, {
+      className: 'Class2'
+    }];
+
+    schemaCache.setAllClasses(allSchemas).then(() => {
+      return schemaCache.getAllClasses();
+    }).then((allSchemas) => {
+      expect(allSchemas).toBeNull();
       done();
     });
   });

--- a/src/Config.js
+++ b/src/Config.js
@@ -37,7 +37,8 @@ export class Config {
 
     // Create a new DatabaseController per request
     if (cacheInfo.databaseController) {
-      this.database = new DatabaseController(cacheInfo.databaseController.adapter, cacheInfo.schemaCache);
+      const schemaCache = new SchemaCache(cacheInfo.cacheController, cacheInfo.schemaCacheTTL, cacheInfo.freezeSchema);
+      this.database = new DatabaseController(cacheInfo.databaseController.adapter, schemaCache);
     }
 
     this.schemaCache = cacheInfo.schemaCache;

--- a/src/Config.js
+++ b/src/Config.js
@@ -37,11 +37,12 @@ export class Config {
 
     // Create a new DatabaseController per request
     if (cacheInfo.databaseController) {
-      const schemaCache = new SchemaCache(cacheInfo.cacheController, cacheInfo.schemaCacheTTL);
+      const schemaCache = new SchemaCache(cacheInfo.cacheController, cacheInfo.schemaCacheTTL, cacheInfo.schemaCacheFrozen);
       this.database = new DatabaseController(cacheInfo.databaseController.adapter, schemaCache);
     }
 
     this.schemaCacheTTL = cacheInfo.schemaCacheTTL;
+    this.schemaCacheFrozen = cacheInfo.schemaCacheFrozen;
 
     this.serverURL = cacheInfo.serverURL;
     this.publicServerURL = removeTrailingSlash(cacheInfo.publicServerURL);

--- a/src/Config.js
+++ b/src/Config.js
@@ -37,12 +37,10 @@ export class Config {
 
     // Create a new DatabaseController per request
     if (cacheInfo.databaseController) {
-      const schemaCache = new SchemaCache(cacheInfo.cacheController, cacheInfo.schemaCacheTTL, cacheInfo.schemaCacheFrozen);
-      this.database = new DatabaseController(cacheInfo.databaseController.adapter, schemaCache);
+      this.database = new DatabaseController(cacheInfo.databaseController.adapter, cacheInfo.schemaCache);
     }
 
-    this.schemaCacheTTL = cacheInfo.schemaCacheTTL;
-    this.schemaCacheFrozen = cacheInfo.schemaCacheFrozen;
+    this.schemaCache = cacheInfo.schemaCache;
 
     this.serverURL = cacheInfo.serverURL;
     this.publicServerURL = removeTrailingSlash(cacheInfo.publicServerURL);

--- a/src/Config.js
+++ b/src/Config.js
@@ -41,7 +41,8 @@ export class Config {
       this.database = new DatabaseController(cacheInfo.databaseController.adapter, schemaCache);
     }
 
-    this.schemaCache = cacheInfo.schemaCache;
+    this.schemaCacheTTL = cacheInfo.schemaCacheTTL;
+    this.freezeSchema = cacheInfo.freezeSchema;
 
     this.serverURL = cacheInfo.serverURL;
     this.publicServerURL = removeTrailingSlash(cacheInfo.publicServerURL);

--- a/src/Controllers/SchemaCache.js
+++ b/src/Controllers/SchemaCache.js
@@ -8,8 +8,9 @@ import defaults from '../defaults';
 export default class SchemaCache {
   cache: Object;
 
-  constructor(cacheController, ttl = defaults.schemaCacheTTL) {
+  constructor(cacheController, ttl = defaults.schemaCacheTTL, frozen = false) {
     this.ttl = ttl;
+    this.frozen = frozen;
     if (typeof ttl == 'string') {
       this.ttl = parseInt(ttl);
     }
@@ -69,6 +70,9 @@ export default class SchemaCache {
 
   clear() {
     // That clears all caches...
+    if (this.frozen) {
+      return;
+    }
     let promise = Promise.resolve();
     return this.cache.get(this.prefix+ALL_KEYS).then((allKeys) => {
       if (!allKeys) {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -139,6 +139,7 @@ class ParseServer {
     expireInactiveSessions = defaults.expireInactiveSessions,
     revokeSessionOnPasswordReset = defaults.revokeSessionOnPasswordReset,
     schemaCacheTTL = defaults.schemaCacheTTL, // cache for 5s
+    schemaCacheFrozen = defaults.schemaCacheFrozen, // false
     __indexBuildCompletionCallbackForTests = () => {},
   }) {
     // Initialize the node client SDK automatically
@@ -181,7 +182,7 @@ class ParseServer {
     const analyticsController = new AnalyticsController(analyticsControllerAdapter);
 
     const liveQueryController = new LiveQueryController(liveQuery);
-    const databaseController = new DatabaseController(databaseAdapter, new SchemaCache(cacheController, schemaCacheTTL));
+    const databaseController = new DatabaseController(databaseAdapter, new SchemaCache(cacheController, schemaCacheTTL, schemaCacheFrozen));
     const hooksController = new HooksController(appId, databaseController, webhookKey);
 
     const dbInitPromise = databaseController.performInitizalization();
@@ -221,7 +222,8 @@ class ParseServer {
       jsonLogs,
       revokeSessionOnPasswordReset,
       databaseController,
-      schemaCacheTTL
+      schemaCacheTTL,
+      schemaCacheFrozen
     });
 
     // To maintain compatibility. TODO: Remove in some version that breaks backwards compatability

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -223,6 +223,7 @@ class ParseServer {
       jsonLogs,
       revokeSessionOnPasswordReset,
       databaseController,
+      schemaCacheTTL,
       freezeSchema
     });
 

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -182,7 +182,8 @@ class ParseServer {
     const analyticsController = new AnalyticsController(analyticsControllerAdapter);
 
     const liveQueryController = new LiveQueryController(liveQuery);
-    const databaseController = new DatabaseController(databaseAdapter, new SchemaCache(cacheController, schemaCacheTTL, schemaCacheFrozen));
+    const schemaCache = new SchemaCache(cacheController, schemaCacheTTL, schemaCacheFrozen);
+    const databaseController = new DatabaseController(databaseAdapter, schemaCache);
     const hooksController = new HooksController(appId, databaseController, webhookKey);
 
     const dbInitPromise = databaseController.performInitizalization();
@@ -222,8 +223,7 @@ class ParseServer {
       jsonLogs,
       revokeSessionOnPasswordReset,
       databaseController,
-      schemaCacheTTL,
-      schemaCacheFrozen
+      schemaCache
     });
 
     // To maintain compatibility. TODO: Remove in some version that breaks backwards compatability

--- a/src/cli/definitions/parse-server.js
+++ b/src/cli/definitions/parse-server.js
@@ -195,6 +195,11 @@ export default {
     help: "The TTL for caching the schema for optimizing read/write operations. You should put a long TTL when your DB is in production. default to 0; disabled.",
     action: numberParser("schemaCacheTTL"),
   },
+  "schemaCacheFrozen": {
+    env: "PARSE_SERVER_SCHEMA_CACHE_FROZEN",
+    help: "Whether the schema cache is retained between requests. Set to true to reduce _SCHEMA queries. Does not override schema cache TTL setting. Defaults to false.",
+    action: booleanParser
+  },
   "cluster": {
     help: "Run with cluster, optionally set the number of processes default to os.cpus().length",
     action: numberOrBoolParser("cluster")

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -27,5 +27,6 @@ export default {
   sessionLength: 31536000,
   expireInactiveSessions: true,
   revokeSessionOnPasswordReset: true,
-  schemaCacheTTL: 5000 // in ms
+  schemaCacheTTL: 5000, // in ms
+  schemaCacheFrozen: false
 }


### PR DESCRIPTION
This reduces _Schema queries to happen only as frequently as specified in schemaCacheTTL so will be useful in production.

Previously a new schemaCache is created per request but now the schemaCache is added to AppCache and retrieved from there.
Alternatively we could retrieve databaseController from the AppCache instead of creating per request but not sure if this is required.