### PR TITLE
Allow the URI for the test DB to be set via env

### DIFF
--- a/spec/helper.js
+++ b/spec/helper.js
@@ -41,7 +41,7 @@ let stopDB = () => {};
 
 if (process.env.PARSE_SERVER_TEST_DB === 'postgres') {
   databaseAdapter = new PostgresStorageAdapter({
-    uri: postgresURI,
+    uri: process.env.PARSE_SERVER_TEST_DATABASE_URI || postgresURI,
     collectionPrefix: 'test_',
   });
 } else {


### PR DESCRIPTION
Allowing a custom Postgres URI to be set using the environment is helpful during local testing