### PR TITLE
Fix the error returned when class already exists

### DIFF
--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -417,7 +417,7 @@ export class PostgresStorageAdapter {
     })
     .catch((err) => {
       if (err.code === PostgresUniqueIndexViolationError && err.detail.includes(className)) {
-        throw new Parse.Error(Parse.Error.INVALID_CLASS_NAME, `Class ${className} already exists.`)
+        throw new Parse.Error(Parse.Error.DUPLICATE_VALUE, `Class ${className} already exists.`)
       }
       throw err;
     })


### PR DESCRIPTION
Currently  the `createClass` method of PosgresStorageAdapter throws a `Parse.Error.INVALID_CLASS_NAME` exception on an attempt to insert a class that already exists.

This PR changes this exception to `Parse.Error.DUPLICATE_VALUE` (which is also what the [MongoDB adapter throws in a similar case](https://github.com/ParsePlatform/parse-server/blob/master/src/Adapters/Storage/Mongo/MongoStorageAdapter.js#L162))