### PR TITLE
Close client connections on SIGINT/SIGTERM

### DIFF
--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -36,7 +36,7 @@ function startServer(options, callback) {
   app.use(options.mountPath, api);
 
   var server = app.listen(options.port, callback);
-  //server.on('connection', initializeConnections);
+  server.on('connection', initializeConnections);
   if (options.startLiveQueryServer || options.liveQueryServerOptions) {
     let liveQueryServer = server;
     if (options.liveQueryPort) {

--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -121,7 +121,7 @@ runner({
         });
       }
     } else {
-      startServer(options, (p) => {
+      startServer(options, () => {
         logOptions();
         console.log('');
         console.log('['+process.pid+'] parse-server running on '+options.serverURL);


### PR DESCRIPTION
**Please DO NOT merge this yet**

Fixes #2875 

Currerntly, express doesn't shut down immediately after receiving SIGINT/SIGTERM if it has client connections that haven't timed out. 

This PR intends to fix this behavior such that parse server will close all open connections and initiate the shutdown process as soon as it receives a SIGINT/SIGTERM signal.