### PR TITLE
Adding support for AfterFind

### DIFF
--- a/spec/CloudCode.spec.js
+++ b/spec/CloudCode.spec.js
@@ -1306,4 +1306,132 @@ describe('beforeFind hooks', () => {
       done();
     });
   });
-})
+
+});
+
+describe('afterFind hooks', () => {
+  it('should add afterFind trigger using get',(done) => {
+    Parse.Cloud.afterFind('MyObject', (req, res) => {
+      for(var i = 0 ; i < res.results.length ; i++){
+        res.results[i].set("secretField","###");
+      }
+    });
+    var obj = new Parse.Object('MyObject');
+    obj.set('secretField', 'SSID');
+    obj.save().then(function() {
+      var query = new Parse.Query('MyObject');
+      query.get(obj.id).then(function(result) {
+        expect(result.get('secretField')).toEqual('###');
+        done();
+      }, function(error) {
+        fail(error);
+        done();
+      });
+    }, function(error) {
+      fail(error);
+      done();
+    });
+  });
+
+  it('should add afterFind trigger using find',(done) => {
+    Parse.Cloud.afterFind('MyObject', (req, res) => {
+      for(var i = 0 ; i < res.results.length ; i++){
+        res.results[i].set("secretField","###");
+      }
+    });
+    var obj = new Parse.Object('MyObject');
+    obj.set('secretField', 'SSID');
+    obj.save().then(function() {
+      var query = new Parse.Query('MyObject');
+      query.equalTo('objectId',obj.id);
+      query.find().then(function(results) {
+        expect(results[0].get('secretField')).toEqual('###');
+        done();
+      }, function(error) {
+        fail(error);
+        done();
+      });
+    }, function(error) {
+      fail(error);
+      done();
+    });
+  });
+
+  it('should filter out results',(done) => {
+    Parse.Cloud.afterFind('MyObject', (req, res) => {
+      var filteredResults = [];
+      for(var i = 0 ; i < res.results.length ; i++){
+        if(res.results[i].get("secretField")==="SSID1") {
+          filteredResults.push(res.results[i]);
+        }
+      }
+      res.results = filteredResults;
+    });
+    var obj0 = new Parse.Object('MyObject');
+    obj0.set('secretField', 'SSID1');
+    var obj1 = new Parse.Object('MyObject');
+    obj1.set('secretField', 'SSID2');
+    Parse.Object.saveAll([obj0, obj1]).then(function() {
+      var query = new Parse.Query('MyObject');
+      query.find().then(function(results) {
+        expect(results[0].get('secretField')).toEqual('SSID1');
+        expect(results.length).toEqual(1);
+        done();
+      }, function(error) {
+        fail(error);
+        done();
+      });
+    }, function(error) {
+      fail(error);
+      done();
+    });
+  });
+
+  it('should handle failures',(done) => {
+    Parse.Cloud.afterFind('MyObject', (req, res) => {
+      res.error(Parse.Error.SCRIPT_FAILED, "It should fail");
+    });
+    var obj = new Parse.Object('MyObject');
+    obj.set('secretField', 'SSID');
+    obj.save().then(function() {
+      var query = new Parse.Query('MyObject');
+      query.equalTo('objectId',obj.id);
+      query.find().then(function(results) {
+        fail("AfterFind should handle response failure correctly");
+        done();
+      }, function(error) {
+        done();
+      });
+    }, function(error) {
+      done();
+    });
+  });
+
+  it('should also work with promise',(done) => {
+    Parse.Cloud.afterFind('MyObject', (req, res) => {
+      let promise = new Parse.Promise();
+      setTimeout(function(){
+        for(var i = 0 ; i < res.results.length ; i++){
+          res.results[i].set("secretField","###");
+        }
+        promise.resolve(res.results);
+      }, 1000);
+      return promise;
+    });
+    var obj = new Parse.Object('MyObject');
+    obj.set('secretField', 'SSID');
+    obj.save().then(function() {
+      var query = new Parse.Query('MyObject');
+      query.equalTo('objectId',obj.id);
+      query.find().then(function(results) {
+        expect(results[0].get('secretField')).toEqual('###');
+        done();
+      }, function(error) {
+        fail(error);
+      });
+    }, function(error) {
+      fail(error);
+    });
+  });
+
+});

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1129,7 +1129,7 @@ it('ensure that if you try to sign up a user with a unique username and email, b
       done();
     }, (e) => {
       expect(e.code).toEqual(Parse.Error.SCRIPT_FAILED);
-      expect(e.message).toEqual('Invalid function.');
+      expect(e.message).toEqual('Invalid function: "somethingThatDoesDefinitelyNotExist"');
       done();
     });
   });

--- a/src/RestQuery.js
+++ b/src/RestQuery.js
@@ -3,6 +3,7 @@
 
 var SchemaController = require('./Controllers/SchemaController');
 var Parse = require('parse/node').Parse;
+var triggers = require('./triggers');
 
 import { default as FilesController } from './Controllers/FilesController';
 
@@ -122,6 +123,8 @@ RestQuery.prototype.execute = function(executeOptions) {
     return this.runCount();
   }).then(() => {
     return this.handleInclude();
+  }).then(() => {
+    return this.runAfterFindTrigger();
   }).then(() => {
     return this.response;
   });
@@ -468,6 +471,23 @@ RestQuery.prototype.handleInclude = function() {
   return pathResponse;
 };
 
+
+//Returns a promise of a processed set of results
+RestQuery.prototype.runAfterFindTrigger = function() {
+  if (!this.response) {
+    return;
+  }
+  // Avoid doing any setup for triggers if there is no 'afterFind' trigger for this class.
+  let hasAfterFindHook = triggers.triggerExists(this.className, triggers.Types.afterFind, this.config.applicationId);
+  if (!hasAfterFindHook) {
+    return Promise.resolve();
+  }
+  // Run afterFind trigger and set the new results
+  return triggers.maybeRunAfterFindTrigger(triggers.Types.afterFind, this.auth, this.className,this.response.results, this.config).then((results) => {
+    this.response.results = results;
+  });
+};
+
 // Adds included values to the response.
 // Path is a list of field names.
 // Returns a promise for an augmented response.
@@ -639,5 +659,8 @@ function findObjectWithKey(root, key) {
     }
   }
 }
+
+
+
 
 module.exports = RestQuery;

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -161,7 +161,7 @@ export class FunctionsRouter extends PromiseRouter {
         theFunction(request, response);
       });
     } else {
-      throw new Parse.Error(Parse.Error.SCRIPT_FAILED, 'Invalid function.');
+      throw new Parse.Error(Parse.Error.SCRIPT_FAILED, `Invalid function: "${functionName}"`);
     }
   }
 }

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -50,6 +50,11 @@ ParseCloud.beforeFind = function(parseClass, handler) {
   triggers.addTrigger(triggers.Types.beforeFind, className, handler, Parse.applicationId);
 };
 
+ParseCloud.afterFind = function(parseClass, handler) {
+  var className = getClassName(parseClass);
+  triggers.addTrigger(triggers.Types.afterFind, className, handler, Parse.applicationId);
+};
+
 ParseCloud._removeAllHooks = () => {
   triggers._unregisterAll();
 }


### PR DESCRIPTION
For security reasons, I need to hide certain fields (like email) and rows from the API for use cases which are not supported by the current ACL framework. This plugin will enable all sorts of manipulation. Next step would be to support promise to maybe augment the response from other data source.