### PR TITLE
Add functionName to "invalid function" error

### DIFF
--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -1129,7 +1129,7 @@ it('ensure that if you try to sign up a user with a unique username and email, b
       done();
     }, (e) => {
       expect(e.code).toEqual(Parse.Error.SCRIPT_FAILED);
-      expect(e.message).toEqual('Invalid function.');
+      expect(e.message).toEqual('Invalid function: "somethingThatDoesDefinitelyNotExist"');
       done();
     });
   });

--- a/src/Routers/FunctionsRouter.js
+++ b/src/Routers/FunctionsRouter.js
@@ -161,7 +161,7 @@ export class FunctionsRouter extends PromiseRouter {
         theFunction(request, response);
       });
     } else {
-      throw new Parse.Error(Parse.Error.SCRIPT_FAILED, 'Invalid function.');
+      throw new Parse.Error(Parse.Error.SCRIPT_FAILED, `Invalid function: "${functionName}"`);
     }
   }
 }


### PR DESCRIPTION
Currently in the logs if an invalid function is called, the error message just says "invalid function", which is decidedly unhelpful when looking through server logs. :)

This PR adds the function name to the error message.