### PR TITLE
Adding support for AfterFind

### DIFF
--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -50,6 +50,11 @@ ParseCloud.beforeFind = function(parseClass, handler) {
   triggers.addTrigger(triggers.Types.beforeFind, className, handler, Parse.applicationId);
 };
 
+ParseCloud.afterFind = function(parseClass, handler) {
+  const className = getClassName(parseClass);
+  triggers.addTrigger(triggers.Types.afterFind, className, handler, Parse.applicationId);
+};
+
 ParseCloud._removeAllHooks = () => {
   triggers._unregisterAll();
 }


### PR DESCRIPTION
Resubmitting (https://github.com/ParsePlatform/parse-server/pull/2962) and fix git history issue.
For security reasons, I need to hide certain fields (like email) and rows from the API for use cases which are not supported by the current ACL framework. This plugin will enable all sorts of manipulation. With the promise, one can even augment their parse data !
