### PR TITLE
Use spec reporter instead of dots

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "gaze": "1.1.1",
     "istanbul": "1.0.0-alpha.1",
     "jasmine": "2.5.2",
+    "jasmine-spec-reporter": "^2.7.0",
     "mongodb-runner": "3.4.0",
     "nodemon": "1.11.0",
     "request-promise": "4.1.1"
@@ -64,7 +65,7 @@
   "scripts": {
     "dev": "npm run build && node bin/dev",
     "build": "babel src/ -d lib/",
-    "test": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 NODE_ENV=test TESTING=1 node $COVERAGE_OPTION ./node_modules/jasmine/bin/jasmine.js",
+    "test": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 NODE_ENV=test TESTING=1 node $COVERAGE_OPTION ./spec/support/runner.js",
     "test:win": "npm run pretest && cross-env NODE_ENV=test TESTING=1 node ./node_modules/jasmine/bin/jasmine.js && npm run posttest",
     "coverage": "cross-env COVERAGE_OPTION='./node_modules/.bin/istanbul cover' npm test",
     "coverage:win": "npm run pretest && cross-env NODE_ENV=test TESTING=1 node ./node_modules/babel-istanbul/lib/cli.js cover ./node_modules/jasmine/bin/jasmine.js && npm run posttest",

--- a/spec/support/runner.js
+++ b/spec/support/runner.js
@@ -1,0 +1,8 @@
+var Jasmine = require('jasmine');
+var SpecReporter = require('jasmine-spec-reporter');
+
+var jrunner = new Jasmine();
+jrunner.env.clearReporters();                       // jasmine >= 2.5.2, remove default reporter logs
+jrunner.addReporter(new SpecReporter());            // add jasmine-spec-reporter
+jrunner.loadConfigFile();                           // load jasmine.json configuration
+jrunner.execute();


### PR DESCRIPTION
It's hard tracking down which tests fail when you just get an red "F" or a green "."

I'm also super impatient when it comes for waiting for the whole test suite to finish to see which tests fail.

This change switches parse-server to use the spec reporter so that you can quickly identify which tests are failing and then focus on them to fix your code.