### PR TITLE
Add health-checking endpoint on '/' that always returns 200

### DIFF
--- a/spec/PublicAPI.spec.js
+++ b/spec/PublicAPI.spec.js
@@ -35,13 +35,20 @@ describe("public API", () => {
       done();
     });
   });
+
+  it('should get 200 on health', (done) => {
+    request('http://localhost:8378/1/health', (err, httpResponse, body) => {
+      expect(httpResponse.statusCode).toBe(200);
+      done();
+    });
+  });
 });
 
 describe("public API without publicServerURL", () => {
   beforeEach(done => {
     reconfigureServer({ appName: 'unused' })
     .then(done, fail);
-  })
+  });
   it("should get 404 on verify_email", (done) => {
     request('http://localhost:8378/1/apps/test/verify_email', (err, httpResponse, body) => {
       expect(httpResponse.statusCode).toBe(404);
@@ -59,6 +66,13 @@ describe("public API without publicServerURL", () => {
   it("should get 404 on request_password_reset", (done) => {
     request('http://localhost:8378/1/apps/test/request_password_reset', (err, httpResponse, body) => {
       expect(httpResponse.statusCode).toBe(404);
+      done();
+    });
+  });
+
+  it('should get 200 on health', (done) => {
+    request('http://localhost:8378/1/health', (err, httpResponse, body) => {
+      expect(httpResponse.statusCode).toBe(200);
       done();
     });
   });

--- a/spec/PublicAPI.spec.js
+++ b/spec/PublicAPI.spec.js
@@ -35,13 +35,6 @@ describe("public API", () => {
       done();
     });
   });
-
-  it('should get 200 on health', (done) => {
-    request('http://localhost:8378/1/health', (err, httpResponse, body) => {
-      expect(httpResponse.statusCode).toBe(200);
-      done();
-    });
-  });
 });
 
 describe("public API without publicServerURL", () => {
@@ -66,13 +59,6 @@ describe("public API without publicServerURL", () => {
   it("should get 404 on request_password_reset", (done) => {
     request('http://localhost:8378/1/apps/test/request_password_reset', (err, httpResponse, body) => {
       expect(httpResponse.statusCode).toBe(404);
-      done();
-    });
-  });
-
-  it('should get 200 on health', (done) => {
-    request('http://localhost:8378/1/health', (err, httpResponse, body) => {
-      expect(httpResponse.statusCode).toBe(200);
       done();
     });
   });

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -164,6 +164,15 @@ describe('server', () => {
     })
   });
 
+  it('can respond 200 on path health', done => {
+    request.get({
+      url: 'http://localhost:8378/1/health',
+    }, (error, response, body) => {
+      expect(response.statusCode).toBe(200);
+      done();
+    });
+  });
+
   it('can create a parse-server v1', done => {
     var parseServer = new ParseServer.default(Object.assign({},
       defaultConfiguration, {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -153,7 +153,7 @@ class ParseServer {
     }
 
     if (!filesAdapter && !databaseURI) {
-      throw 'When using an explicit database adapter, you must also use and explicit filesAdapter.';
+      throw 'When using an explicit database adapter, you must also use an explicit filesAdapter.';
     }
 
     const loggerControllerAdapter = loadAdapter(loggerAdapter, WinstonLoggerAdapter, { jsonLogs, logsFolder, verbose, logLevel, silent });
@@ -285,6 +285,8 @@ class ParseServer {
     api.use('/', middlewares.allowCrossDomain, new FilesRouter().expressRouter({
       maxUploadSize: maxUploadSize
     }));
+
+    api.use('/health', (req, res) => res.sendStatus(200));
 
     api.use('/', bodyParser.urlencoded({extended: false}), new PublicAPIRouter().expressRouter());
 

--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -33,6 +33,10 @@ function startServer(options, callback) {
   const api = new ParseServer(options);
   const sockets = {};
 
+  app.get('/', function(req, res) {
+    res.sendStatus(200);
+  });
+
   app.use(options.mountPath, api);
 
   var server = app.listen(options.port, callback);

--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -33,10 +33,6 @@ function startServer(options, callback) {
   const api = new ParseServer(options);
   const sockets = {};
 
-  app.get('/', function(req, res) {
-    res.sendStatus(200);
-  });
-
   app.use(options.mountPath, api);
 
   var server = app.listen(options.port, callback);


### PR DESCRIPTION
At some point people may need to have an endpoint that simply responds 200 OK without any authentication. In our case, we need it for L7 GSLB health-checker, as we cannot pass any custom auth headers.  

This PR would make parse to always respond with 200  and text "Ok" on path `/`.