### PR TITLE
Add support for Bytes in postgres adapter

### DIFF
--- a/spec/ParseObject.spec.js
+++ b/spec/ParseObject.spec.js
@@ -268,18 +268,15 @@ describe('Parse.Object testing', () => {
     });
   });
 
+  // This test isn't applicable to Postgres
+  // More info: https://github.com/ParsePlatform/parse-server/pull/2999 
   it_exclude_dbs(['postgres'])("can set null", function(done) {
     var errored = false;
     var obj = new Parse.Object("TestObject");
     obj.set("foo", null);
     obj.save(null, {
       success: function(obj) {
-        on_db('mongo', () => {
-          equal(obj.get("foo"), null);
-        });
-        on_db('postgres', () => {
-          fail('should not succeed');
-        });
+        equal(obj.get("foo"), null);
         done();
       },
       error: function(obj, error) {
@@ -1331,6 +1328,8 @@ describe('Parse.Object testing', () => {
     });
   });
 
+  // This test is not applicable to Postgres
+  // More info: https://github.com/ParsePlatform/parse-server/pull/2999 
   it_exclude_dbs(['postgres'])("bytes work", function(done) {
     Parse.Promise.as().then(function() {
       var obj = new TestObject();


### PR DESCRIPTION
This PR needs a closer review due to the following change:

Currently, in a request to create an object, the postgres adapter throws a runtime error if the request contains a field that doesn't exist in the corresponding schema. This PR (apart from adding support for Bytes) updates the schema for such requests. 

**Edit:** It ignores parse specific fields (those that begin with an underscore) for this action.

**Edit 2:** The same part of code now sets the field type to `String` (is this acceptable?) if the value of the new field is `null`. This particular change allows enabling another previously excluded test for postgres.

This change was required to get one test (enabled as part of this PR) to run successfully against Postgres

Is this behavior acceptable?