### PR TITLE
Dockerizing Parse Server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+node_modules
+npm-debug.log
+*.md
+PATENTS
+LICENSE
+Dockerfile
+.dockerignore
+.gitignore
+.travis.yml
+.istanbul.yml
+.git
+.github
+
+# Build folder
+lib/
+
+# Tests
+spec/
+
+# IDEs
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:boron
+
+RUN mkdir -p /parse-server
+COPY ./ /parse-server/
+
+RUN mkdir -p /parse-server/config
+VOLUME /parse-server/config
+
+RUN mkdir -p /parse-server/cloud
+VOLUME /parse-server/cloud
+
+WORKDIR /parse-server
+
+RUN npm install && \
+    npm run build
+
+ENV PORT=1337
+ENV PARSE_SERVER_CLOUD_CODE_MAIN=/parse-server/cloud/main.js
+
+EXPOSE $PORT
+
+ENTRYPOINT ["npm", "start", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN npm install && \
     npm run build
 
 ENV PORT=1337
-ENV PARSE_SERVER_CLOUD_CODE_MAIN=/parse-server/cloud/main.js
 
 EXPOSE $PORT
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ $ mongodb-runner start
 $ parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongodb://localhost/test
 ```
 
+## Running Parse Server in a Docker container
+```
+$ docker build --tag my-parse-server .
+$ docker run parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongodb://localhost/test
+```
+
 You can use any arbitrary string as your application id and master key. These will be used by your clients to authenticate with the Parse Server.
 
 That's it! You are now running a standalone version of Parse Server on your machine.

--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ April 2016 - We created a series of video screencasts, please check them out her
 
 The fastest and easiest way to get started is to run MongoDB and Parse Server locally.
 
-## Running Parse Server locally
+## Running Parse Server
 
+### Locally
 ```
 $ npm install -g parse-server mongodb-runner
 $ mongodb-runner start
 $ parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongodb://localhost/test
 ```
 
-You can run a Docker container instead
+### Inside a Docker container
 ```
 $ docker build --tag my-parse-server .
 $ docker run --name my-mongo -d mongo

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ $ parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongo
 ## Running Parse Server in a Docker container
 ```
 $ docker build --tag my-parse-server .
-$ docker run parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongodb://localhost/test
+$ docker run --name my-mongo -d mongo
+$ docker run --name my-parse-server --link my-mongo:mongo parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongodb://mongo/test
 ```
 
 You can use any arbitrary string as your application id and master key. These will be used by your clients to authenticate with the Parse Server.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ $ mongodb-runner start
 $ parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongodb://localhost/test
 ```
 
-## Running Parse Server in a Docker container
+You can run a Docker container instead
 ```
 $ docker build --tag my-parse-server .
 $ docker run --name my-mongo -d mongo
 $ docker run --name my-parse-server --link my-mongo:mongo parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongodb://mongo/test
-```
+```  
 
 You can use any arbitrary string as your application id and master key. These will be used by your clients to authenticate with the Parse Server.
 


### PR DESCRIPTION
Hey everyone,   

Since me and my company is running parse-server in our container clusters in production, we are really missing an official Docker image with Parse-server that is configurable and not over-bloated with stuff. We ended up making our own Parse Server image which you can see in this PR.
It is pretty simple, yet configurable. You can configure the same way you configure parse-server, either with environment variables or by passing parameters. Also, you can attach a volume with your JSON configuration and pass the path to it when you run container. Besides, you can also attach a volume with your Cloud Code.

Eventually we would love to see an official Parse Server on Docker Hub, so that we can simply pull it from there (ideally, tagged for a specific version, like `docker pull parseplatform/parse-server:2.2.25`). That would be really handy for us, and I bet for many other out there.

If you have any concerns or you want anything to be different, feel free to comment and I will do it :-)