### PR TITLE
Don't create default folder when PARSE_SERVER_LOGS_FOLDER is null or "null"

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,9 +1,13 @@
+import {nullParser} from './cli/utils/parsers';
+
 let logsFolder = (() => {
   let folder = './logs/';
   if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
     folder = './test_logs/'
   }
-  folder = process.env.PARSE_SERVER_LOGS_FOLDER || folder;
+  if (process.env.PARSE_SERVER_LOGS_FOLDER) {
+    folder = nullParser(process.env.PARSE_SERVER_LOGS_FOLDER);
+  }
   return folder;
 })();
 


### PR DESCRIPTION
While 'null' works for the logger adapter created in ParseServer.js, it does not work for the default logger that is created in logger.js. 

E.g. currently if the following is set
```
export PARSE_SERVER_LOGS_FOLDER="null"
```

Then a folder with the name null is created.
