### PR TITLE
Add support for maxTimeMS mongoOption

### DIFF
--- a/src/Adapters/Storage/Mongo/MongoCollection.js
+++ b/src/Adapters/Storage/Mongo/MongoCollection.js
@@ -13,8 +13,8 @@ export default class MongoCollection {
   // none, then build the geoindex.
   // This could be improved a lot but it's not clear if that's a good
   // idea. Or even if this behavior is a good idea.
-  find(query, { skip, limit, sort, keys } = {}) {
-    return this._rawFind(query, { skip, limit, sort, keys })
+  find(query, { skip, limit, sort, keys, maxTimeMS } = {}) {
+    return this._rawFind(query, { skip, limit, sort, keys, maxTimeMS })
       .catch(error => {
         // Check for "no geoindex" error
         if (error.code != 17007 && !error.message.match(/unable to find index for .geoNear/)) {
@@ -30,22 +30,29 @@ export default class MongoCollection {
         index[key] = '2d';
         return this._mongoCollection.createIndex(index)
           // Retry, but just once.
-          .then(() => this._rawFind(query, { skip, limit, sort, keys }));
+          .then(() => this._rawFind(query, { skip, limit, sort, keys, maxTimeMS }));
       });
   }
 
-  _rawFind(query, { skip, limit, sort, keys } = {}) {
+  _rawFind(query, { skip, limit, sort, keys, maxTimeMS } = {}) {
     let findOperation = this._mongoCollection
       .find(query, { skip, limit, sort })
 
     if (keys) {
       findOperation = findOperation.project(keys);
     }
+
+    if (maxTimeMS) {
+      findOperation = findOperation.maxTimeMS(maxTimeMS);
+    }
+
     return findOperation.toArray();
   }
 
-  count(query, { skip, limit, sort } = {}) {
-    return this._mongoCollection.count(query, { skip, limit, sort });
+  count(query, { skip, limit, sort, maxTimeMS } = {}) {
+    let countOperation = this._mongoCollection.count(query, { skip, limit, sort, maxTimeMS });
+
+    return countOperation;
   }
 
   insertOne(object) {


### PR DESCRIPTION
We have several enormous collections (think 35 million+ objects). When running parse-dashboard there is no way to prevent users from finding/sorting on criteria having no index. The dashboard doesn't respond, users click to sort the other direction, more slow running queries... eventually the system comes down.

Eventually it would be nice to have parse-dashboard only allow sorting/filtering on indexed columns and on all columns when the collection size is less than 10k objects or something. Even then, there is no guarantee our application's inbound queries are all covered. For example a user in the browser JS console making their own queries.

It would be nice to put a limit on find/count (in MS) by taking advantage of the per-operation $maxTimeMS MongoDB query operator. This is an initial stab at getting it to work.