### PR TITLE
Injected the username when password has changed.

### DIFF
--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -816,7 +816,7 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
               return;
             }
             expect(response.statusCode).toEqual(302);
-            expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/password_reset_success.html');
+            expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/password_reset_success.html?username=zxcv');
 
             Parse.User.logIn("zxcv", "hello").then(function(user){
               let config = new Config('test');

--- a/src/Routers/PublicAPIRouter.js
+++ b/src/Routers/PublicAPIRouter.js
@@ -102,9 +102,10 @@ export class PublicAPIRouter extends PromiseRouter {
     }
 
     return config.userController.updatePassword(username, token, new_password).then((result) => {
+      let params = qs.stringify({username: username});
       return Promise.resolve({
         status: 302,
-        location: config.passwordResetSuccessURL
+        location: `${config.passwordResetSuccessURL}?${params}`
       });
     }, (err) => {
       let params = qs.stringify({username: username, token: token, id: config.applicationId, error:err, app:config.appName})


### PR DESCRIPTION
When the `resetPassword` handler has successfully updated the user's password, it redirects the user to the password changed page without passing it the `username` value as a query parameter, which the hosted parse server did.

This commit makes it possible to pass the `username` value to the password change confirmation page.