### PR TITLE
Improvements to CLI parsers

### DIFF
--- a/spec/parsers.spec.js
+++ b/spec/parsers.spec.js
@@ -1,0 +1,34 @@
+import {
+	numberParser,
+	numberOrBoolParser,
+	booleanParser,
+} from '../src/cli/utils/parsers';
+
+describe('parsers', () => {
+	it('parses correctly with numberParser', () => {
+		const parser = numberParser('key');
+		expect(parser(2)).toEqual(2);
+		expect(parser('2')).toEqual(2);
+		expect(() => {parser('string')}).toThrow();
+	});
+
+	it('parses correctly with numberOrBoolParser', () => {
+		const parser = numberOrBoolParser('key');
+		expect(parser(true)).toEqual(true);
+		expect(parser(false)).toEqual(false);
+		expect(parser('true')).toEqual(true);
+		expect(parser('false')).toEqual(false);
+		expect(parser(1)).toEqual(1);
+		expect(parser('1')).toEqual(1);
+	});
+
+	it('parses correctly with booleanParser', () => {
+		const parser = booleanParser;
+		expect(parser(true)).toEqual(true);
+		expect(parser(false)).toEqual(false);
+		expect(parser('true')).toEqual(true);
+		expect(parser('false')).toEqual(false);
+		expect(parser(1)).toEqual(true);
+		expect(parser(2)).toEqual(false);
+	});
+});

--- a/src/cli/definitions/parse-server.js
+++ b/src/cli/definitions/parse-server.js
@@ -201,6 +201,7 @@ export default {
     action: booleanParser
   },
   "cluster": {
+    env: PARSE_SERVER_CLUSTER,
     help: "Run with cluster, optionally set the number of processes default to os.cpus().length",
     action: numberOrBoolParser("cluster")
   },

--- a/src/cli/utils/parsers.js
+++ b/src/cli/utils/parsers.js
@@ -1,10 +1,10 @@
 export function numberParser(key) {
   return function(opt) {
-    opt = parseInt(opt);
-    if (!Number.isInteger(opt)) {
-      throw new Error(`The ${key} is invalid`);
+    const intOpt = parseInt(opt);
+    if (!Number.isInteger(intOpt)) {
+      throw new Error(`Key ${key} has invalid value ${opt}`);
     }
-    return opt;
+    return intOpt;
   }
 }
 
@@ -12,6 +12,12 @@ export function numberOrBoolParser(key) {
   return function(opt) {
     if (typeof opt === 'boolean') {
       return opt;
+    }
+    if (opt === 'true') {
+      return true;
+    }
+    if (opt === 'false') {
+      return false;
     }
     return numberParser(key)(opt);
   }
@@ -45,7 +51,7 @@ export function moduleOrObjectParser(opt) {
 }
 
 export function booleanParser(opt) {
-  if (opt == true || opt == "true" || opt == "1") {
+  if (opt == true || opt == 'true' || opt == '1') {
     return true;
   }
   return false;


### PR DESCRIPTION
Allow numberOrBooleanParser to parse a string correctly so `parse-server -cluster true` will now work. In a quick test, all cli options are typed as strings, e.g. null, true, 2. Not sure if this is platform/nodejs version specific though.

Improve error message in numberParser, e.g. `parse-server -cluster fail` will be `Key cluster has invalid value fail` instead of `The cluster is invalid`

Add env variable PARSE_SERVER_CLUSTER for cluster, because we want to set this per environment.

Added some basic tests to clarify existing parser behavior.