### PR TITLE
Let multiple installations be updates if no critical values are set

### DIFF
--- a/src/LiveQuery/ParseCloudCodePublisher.js
+++ b/src/LiveQuery/ParseCloudCodePublisher.js
@@ -1,4 +1,5 @@
 import { ParsePubSub } from './ParsePubSub';
+import Parse  from 'parse/node';
 import logger from '../logger';
 
 class ParseCloudCodePublisher {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -602,6 +602,12 @@ RestWrite.prototype.handleInstallation = function() {
                           'must be specified in this operation');
   }
 
+  // Updating _Installation but not updating anything critical
+  if (this.query && !this.data.deviceToken 
+                  && !this.data.installationId && !this.data.deviceType) {
+    return;
+  }
+
   // If the device token is 64 characters long, we assume it is for iOS
   // and lowercase it.
   if (this.data.deviceToken && this.data.deviceToken.length == 64) {

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -602,12 +602,6 @@ RestWrite.prototype.handleInstallation = function() {
                           'must be specified in this operation');
   }
 
-  // Updating _Installation but not updating anything critical
-  if (this.query && !this.data.deviceToken 
-                  && !this.data.installationId && !this.data.deviceType) {
-    return;
-  }
-
   // If the device token is 64 characters long, we assume it is for iOS
   // and lowercase it.
   if (this.data.deviceToken && this.data.deviceToken.length == 64) {
@@ -628,6 +622,12 @@ RestWrite.prototype.handleInstallation = function() {
 
   if (installationId) {
     installationId = installationId.toLowerCase();
+  }
+
+  // Updating _Installation but not updating anything critical
+  if (this.query && !this.data.deviceToken 
+                  && !installationId && !this.data.deviceType) {
+    return;
   }
 
   var promise = Promise.resolve();


### PR DESCRIPTION
Fixes #2903
Fixes #3036

When sending push with badge, multiple installations may be updated, and blocked by the RESTWrite implementation. 

This PR ensures that when not critical update is done to the _Installation, the safeguards are skipped.