### PR TITLE
Enhanced support for batch endpoints

### DIFF
--- a/spec/batch.spec.js
+++ b/spec/batch.spec.js
@@ -7,37 +7,37 @@ const serverURLNaked = 'http://localhost:1234/';
 const publicServerURL = 'http://domain.com/parse';
 const publicServerURLNaked = 'http://domain.com/';
 
-describe('batch', () => {
-  it('should return the proper url', () => {
-    let internalURL = batch.mBatchRoutingPath(originalURL)('/parse/classes/Object');
+describe('batch', () => {
+  it('should return the proper url', () => {
+    let internalURL = batch.makeBatchRoutingPathFunction(originalURL)('/parse/classes/Object');
 
     expect(internalURL).toEqual('/classes/Object');
   });
 
-  it('should return the proper url same public/local endpoint', () => {
+  it('should return the proper url same public/local endpoint', () => {
     let originalURL = '/parse/batch';
-    let internalURL = batch.mBatchRoutingPath(originalURL, serverURL, publicServerURL)('/parse/classes/Object');
+    let internalURL = batch.makeBatchRoutingPathFunction(originalURL, serverURL, publicServerURL)('/parse/classes/Object');
 
     expect(internalURL).toEqual('/classes/Object');
   });
 
-  it('should return the proper url with different public/local mount', () => {
+  it('should return the proper url with different public/local mount', () => {
     let originalURL = '/parse/batch';
-    let internalURL = batch.mBatchRoutingPath(originalURL, serverURL1, publicServerURL)('/parse/classes/Object');
+    let internalURL = batch.makeBatchRoutingPathFunction(originalURL, serverURL1, publicServerURL)('/parse/classes/Object');
 
     expect(internalURL).toEqual('/classes/Object');
   });
 
-  it('should return the proper url with naked public', () => {
+  it('should return the proper url with naked public', () => {
     let originalURL = '/batch';
-    let internalURL = batch.mBatchRoutingPath(originalURL, serverURL, publicServerURLNaked)('/classes/Object');
+    let internalURL = batch.makeBatchRoutingPathFunction(originalURL, serverURL, publicServerURLNaked)('/classes/Object');
 
     expect(internalURL).toEqual('/classes/Object');
   });
 
-  it('should return the proper url with naked local', () => {
+  it('should return the proper url with naked local', () => {
     let originalURL = '/parse/batch';
-    let internalURL = batch.mBatchRoutingPath(originalURL, serverURLNaked, publicServerURL)('/parse/classes/Object');
+    let internalURL = batch.makeBatchRoutingPathFunction(originalURL, serverURLNaked, publicServerURL)('/parse/classes/Object');
 
     expect(internalURL).toEqual('/classes/Object');
   });

--- a/spec/batch.spec.js
+++ b/spec/batch.spec.js
@@ -1,0 +1,44 @@
+var batch = require('../src/batch');
+
+const originalURL = '/parse/batch';
+const serverURL = 'http://localhost:1234/parse';
+const serverURL1 = 'http://localhost:1234/1';
+const serverURLNaked = 'http://localhost:1234/';
+const publicServerURL = 'http://domain.com/parse';
+const publicServerURLNaked = 'http://domain.com/';
+
+describe('batch', () => {
+  it('should return the proper url', () => {
+    let internalURL = batch.mBatchRoutingPath(originalURL)('/parse/classes/Object');
+
+    expect(internalURL).toEqual('/classes/Object');
+  });
+
+  it('should return the proper url same public/local endpoint', () => {
+    let originalURL = '/parse/batch';
+    let internalURL = batch.mBatchRoutingPath(originalURL, serverURL, publicServerURL)('/parse/classes/Object');
+
+    expect(internalURL).toEqual('/classes/Object');
+  });
+
+  it('should return the proper url with different public/local mount', () => {
+    let originalURL = '/parse/batch';
+    let internalURL = batch.mBatchRoutingPath(originalURL, serverURL1, publicServerURL)('/parse/classes/Object');
+
+    expect(internalURL).toEqual('/classes/Object');
+  });
+
+  it('should return the proper url with naked public', () => {
+    let originalURL = '/batch';
+    let internalURL = batch.mBatchRoutingPath(originalURL, serverURL, publicServerURLNaked)('/classes/Object');
+
+    expect(internalURL).toEqual('/classes/Object');
+  });
+
+  it('should return the proper url with naked local', () => {
+    let originalURL = '/parse/batch';
+    let internalURL = batch.mBatchRoutingPath(originalURL, serverURLNaked, publicServerURL)('/parse/classes/Object');
+
+    expect(internalURL).toEqual('/classes/Object');
+  });
+});

--- a/src/batch.js
+++ b/src/batch.js
@@ -1,13 +1,57 @@
-var Parse = require('parse/node').Parse;
-
+const Parse = require('parse/node').Parse;
+const url = require('url');
+const path = require('path');
 // These methods handle batch requests.
-var batchPath = '/batch';
+const batchPath = '/batch';
 
 // Mounts a batch-handler onto a PromiseRouter.
 function mountOnto(router) {
   router.route('POST', batchPath, (req) => {
     return handleBatch(router, req);
   });
+}
+
+function parseURL(URL) {
+  if (typeof URL === 'string') {
+    return url.parse(URL)
+  }
+  return undefined;
+}
+
+function mBatchRoutingPath(originalUrl, serverURL, publicServerURL) {
+    serverURL = serverURL ? parseURL(serverURL) : undefined;
+    publicServerURL = publicServerURL ? parseURL(publicServerURL): undefined;
+
+    let apiPrefixLength = originalUrl.length - batchPath.length;
+    let apiPrefix = originalUrl.slice(0, apiPrefixLength);
+
+    let makeRoutablePath = function(requestPath) {
+      // The routablePath is the path minus the api prefix
+      if (requestPath.slice(0, apiPrefixLength) != apiPrefix) {
+        throw new Parse.Error(
+          Parse.Error.INVALID_JSON,
+          'cannot route batch path ' + path);
+      }
+      return path.join('/', requestPath.slice(apiPrefixLength));
+    }
+
+    if (serverURL && publicServerURL 
+        && (serverURL.path != publicServerURL.path)) {
+      let localPath = serverURL.path;
+      let publicPath = publicServerURL.path;
+      // Override the api prefix
+      apiPrefix = localPath;
+      apiPrefixLength = localPath.length;
+      return function(requestPath) {
+        // Build the new path by removing the public path
+        // and joining with the local path
+        let newPath = path.join('/', localPath, '/' , requestPath.slice(publicPath.length));
+        // Use the method for local routing
+        return makeRoutablePath(newPath);
+      }
+    }
+
+    return makeRoutablePath;
 }
 
 // Returns a promise for a {response} object.
@@ -26,19 +70,13 @@ function handleBatch(router, req) {
   if (!req.originalUrl.endsWith(batchPath)) {
     throw 'internal routing problem - expected url to end with batch';
   }
-  var apiPrefixLength = req.originalUrl.length - batchPath.length;
-  var apiPrefix = req.originalUrl.slice(0, apiPrefixLength);
+
+  const makeRoutablePath = mBatchRoutingPath(req.originalUrl, req.config.serverURL, req.config.publicServerURL);
 
   const promises = req.body.requests.map((restRequest) => {
-    // The routablePath is the path minus the api prefix
-    if (restRequest.path.slice(0, apiPrefixLength) != apiPrefix) {
-      throw new Parse.Error(
-        Parse.Error.INVALID_JSON,
-        'cannot route batch path ' + restRequest.path);
-    }
-    var routablePath = restRequest.path.slice(apiPrefixLength);
+    const routablePath = makeRoutablePath(restRequest.path);
     // Construct a request that we can send to a handler
-    var request = {
+    const request = {
       body: restRequest.body,
       config: req.config,
       auth: req.auth,
@@ -58,5 +96,6 @@ function handleBatch(router, req) {
 }
 
 module.exports = {
-  mountOnto: mountOnto
+  mountOnto,
+  mBatchRoutingPath
 };


### PR DESCRIPTION
Adds ability to have publicServerURL different from serverURL ex: `http://api.my-parse.com/` and `http://localhost/parse` for batch calls

Fixes #2980