### PR TITLE
Fix MongoStorageAdapter.findOneAndUpdate to return Parse Object (#3053)

### DIFF
--- a/spec/MongoStorageAdapter.spec.js
+++ b/spec/MongoStorageAdapter.spec.js
@@ -149,7 +149,7 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
     });
   });
 
-  it('handles array, object, date', (done) => {
+  it('handles creating an array, object, date', (done) => {
     let adapter = new MongoStorageAdapter({ uri: databaseURI });
     let obj = {
       array: [1, 2, 3],
@@ -181,6 +181,54 @@ describe_only_db('mongo')('MongoStorageAdapter', () => {
       expect(typeof mob.object).toBe('object');
       expect(mob.date.__type).toBe('Date');
       expect(mob.date.iso).toBe('2016-05-26T20:55:01.154Z');
+      done();
+    })
+    .catch(error => {
+      console.log(error);
+      fail();
+      done();
+    });
+  });
+
+  it("handles updating a single object with array, object date", (done) => {
+    let adapter = new MongoStorageAdapter({ uri: databaseURI });
+    
+    let schema = { fields: {
+      array: { type: 'Array' },
+      object: { type: 'Object' },
+      date: { type: 'Date' },
+    } };
+
+    
+    adapter.createObject('MyClass', schema, {})
+    .then(() => adapter._rawFind('MyClass', {}))
+    .then(results => {
+      expect(results.length).toEqual(1);
+      let update = {
+        array: [1, 2, 3],
+        object: {foo: 'bar'},
+        date: {
+          __type: 'Date',
+          iso: '2016-05-26T20:55:01.154Z',
+        },
+      };
+      let query = {};
+      return adapter.findOneAndUpdate('MyClass', schema, query, update)
+    })
+    .then(results => {
+      let mob = results;
+      expect(mob.array instanceof Array).toBe(true);
+      expect(typeof mob.object).toBe('object');
+      expect(mob.date.__type).toBe('Date');
+      expect(mob.date.iso).toBe('2016-05-26T20:55:01.154Z');
+      return adapter._rawFind('MyClass', {});
+    })
+    .then(results => {
+      expect(results.length).toEqual(1);
+      let mob = results[0];
+      expect(mob.array instanceof Array).toBe(true);
+      expect(typeof mob.object).toBe('object');
+      expect(mob.date instanceof Date).toBe(true);
       done();
     })
     .catch(error => {

--- a/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
+++ b/src/Adapters/Storage/Mongo/MongoStorageAdapter.js
@@ -310,7 +310,7 @@ export class MongoStorageAdapter {
     const mongoWhere = transformWhere(className, query, schema);
     return this._adaptiveCollection(className)
     .then(collection => collection._mongoCollection.findAndModify(mongoWhere, [], mongoUpdate, { new: true }))
-    .then(result => result.value);
+    .then(result => mongoObjectToParseObject(className, result.value, schema));
   }
 
   // Hopefully we can get rid of this. It's only used for config and hooks.


### PR DESCRIPTION
This PR resolves the general issue that the response to PUT request to update an object returns the result formatted as a Mongo DB object rather than a parse object. This results for example as dates objects being serialized as strings instead of objects with appropriate keys e.g.```{"__type":"Date","iso":"2016-11-14T07:37:49.838Z"}```.

Prior to this fix, responses to an update corrupts the local version of an object on the iOS Parse client (and possibly others).

This also generalizes to responses with objects nested in arrays such as recorded in #3053.