### PR TITLE
support Relation object saving

### DIFF
--- a/spec/MongoTransform.spec.js
+++ b/spec/MongoTransform.spec.js
@@ -236,6 +236,19 @@ describe('parseObjectToMongoObjectForCreate', () => {
     done();
   });
 
+  it('removes Relation types', (done) => {
+    var input = {
+      aRelation: { __type: 'Relation', className: 'Stuff' },
+    };
+    var output = transform.parseObjectToMongoObjectForCreate(null, input, {
+      fields: {
+        aRelation: { __type: 'Relation', className: 'Stuff' }, 
+      },
+    });
+    expect(output).toEqual({});
+    done();
+  });
+
   it('writes the old ACL format in addition to rperm and wperm on update', (done) => {
     var input = {
       _rperm: ['*'],
@@ -280,5 +293,19 @@ describe('parseObjectToMongoObjectForCreate', () => {
     expect(output.double).toBe(Number.MAX_VALUE);
     done();
   });
+});
 
+describe('transformUpdate', () => {
+  it('removes Relation types', (done) => {
+    var input = {
+      aRelation: { __type: 'Relation', className: 'Stuff' },
+    };
+    var output = transform.transformUpdate(null, input, {
+      fields: {
+        aRelation: { __type: 'Relation', className: 'Stuff' }, 
+      },
+    });
+    expect(output).toEqual({});
+    done();
+  });
 });

--- a/spec/ParseRelation.spec.js
+++ b/spec/ParseRelation.spec.js
@@ -741,4 +741,32 @@ describe('Parse.Relation testing', () => {
       done();
     });
   });
+
+  it('can be saved without error', done => {
+    let obj1 = new Parse.Object('PPAP');
+    obj1.save()
+    .then(() => {
+      let newRelation = obj1.relation('aRelation');
+      newRelation.add(obj1);
+      obj1.save().then(() => {
+        let relation = obj1.get('aRelation');
+        obj1.set('aRelation', relation);
+        obj1.save().then(() => {
+          done();
+        }, error => {
+          fail('failed to save ParseRelation object');
+          fail(error);
+          done();
+        });
+      }, error => {
+        fail('failed to create relation field');
+        fail(error);
+        done();
+      });
+    }, error => {
+      fail('failed to save obj');
+      fail(error);
+      done();
+    });
+  });
 });

--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -56,6 +56,21 @@ describe('SchemaController', () => {
     });
   });
 
+  it('can validate Relation object', (done) => {
+    config.database.loadSchema().then((schema) => {
+      return schema.validateObject('Stuff', {aRelation: {__type:'Relation',className:'Stuff'}});
+    }).then((schema) => {
+      return schema.validateObject('Stuff', {aRelation: {__type:'Pointer',className:'Stuff'}})
+      .then((schema) => {
+        fail('expected invalidity');
+        done();
+      }, done);
+    }, (err) => {
+      fail(err);
+      done();
+    });
+  });
+
   it('rejects inconsistent types', (done) => {
     config.database.loadSchema().then((schema) => {
       return schema.validateObject('Stuff', {bacon: 7});

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -319,6 +319,9 @@ const parseObjectToMongoObjectForCreate = (className, restCreate, schema) => {
   restCreate = addLegacyACL(restCreate);
   let mongoCreate = {}
   for (let restKey in restCreate) {
+    if (restCreate[restKey] && restCreate[restKey].__type === 'Relation') {
+      continue;
+    }
     let { key, value } = parseObjectKeyValueToMongoObjectKeyValue(
       restKey,
       restCreate[restKey],
@@ -359,6 +362,9 @@ const transformUpdate = (className, restUpdate, parseFormatSchema) => {
     }
   }
   for (var restKey in restUpdate) {
+    if (restUpdate[restKey] && restUpdate[restKey].__type === 'Relation') {
+      continue;
+    }
     var out = transformKeyValueForUpdate(className, restKey, restUpdate[restKey], parseFormatSchema);
 
     // If the output value is an object with any $ keys, it's an

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -895,6 +895,13 @@ function getObjectType(obj) {
             targetClass: obj.className
           }
         }
+      case 'Relation' :
+        if(obj.className) {
+          return {
+            type: 'Relation',
+            targetClass: obj.className
+          }
+        }
       case 'File' :
         if(obj.name) {
           return 'File';


### PR DESCRIPTION
This PR fixes a compatibility issue for saving Relation object.

Request:

```
curl -X POST \
  -H 'X-Parse-Application-Id: XXX' \
  -H 'X-Parse-Master-Key:  YYY' \
  -H 'Content-Type: application/json' \
  -d '{"aRelation":{"__type":"Relation","className":"Foo"}}' \
https://api.parse.com/1/classes/Foo
```

Response from api.parse.com:

```
{"createdAt":"2016-11-19T11:53:04.087Z","objectId":"blEqHPUBuk"}
```

(Parse Class `Foo` and its field `aRelation` are created implicitly.)

Response from parse-server:

```
{"code":111,"error":"This is not a valid Relation"}
```