### PR TITLE
Properly expose TestUtils through top-level package

### DIFF
--- a/src/TestUtils.js
+++ b/src/TestUtils.js
@@ -1,7 +1,7 @@
 import AppCache from './cache';
 
 //Used by tests
-function destroyAllDataPermanently() {
+export function destroyAllDataPermanently() {
   if (!process.env.TESTING) {
     throw 'Only supported in test environment';
   }
@@ -13,8 +13,4 @@ function destroyAllDataPermanently() {
         return Promise.resolve();
       }
     }));
-}
-
-export {
-  destroyAllDataPermanently
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import FileSystemAdapter    from 'parse-server-fs-adapter'
 import InMemoryCacheAdapter from './Adapters/Cache/InMemoryCacheAdapter'
 import NullCacheAdapter     from './Adapters/Cache/NullCacheAdapter'
 import RedisCacheAdapter    from './Adapters/Cache/RedisCacheAdapter'
-import TestUtils            from './TestUtils';
+import * as TestUtils       from './TestUtils';
 import { useExternal }      from './deprecated';
 import { getLogger }        from './logger';
 


### PR DESCRIPTION
This has been misaligned for a few releases now. This makes `destroyAllDataPermanently` available directly from `require('parse-server')`, without having to negotiate the internal directory structure. Without this, the JS SDK integration tests are frozen targeting v2.2.17