### PR TITLE
fixing equals on array columns in live query

### DIFF
--- a/spec/QueryTools.spec.js
+++ b/spec/QueryTools.spec.js
@@ -226,6 +226,23 @@ describe('matchesQuery', function() {
 
     img.owner.objectId = 'U3';
     expect(matchesQuery(img, q)).toBe(false);
+
+    // pointers in arrays
+    q = new Parse.Query('Image');
+    q.equalTo('owners', u);
+
+    img = {
+      className: 'Image',
+      objectId: 'I1',
+      owners: [{
+        className: '_User',
+        objectId: 'U2'
+      }]
+    };
+    expect(matchesQuery(img, q)).toBe(true);
+
+    img.owners[0].objectId = 'U3';
+    expect(matchesQuery(img, q)).toBe(false);
   });
 
   it('matches on inequalities', function() {


### PR DESCRIPTION
The live queries where showing wrong behavior for an array-typed column containing pointers. Here, `equalTo` should check if any pointer matches the constraint. This PR extends the unit test appropriately and fixes the functionality.