### PR TITLE
Adds password history support to passwordPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ var server = ParseServer({
     validatorCallback: (password) => { return validatePassword(password) }, 
     doNotAllowUsername: true, // optional setting to disallow username in passwords
     maxPasswordAge: 90, // optional setting in days for password expiry. Login fails if user does not reset the password within this period after signup/last reset. 
+    passwordHistory: 5, // optional setting to prevent reuse of previous n passwords. Maximum value that can be specified is 20. Not specifying it or specifying 0 will not enforce history.
     //optional setting to set a validity duration for password reset links (in seconds)
     resetTokenValidityDuration: 24*60*60, // expire after 24 hours
   }

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ var server = ParseServer({
     validatorCallback: (password) => { return validatePassword(password) }, 
     doNotAllowUsername: true, // optional setting to disallow username in passwords
     maxPasswordAge: 90, // optional setting in days for password expiry. Login fails if user does not reset the password within this period after signup/last reset. 
-    passwordHistory: 5, // optional setting to prevent reuse of previous n passwords. Maximum value that can be specified is 20. Not specifying it or specifying 0 will not enforce history.
+    maxPasswordHistory: 5, // optional setting to prevent reuse of previous n passwords. Maximum value that can be specified is 20. Not specifying it or specifying 0 will not enforce history.
     //optional setting to set a validity duration for password reset links (in seconds)
     resetTokenValidityDuration: 24*60*60, // expire after 24 hours
   }

--- a/spec/PasswordPolicy.spec.js
+++ b/spec/PasswordPolicy.spec.js
@@ -1267,7 +1267,6 @@ describe("Password Policy: ", () => {
           });
         }).then(data => {
           const response = data[0];
-          const token = data[1];
           expect(response.statusCode).toEqual(302);
           expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/password_reset_success.html?username=user1');
           if(pwCount === 7){ // end it now

--- a/spec/PasswordPolicy.spec.js
+++ b/spec/PasswordPolicy.spec.js
@@ -1010,55 +1010,55 @@ describe("Password Policy: ", () => {
     });
   });
 
-  it('should fail if passwordPolicy.passwordHistory is not a number', done => {
+  it('should fail if passwordPolicy.maxPasswordHistory is not a number', done => {
     reconfigureServer({
       appName: 'passwordPolicy',
       passwordPolicy: {
-        passwordHistory: "not a number"
+        maxPasswordHistory: "not a number"
       },
       publicServerURL: "http://localhost:8378/1"
     }).then(() => {
-      fail('passwordPolicy.passwordHistory "not a number" test failed');
+      fail('passwordPolicy.maxPasswordHistory "not a number" test failed');
       done();
     }).catch(err => {
-      expect(err).toEqual('passwordPolicy.passwordHistory must be an integer ranging 0 - 20');
+      expect(err).toEqual('passwordPolicy.maxPasswordHistory must be an integer ranging 0 - 20');
       done();
     });
   });
 
-  it('should fail if passwordPolicy.passwordHistory is a negative number', done => {
+  it('should fail if passwordPolicy.maxPasswordHistory is a negative number', done => {
     reconfigureServer({
       appName: 'passwordPolicy',
       passwordPolicy: {
-        passwordHistory: -10
+        maxPasswordHistory: -10
       },
       publicServerURL: "http://localhost:8378/1"
     }).then(() => {
-      fail('passwordPolicy.passwordHistory negative number test failed');
+      fail('passwordPolicy.maxPasswordHistory negative number test failed');
       done();
     }).catch(err => {
-      expect(err).toEqual('passwordPolicy.passwordHistory must be an integer ranging 0 - 20');
+      expect(err).toEqual('passwordPolicy.maxPasswordHistory must be an integer ranging 0 - 20');
       done();
     });
   });
 
-  it('should fail if passwordPolicy.passwordHistory is greater than 20', done => {
+  it('should fail if passwordPolicy.maxPasswordHistory is greater than 20', done => {
     reconfigureServer({
       appName: 'passwordPolicy',
       passwordPolicy: {
-        passwordHistory: 21
+        maxPasswordHistory: 21
       },
       publicServerURL: "http://localhost:8378/1"
     }).then(() => {
-      fail('passwordPolicy.passwordHistory negative number test failed');
+      fail('passwordPolicy.maxPasswordHistory negative number test failed');
       done();
     }).catch(err => {
-      expect(err).toEqual('passwordPolicy.passwordHistory must be an integer ranging 0 - 20');
+      expect(err).toEqual('passwordPolicy.maxPasswordHistory must be an integer ranging 0 - 20');
       done();
     });
   });
 
-  it('should fail if the new password is same as the last password', done => {
+  it('should fail to reset if the new password is same as the last password', done => {
     const user = new Parse.User();
     const emailAdapter = {
       sendVerificationEmail: () => Promise.resolve(),
@@ -1115,7 +1115,7 @@ describe("Password Policy: ", () => {
       verifyUserEmails: false,
       emailAdapter: emailAdapter,
       passwordPolicy: {
-        passwordHistory: 1
+        maxPasswordHistory: 1
       },
       publicServerURL: "http://localhost:8378/1"
     }).then(() => {
@@ -1134,76 +1134,15 @@ describe("Password Policy: ", () => {
     });
   });
 
-  it('should fail if the new password is same as 5th oldest password in history when policy does not allow last 5 passwords', done => {
-    const user = new Parse.User();
-    let pwCount = 1;
-    const emailAdapter = {
-      sendVerificationEmail: () => Promise.resolve(),
-      sendPasswordResetEmail: options => {
-        pwCount++; // counter for password generation like user2, user3, .... (user1 is used during signup)
 
-        requestp.get({
-          uri: options.link,
-          followRedirect: false,
-          simple: false,
-          resolveWithFullResponse: true
-        }).then(response => {
-          expect(response.statusCode).toEqual(302);
-          const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=([a-zA-Z0-9]+)\&id=test\&username=user1/;
-          const match = response.body.match(re);
-          if (!match) {
-            fail("should have a token");
-            return Promise.reject("Invalid password link");
-          }
-          return Promise.resolve(match[1]); // token
-        }).then(token => {
-          let newpw = `user${pwCount}`;
-          if(pwCount === 6) // try to reuse the first password which is in history
-            newpw = 'user1';
-          return new Promise((resolve, reject) => {
-            requestp.post({
-              uri: "http://localhost:8378/1/apps/test/request_password_reset",
-              body: `new_password=${newpw}&token=${token}&username=user1`,
-              headers: {
-                'Content-Type': 'application/x-www-form-urlencoded'
-              },
-              followRedirect: false,
-              simple: false,
-              resolveWithFullResponse: true
-            }).then(response => {
-              resolve([response, token]);
-            }).catch(error => {
-              reject(error);
-            });
-          });
-        }).then(data => {
-          const response = data[0];
-          const token = data[1];
-          if(pwCount === 6){ // repeating password 'user1' - must fail
-            expect(response.statusCode).toEqual(302);
-            expect(response.body).toEqual(`Found. Redirecting to http://localhost:8378/1/apps/choose_password?username=user1&token=${token}&id=test&error=New%20password%20should%20not%20be%20the%20same%20as%20last%205%20passwords.&app=passwordPolicy`);
-            done();
-          } else { // continue with resets
-            expect(response.statusCode).toEqual(302);
-            expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/password_reset_success.html?username=user1');
-            Parse.User.requestPasswordReset('user1@parse.com');
-          }
-          return Promise.resolve();
-        }).catch(error => {
-          jfail(error);
-          fail("Repeat password test failed");
-          done();
-        });
-      },
-      sendMail: () => {
-      }
-    };
+  it('should fail if the new password is same as the previous one', done => {
+    const user = new Parse.User();
+
     reconfigureServer({
       appName: 'passwordPolicy',
       verifyUserEmails: false,
-      emailAdapter: emailAdapter,
       passwordPolicy: {
-        passwordHistory: 5
+        maxPasswordHistory: 5
       },
       publicServerURL: "http://localhost:8378/1"
     }).then(() => {
@@ -1211,85 +1150,28 @@ describe("Password Policy: ", () => {
       user.setPassword("user1");
       user.set('email', 'user1@parse.com');
       user.signUp().then(() => {
-        return Parse.User.logOut();
+        // try to set the same password as the previous one
+        user.setPassword('user1');
+        return user.save();
       }).then(() => {
-        // initiate a sequence of password resets
-        return Parse.User.requestPasswordReset('user1@parse.com');
+        fail("should have failed because the new password is same as the old");
+        done();
       }).catch(error => {
-        jfail(error);
-        fail("SignUp or reset request failed");
+        expect(error.message).toEqual('New password should not be the same as last 5 passwords.');
+        expect(error.code).toEqual(Parse.Error.VALIDATION_ERROR);
         done();
       });
     });
   });
 
-  it('should succeed if the a password beyond the history limit is reused', done => {
+  it('should fail if the new password is same as the 5th oldest one and policy does not allow the previous 5', done => {
     const user = new Parse.User();
-    let pwCount = 1;
-    const emailAdapter = {
-      sendVerificationEmail: () => Promise.resolve(),
-      sendPasswordResetEmail: options => {
-        pwCount++; // counter for password sequence (user2, user3, ...)
 
-        requestp.get({
-          uri: options.link,
-          followRedirect: false,
-          simple: false,
-          resolveWithFullResponse: true
-        }).then(response => {
-          expect(response.statusCode).toEqual(302);
-          const re = /http:\/\/localhost:8378\/1\/apps\/choose_password\?token=([a-zA-Z0-9]+)\&id=test\&username=user1/;
-          const match = response.body.match(re);
-          if (!match) {
-            fail("should have a token");
-            return Promise.reject("Invalid password link");
-          }
-          return Promise.resolve(match[1]); // token
-        }).then(token => {
-          let newpw = `user${pwCount}`;
-          if(pwCount === 7) //  reuse the first password now
-            newpw = 'user1';
-          return new Promise((resolve, reject) => {
-            requestp.post({
-              uri: "http://localhost:8378/1/apps/test/request_password_reset",
-              body: `new_password=${newpw}&token=${token}&username=user1`,
-              headers: {
-                'Content-Type': 'application/x-www-form-urlencoded'
-              },
-              followRedirect: false,
-              simple: false,
-              resolveWithFullResponse: true
-            }).then(response => {
-              resolve([response, token]);
-            }).catch(error => {
-              reject(error);
-            });
-          });
-        }).then(data => {
-          const response = data[0];
-          expect(response.statusCode).toEqual(302);
-          expect(response.body).toEqual('Found. Redirecting to http://localhost:8378/1/apps/password_reset_success.html?username=user1');
-          if(pwCount === 7){ // end it now
-            done();
-          } else { //continue with more resets
-            Parse.User.requestPasswordReset('user1@parse.com');
-          }
-          return Promise.resolve();
-        }).catch(error => {
-          jfail(error);
-          fail("Repeat password test failed");
-          done();
-        });
-      },
-      sendMail: () => {
-      }
-    };
     reconfigureServer({
       appName: 'passwordPolicy',
       verifyUserEmails: false,
-      emailAdapter: emailAdapter,
       passwordPolicy: {
-        passwordHistory: 5
+        maxPasswordHistory: 5
       },
       publicServerURL: "http://localhost:8378/1"
     }).then(() => {
@@ -1297,16 +1179,73 @@ describe("Password Policy: ", () => {
       user.setPassword("user1");
       user.set('email', 'user1@parse.com');
       user.signUp().then(() => {
-        return Parse.User.logOut();
+        // build history
+        user.setPassword('user2');
+        return user.save();
       }).then(() => {
-        // initiate sequence of password resets
-        return Parse.User.requestPasswordReset('user1@parse.com');
+        user.setPassword('user3');
+        return user.save();
+      }).then(() => {
+        user.setPassword('user4');
+        return user.save();
+      }).then(() => {
+        user.setPassword('user5');
+        return user.save();
+      }).then(() => {
+        // set the same password as the initial one
+        user.setPassword('user1');
+        return user.save();
+      }).then(() => {
+        fail("should have failed because the new password is same as the old");
+        done();
       }).catch(error => {
-        jfail(error);
-        fail("SignUp or reset request failed");
+        expect(error.message).toEqual('New password should not be the same as last 5 passwords.');
+        expect(error.code).toEqual(Parse.Error.VALIDATION_ERROR);
         done();
       });
     });
   });
 
+  it('should succeed if the new password is same as the 6th oldest one and policy does not allow only previous 5', done => {
+    const user = new Parse.User();
+
+    reconfigureServer({
+      appName: 'passwordPolicy',
+      verifyUserEmails: false,
+      passwordPolicy: {
+        maxPasswordHistory: 5
+      },
+      publicServerURL: "http://localhost:8378/1"
+    }).then(() => {
+      user.setUsername("user1");
+      user.setPassword("user1");
+      user.set('email', 'user1@parse.com');
+      user.signUp().then(() => {
+        // build history
+        user.setPassword('user2');
+        return user.save();
+      }).then(() => {
+        user.setPassword('user3');
+        return user.save();
+      }).then(() => {
+        user.setPassword('user4');
+        return user.save();
+      }).then(() => {
+        user.setPassword('user5');
+        return user.save();
+      }).then(() => {
+        user.setPassword('user6'); // this pushes initial password out of history
+        return user.save();
+      }).then(() => {
+        // set the same password as the initial one
+        user.setPassword('user1');
+        return user.save();
+      }).then(() => {
+        done();
+      }).catch(() => {
+        fail("should have succeeded because the new password is not in history");
+        done();
+      });
+    });
+  });
 })

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -787,7 +787,7 @@ const mongoObjectToParseObject = (className, mongoObject, schema) => {
       case '_email_verify_token_expires_at':
       case '_account_lockout_expires_at':
       case '_failed_login_count':
-      case '_old_passwords':
+      case '_password_history':
         // Those keys will be deleted if needed in the DB Controller
         restObject[key] = mongoObject[key];
         break;

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -787,6 +787,7 @@ const mongoObjectToParseObject = (className, mongoObject, schema) => {
       case '_email_verify_token_expires_at':
       case '_account_lockout_expires_at':
       case '_failed_login_count':
+      case '_old_passwords':
         // Those keys will be deleted if needed in the DB Controller
         restObject[key] = mongoObject[key];
         break;

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -108,6 +108,7 @@ const toPostgresSchema = (schema) => {
   schema.fields._rperm = {type: 'Array', contents: {type: 'String'}}
   if (schema.className === '_User') {
     schema.fields._hashed_password = {type: 'String'};
+    schema.fields._old_passwords = {type: 'Array'};
   }
   return schema;
 }
@@ -471,6 +472,7 @@ export class PostgresStorageAdapter {
       fields._perishable_token = {type: 'String'};
       fields._perishable_token_expires_at = {type: 'Date'};
       fields._password_changed_at = {type: 'Date'};
+      fields._old_passwords = { type: 'Array'};
     }
     let index = 2;
     let relations = [];
@@ -683,7 +685,8 @@ export class PostgresStorageAdapter {
       if (!schema.fields[fieldName] && className === '_User') {
         if (fieldName === '_email_verify_token' ||
             fieldName === '_failed_login_count' ||
-            fieldName === '_perishable_token') {
+            fieldName === '_perishable_token' ||
+            fieldName === '_old_passwords'){
           valuesArray.push(object[fieldName]);
         }
 

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -108,7 +108,7 @@ const toPostgresSchema = (schema) => {
   schema.fields._rperm = {type: 'Array', contents: {type: 'String'}}
   if (schema.className === '_User') {
     schema.fields._hashed_password = {type: 'String'};
-    schema.fields._old_passwords = {type: 'Array'};
+    schema.fields._password_history = {type: 'Array'};
   }
   return schema;
 }
@@ -472,7 +472,7 @@ export class PostgresStorageAdapter {
       fields._perishable_token = {type: 'String'};
       fields._perishable_token_expires_at = {type: 'Date'};
       fields._password_changed_at = {type: 'Date'};
-      fields._old_passwords = { type: 'Array'};
+      fields._password_history = { type: 'Array'};
     }
     let index = 2;
     let relations = [];
@@ -686,7 +686,7 @@ export class PostgresStorageAdapter {
         if (fieldName === '_email_verify_token' ||
             fieldName === '_failed_login_count' ||
             fieldName === '_perishable_token' ||
-            fieldName === '_old_passwords'){
+            fieldName === '_password_history'){
           valuesArray.push(object[fieldName]);
         }
 

--- a/src/Config.js
+++ b/src/Config.js
@@ -139,8 +139,8 @@ export class Config {
         throw 'passwordPolicy.doNotAllowUsername must be a boolean value.';
       }
 
-      if (passwordPolicy.passwordHistory && (!Number.isInteger(passwordPolicy.passwordHistory) || passwordPolicy.passwordHistory <= 0 || passwordPolicy.passwordHistory > 20)) {
-        throw 'passwordPolicy.passwordHistory must be an integer ranging 0 - 20';
+      if (passwordPolicy.maxPasswordHistory && (!Number.isInteger(passwordPolicy.maxPasswordHistory) || passwordPolicy.maxPasswordHistory <= 0 || passwordPolicy.maxPasswordHistory > 20)) {
+        throw 'passwordPolicy.maxPasswordHistory must be an integer ranging 0 - 20';
       }
     }
   }

--- a/src/Config.js
+++ b/src/Config.js
@@ -138,6 +138,10 @@ export class Config {
       if(passwordPolicy.doNotAllowUsername && typeof passwordPolicy.doNotAllowUsername !== 'boolean') {
         throw 'passwordPolicy.doNotAllowUsername must be a boolean value.';
       }
+
+      if (passwordPolicy.passwordHistory && (!Number.isInteger(passwordPolicy.passwordHistory) || passwordPolicy.passwordHistory <= 0 || passwordPolicy.passwordHistory > 20)) {
+        throw 'passwordPolicy.passwordHistory must be an integer ranging 0 - 20';
+      }
     }
   }
 

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -190,7 +190,7 @@ const filterSensitiveData = (isMaster, aclGroup, className, object) => {
 //   acl:  a list of strings. If the object to be updated has an ACL,
 //         one of the provided strings must provide the caller with
 //         write permissions.
-const specialKeysForUpdate = ['_hashed_password', '_perishable_token', '_email_verify_token', '_email_verify_token_expires_at', '_account_lockout_expires_at', '_failed_login_count', '_perishable_token_expires_at', '_password_changed_at', '_old_passwords'];
+const specialKeysForUpdate = ['_hashed_password', '_perishable_token', '_email_verify_token', '_email_verify_token_expires_at', '_account_lockout_expires_at', '_failed_login_count', '_perishable_token_expires_at', '_password_changed_at', '_password_history'];
 
 const isSpecialUpdateKey = key => {
   return specialKeysForUpdate.indexOf(key) >= 0;

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -190,7 +190,7 @@ const filterSensitiveData = (isMaster, aclGroup, className, object) => {
 //   acl:  a list of strings. If the object to be updated has an ACL,
 //         one of the provided strings must provide the caller with
 //         write permissions.
-const specialKeysForUpdate = ['_hashed_password', '_perishable_token', '_email_verify_token', '_email_verify_token_expires_at', '_account_lockout_expires_at', '_failed_login_count', '_perishable_token_expires_at', '_password_changed_at'];
+const specialKeysForUpdate = ['_hashed_password', '_perishable_token', '_email_verify_token', '_email_verify_token_expires_at', '_account_lockout_expires_at', '_failed_login_count', '_perishable_token_expires_at', '_password_changed_at', '_old_passwords'];
 
 const isSpecialUpdateKey = key => {
   return specialKeysForUpdate.indexOf(key) >= 0;

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -903,9 +903,7 @@ RestWrite.prototype.runDatabaseOperation = function() {
     let defer = Promise.resolve();
     // if password history is enabled then save the current password to history
     if (this.className === '_User' && this.data._hashed_password && this.config.passwordPolicy && this.config.passwordPolicy.passwordHistory) {
-      defer = this.config.database.find('_User', {objectId: this.objectId()},
-        {keys: ["_old_passwords", "_hashed_password"]}).then(results => {
-
+      defer = this.config.database.find('_User', {objectId: this.objectId()}, {keys: ["_old_passwords", "_hashed_password"]}).then(results => {
         if (results.length != 1) {
           throw undefined;
         }


### PR DESCRIPTION
### passwordPolicy.passwordHistory
Optional setting to specify the number of passwords to retain in history and prevent reusing the same during password reset. The maximum value is 20.

a new Array field **_old_passwords** is added to _User object to store the old passwords (hash values) whenever password is changed. 