### PR TITLE
Ignores createdAt when update

### DIFF
--- a/spec/rest.spec.js
+++ b/spec/rest.spec.js
@@ -420,3 +420,34 @@ describe('rest create', () => {
       })
   });
 });
+
+describe('rest update', () => {
+
+  it('ignores createdAt', done => {
+    const nobody = auth.nobody(config);
+    const className = 'Foo';
+    const newCreatedAt = new Date('1970-01-01T00:00:00.000Z');
+
+    rest.create(config, nobody, className, {}).then(res => {
+      const objectId = res.response.objectId;
+      const restObject = {
+        createdAt: {__type: "Date", iso: newCreatedAt}, // should be ignored
+      };
+
+      return rest.update(config, nobody, className, objectId, restObject).then(() => {
+        const restWhere = {
+          objectId: objectId,
+        };
+        return rest.find(config, nobody, className, restWhere, {});
+      });
+    }).then(res2 => {
+      const updatedObject = res2.results[0];
+      expect(new Date(updatedObject.createdAt)).not.toEqual(newCreatedAt);
+      done();
+    }).then(done).catch(err => {
+      fail(err);
+      done();
+    });
+  });
+
+});

--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -842,6 +842,9 @@ RestWrite.prototype.runDatabaseOperation = function() {
     if (this.className === '_User' && this.data._hashed_password && this.config.passwordPolicy && this.config.passwordPolicy.maxPasswordAge) {
       this.data._password_changed_at = Parse._encode(new Date());
     }
+    // Ignore createdAt when update
+    delete this.data.createdAt;
+
     // Run an update
     return this.config.database.update(this.className, this.query, this.data, this.runOptions)
     .then(response => {


### PR DESCRIPTION
This PR fixes a compatibility issue for updating `createdAt`.

When `PUT /1/classes/<className>/<objectId>` is requested with body `{"createdAt":{"__type":"Date","iso":"1970-01-01T00:00:00.000Z"}}`, `api.parse.com` ignores and doesn't change `createdAt`.
However parse-server really updates `createdAt`.

That behavior of parse-server is confusing and should be fixed.