### PR TITLE
Add a push configuration supports both the adapter and its configuration

### DIFF
--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -168,10 +168,10 @@ class ParseServer {
     const filesController = new FilesController(filesControllerAdapter, appId);
 
     // Pass the push options too as it works with the default
-    const pushControllerAdapter = loadAdapter(push && push.adapter, ParsePushAdapter, push || {});
+    const pushControllerAdapter = loadAdapter(push && push.adapter, ParsePushAdapter, push.pushConfig || {});
     // We pass the options and the base class for the adatper,
     // Note that passing an instance would work too
-    const pushController = new PushController(pushControllerAdapter, appId, push);
+    const pushController = new PushController(pushControllerAdapter, appId, push.pushConfig);
 
     const emailControllerAdapter = loadAdapter(emailAdapter);
     const userController = new UserController(emailControllerAdapter, appId, { verifyUserEmails });

--- a/src/authDataManager/index.js
+++ b/src/authDataManager/index.js
@@ -10,6 +10,9 @@ let digits = require("./twitter"); // digits tokens are validated by twitter
 let janrainengage = require("./janrainengage");
 let janraincapture = require("./janraincapture");
 let vkontakte = require("./vkontakte");
+let qq = require("./qq");
+let wechat = require("./wechat");
+let weibo = require("./weibo");
 
 let anonymous = {
   validateAuthData: () => {
@@ -33,7 +36,10 @@ let providers = {
   digits,
   janrainengage,
   janraincapture,
-  vkontakte
+  vkontakte,
+  qq:qq,
+  wechat:wechat,
+  weibo:weibo
 }
 
 module.exports = function(oauthOptions = {}, enableAnonymousUsers = true) {

--- a/src/authDataManager/index.js
+++ b/src/authDataManager/index.js
@@ -37,9 +37,9 @@ let providers = {
   janrainengage,
   janraincapture,
   vkontakte,
-  qq:qq,
-  wechat:wechat,
-  weibo:weibo
+  qq,
+  wechat,
+  weibo
 }
 
 module.exports = function(oauthOptions = {}, enableAnonymousUsers = true) {

--- a/src/authDataManager/qq.js
+++ b/src/authDataManager/qq.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var https = require('https');
+var Parse = require('parse/node').Parse;
+
+function validateAuthData(authData) {
+  return graphRequest('me?access_token=' + authData.access_token).then(function (data) {
+    if (data && data.openid == authData.id) {
+      return;
+    }
+    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'qq auth is invalid for this user.');
+  });
+}
+
+function validateAppId(appIds, authData) {
+  return Promise.resolve();
+}
+
+function graphRequest(path) {
+  return new Promise(function (resolve, reject) {
+
+
+    https.get('https://graph.qq.com/oauth2.0/' + path, function (res) {
+      var data = '';
+      res.on('data', function (chunk) {
+        data += chunk;
+      });
+      res.on('end', function () {
+        var starPos=data.indexOf("(");
+        var endPos=data.indexOf(")");
+        if(starPos==-1||endPos==-1){
+          throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'qq auth is invalid for this user.');
+        }
+        data=data.substring(starPos+1,endPos-1);
+        data = JSON.parse(data);
+        resolve(data);
+      });
+    }).on('error', function (e) {
+      reject('Failed to validate this access token with qq.');
+    });
+
+
+  });
+}
+
+module.exports = {
+  validateAppId: validateAppId,
+  validateAuthData: validateAuthData
+};

--- a/src/authDataManager/qq.js
+++ b/src/authDataManager/qq.js
@@ -1,8 +1,8 @@
-'use strict';
-
+// Helper functions for accessing the qq Graph API.
 var https = require('https');
 var Parse = require('parse/node').Parse;
 
+// Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData) {
   return graphRequest('me?access_token=' + authData.access_token).then(function (data) {
     if (data && data.openid == authData.id) {
@@ -12,14 +12,14 @@ function validateAuthData(authData) {
   });
 }
 
+// Returns a promise that fulfills if this app id is valid.
 function validateAppId(appIds, authData) {
   return Promise.resolve();
 }
 
+// A promisey wrapper for qq graph requests.
 function graphRequest(path) {
   return new Promise(function (resolve, reject) {
-
-
     https.get('https://graph.qq.com/oauth2.0/' + path, function (res) {
       var data = '';
       res.on('data', function (chunk) {
@@ -38,12 +38,10 @@ function graphRequest(path) {
     }).on('error', function (e) {
       reject('Failed to validate this access token with qq.');
     });
-
-
   });
 }
 
 module.exports = {
-  validateAppId: validateAppId,
-  validateAuthData: validateAuthData
+  validateAppId,
+  validateAuthData
 };

--- a/src/authDataManager/wechat.js
+++ b/src/authDataManager/wechat.js
@@ -1,0 +1,43 @@
+'use strict';
+
+var https = require('https');
+var Parse = require('parse/node').Parse;
+
+function validateAuthData(authData) {
+  return graphRequest('auth?access_token=' + authData.access_token +'&openid=' +authData.id).then(function (data) {
+    if (data.errcode == 0) {
+      return;
+    }
+    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'qq auth is invalid for this user.');
+  });
+}
+
+function validateAppId(appIds, authData) {
+  return Promise.resolve();
+}
+
+function graphRequest(path) {
+  return new Promise(function (resolve, reject) {
+
+
+    https.get('https://api.weixin.qq.com/sns/' + path, function (res) {
+      var data = '';
+      res.on('data', function (chunk) {
+        data += chunk;
+      });
+      res.on('end', function () {
+        data = JSON.parse(data);
+        resolve(data);
+      });
+    }).on('error', function (e) {
+      reject('Failed to validate this access token with weixin.');
+    });
+
+
+  });
+}
+
+module.exports = {
+  validateAppId: validateAppId,
+  validateAuthData: validateAuthData
+};

--- a/src/authDataManager/wechat.js
+++ b/src/authDataManager/wechat.js
@@ -1,8 +1,8 @@
-'use strict';
-
+// Helper functions for accessing the WeChat Graph API.
 var https = require('https');
 var Parse = require('parse/node').Parse;
 
+// Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData) {
   return graphRequest('auth?access_token=' + authData.access_token +'&openid=' +authData.id).then(function (data) {
     if (data.errcode == 0) {
@@ -12,14 +12,14 @@ function validateAuthData(authData) {
   });
 }
 
+// Returns a promise that fulfills if this app id is valid.
 function validateAppId(appIds, authData) {
   return Promise.resolve();
 }
 
+// A promisey wrapper for WeChat graph requests.
 function graphRequest(path) {
   return new Promise(function (resolve, reject) {
-
-
     https.get('https://api.weixin.qq.com/sns/' + path, function (res) {
       var data = '';
       res.on('data', function (chunk) {
@@ -32,12 +32,10 @@ function graphRequest(path) {
     }).on('error', function (e) {
       reject('Failed to validate this access token with weixin.');
     });
-
-
   });
 }
 
 module.exports = {
-  validateAppId: validateAppId,
-  validateAuthData: validateAuthData
+  validateAppId,
+  validateAuthData
 };

--- a/src/authDataManager/weibo.js
+++ b/src/authDataManager/weibo.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var https = require('https');
+var Parse = require('parse/node').Parse;
+var querystring=require('querystring');
+
+function validateAuthData(authData) {
+  return graphRequest(authData.access_token).then(function (data) {
+    if (data && data.uid == authData.id) {
+      return;
+    }
+    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'weibo auth is invalid for this user.');
+  });
+}
+
+function validateAppId(appIds, authData) {
+  return Promise.resolve();
+}
+
+function graphRequest(access_token) {
+  return new Promise(function (resolve, reject) {
+    var postData=querystring.stringify({
+      "access_token":access_token
+    });
+
+    var options = {
+      hostname: 'api.weibo.com',
+      path: '/oauth2/get_token_info',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': Buffer.byteLength(postData)
+      }
+    };
+
+    var req = https.request(options, function(res){
+      var data = '';
+      res.on('data', function (chunk) {
+        data += chunk;
+       });
+      res.on('end', function () {
+        data = JSON.parse(data);
+        resolve(data);
+      });
+      res.on('error', function (err) {
+        reject('Failed to validate this access token with weibo.');
+      });
+
+  });
+
+    req.on('error', function (e){
+      reject('Failed to validate this access token with weibo.');
+  });
+    req.write(postData);
+    req.end();
+
+  });
+}
+
+module.exports = {
+  validateAppId: validateAppId,
+  validateAuthData: validateAuthData
+};

--- a/src/authDataManager/weibo.js
+++ b/src/authDataManager/weibo.js
@@ -1,9 +1,9 @@
-'use strict';
-
+// Helper functions for accessing the weibo Graph API.
 var https = require('https');
 var Parse = require('parse/node').Parse;
-var querystring=require('querystring');
+var querystring = require('querystring');
 
+// Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData) {
   return graphRequest(authData.access_token).then(function (data) {
     if (data && data.uid == authData.id) {
@@ -13,16 +13,17 @@ function validateAuthData(authData) {
   });
 }
 
+// Returns a promise that fulfills if this app id is valid.
 function validateAppId(appIds, authData) {
   return Promise.resolve();
 }
 
+// A promisey wrapper for weibo graph requests.
 function graphRequest(access_token) {
   return new Promise(function (resolve, reject) {
-    var postData=querystring.stringify({
+    var postData = querystring.stringify({
       "access_token":access_token
     });
-
     var options = {
       hostname: 'api.weibo.com',
       path: '/oauth2/get_token_info',
@@ -32,12 +33,11 @@ function graphRequest(access_token) {
         'Content-Length': Buffer.byteLength(postData)
       }
     };
-
     var req = https.request(options, function(res){
       var data = '';
       res.on('data', function (chunk) {
         data += chunk;
-       });
+      });
       res.on('end', function () {
         data = JSON.parse(data);
         resolve(data);
@@ -45,19 +45,16 @@ function graphRequest(access_token) {
       res.on('error', function (err) {
         reject('Failed to validate this access token with weibo.');
       });
-
-  });
-
+    });
     req.on('error', function (e){
       reject('Failed to validate this access token with weibo.');
-  });
+    });
     req.write(postData);
     req.end();
-
   });
 }
 
 module.exports = {
-  validateAppId: validateAppId,
-  validateAuthData: validateAuthData
+  validateAppId,
+  validateAuthData
 };


### PR DESCRIPTION
Add a push configuration supports both the adapter and its configuration,When initializing Parse Server, you should pass an push configuration like this:
push: {
        pushConfig:{
		      android: {
		        senderId: '...',
		        apiKey: '...'
		      },
		      ios: {
		        pfx: '/file/path/to/XXX.p12',
		        passphrase: '', // optional password to your p12/PFX
		        bundleId: '',
		        production: false
		      }
        }
        ,adapter:xxPushAdapter
      }
