### PR TITLE
Add a push configuration supports both the adapter and its configuration

### DIFF
--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -165,10 +165,10 @@ class ParseServer {
     const filesController = new FilesController(filesControllerAdapter, appId);
 
     // Pass the push options too as it works with the default
-    const pushControllerAdapter = loadAdapter(push && push.adapter, ParsePushAdapter, push || {});
+    const pushControllerAdapter = loadAdapter(push && push.adapter, ParsePushAdapter, push.pushConfig || {});
     // We pass the options and the base class for the adatper,
     // Note that passing an instance would work too
-    const pushController = new PushController(pushControllerAdapter, appId, push);
+    const pushController = new PushController(pushControllerAdapter, appId, push.pushConfig);
 
     const emailControllerAdapter = loadAdapter(emailAdapter);
     const userController = new UserController(emailControllerAdapter, appId, { verifyUserEmails });


### PR DESCRIPTION
I realized the mi pushadapter and add a push configuration supports both the adapter and its configuration,When initializing Parse Server, you should pass an push configuration like this:
push: {
        pushConfig:{
		      android: {
		        senderId: '...',
		        apiKey: '...'
		      },
		      ios: {
		        pfx: '/file/path/to/XXX.p12',
		        passphrase: '', // optional password to your p12/PFX
		        bundleId: '',
		        production: false
		      }
        }
        ,adapter:xxPushAdapter
      }