### PR TITLE
Fix routing paths on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,9 +70,9 @@
     "lint": "eslint ./",
     "build": "babel src/ -d lib/",
     "test": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 NODE_ENV=test TESTING=1 $COVERAGE_OPTION jasmine",
-    "test:win": "npm run pretest && cross-env NODE_ENV=test TESTING=1 node ./node_modules/jasmine/bin/jasmine.js && npm run posttest",
+    "test:win": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 NODE_ENV=test TESTING=1 jasmine",
     "coverage": "cross-env COVERAGE_OPTION='./node_modules/.bin/istanbul cover' npm test",
-    "coverage:win": "npm run pretest && cross-env NODE_ENV=test TESTING=1 node ./node_modules/babel-istanbul/lib/cli.js cover ./node_modules/jasmine/bin/jasmine.js && npm run posttest",
+    "coverage:win": "cross-env MONGODB_VERSION=${MONGODB_VERSION:=3.2.6} MONGODB_STORAGE_ENGINE=mmapv1 NODE_ENV=test TESTING=1 node ./node_modules/istanbul/lib/cli.js cover ./node_modules/jasmine/bin/jasmine.js",
     "start": "node ./bin/parse-server",
     "prepublish": "npm run build"
   },

--- a/src/batch.js
+++ b/src/batch.js
@@ -32,7 +32,7 @@ function makeBatchRoutingPathFunction(originalUrl, serverURL, publicServerURL) {
           Parse.Error.INVALID_JSON,
           'cannot route batch path ' + requestPath);
     }
-    return path.join('/', requestPath.slice(apiPrefix.length));
+    return path.posix.join('/', requestPath.slice(apiPrefix.length));
   }
 
   if (serverURL && publicServerURL 
@@ -44,7 +44,7 @@ function makeBatchRoutingPathFunction(originalUrl, serverURL, publicServerURL) {
     return function(requestPath) {
         // Build the new path by removing the public path
         // and joining with the local path
-      let newPath = path.join('/', localPath, '/' , requestPath.slice(publicPath.length));
+      let newPath = path.posix.join('/', localPath, '/' , requestPath.slice(publicPath.length));
         // Use the method for local routing
       return makeRoutablePath(newPath);
     }


### PR DESCRIPTION
Ensures batch routing paths use posix separator `/` on Windows
Updated test:win and coverage:win to work again although mongodb-runner is not working on Windows