### PR TITLE
Cloud Code: Allows user session creation with DIRECT_ACCESS

### DIFF
--- a/spec/ParseServerRESTController.spec.js
+++ b/spec/ParseServerRESTController.spec.js
@@ -104,11 +104,27 @@ describe('ParseServerRESTController', () => {
   });
 
   it('ensures no session token is created on creating users', (done) => {
-    RESTController.request("POST", "/classes/_User", {username: "hello", password: "world"}).then(() => {
+    RESTController.request("POST", "/classes/_User", {username: "hello", password: "world"}).then((user) => {
+      expect(user.sessionToken).toBeUndefined();
       let query = new Parse.Query('_Session');
       return query.find({useMasterKey: true});
     }).then(sessions => {
       expect(sessions.length).toBe(0);
+      done();
+    }, (err) => {
+      jfail(err);
+      done();
+    });
+  });
+
+  it('ensures a session token is created when passing installationId != cloud', (done) => {
+    RESTController.request("POST", "/classes/_User", {username: "hello", password: "world"}, {installationId: 'my-installation'}).then((user) => {
+      expect(user.sessionToken).not.toBeUndefined();
+      let query = new Parse.Query('_Session');
+      return query.find({useMasterKey: true});
+    }).then(sessions => {
+      expect(sessions.length).toBe(1);
+      expect(sessions[0].get('installationId')).toBe('my-installation');
       done();
     }, (err) => {
       jfail(err);

--- a/src/ParseServerRESTController.js
+++ b/src/ParseServerRESTController.js
@@ -11,9 +11,10 @@ function getSessionToken(options) {
   return Parse.Promise.as(null);
 }
 
-function getAuth(options, config) {
+function getAuth(options = {}, config) {
+  const installationId = options.installationId || 'cloud';
   if (options.useMasterKey) {
-    return Parse.Promise.as(new Auth.Auth({config, isMaster: true, installationId: 'cloud' }));
+    return Parse.Promise.as(new Auth.Auth({config, isMaster: true, installationId }));
   }
   return getSessionToken(options).then((sessionToken) => {
     if (sessionToken) {
@@ -21,10 +22,10 @@ function getAuth(options, config) {
       return Auth.getAuthForSessionToken({
         config,
         sessionToken: sessionToken,
-        installationId: 'cloud'
+        installationId
       });
     } else {
-      return Parse.Promise.as(new Auth.Auth({ config, installationId: 'cloud' }));
+      return Parse.Promise.as(new Auth.Auth({ config, installationId }));
     }
   })
 }


### PR DESCRIPTION
In an effort to remove the overhead of running cloud code with the HTTP interface, it's required to use the provided optional `installationId`.

For ex:

```
let user = new Parse.User();
user.save({username: "hello", password: "world"}).then((user) => {
     // the user has no Session
});
```

```
Parse.Cloud.define("signupUser", function(req, res) {
  let installationId = req.installationId; // installation Id passed by the client
  let user = new Parse.User();
  user.save({username: req.username, password: req.pass}, { installationId }).then((user) => {
    // the session token will be valid for that user!
    res.success(user.getSessionToken());
  });
});
```
