### PR TITLE
More lint tweaking

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
         "indent": ["error", 2],
         "linebreak-style": ["error", "unix"],
         "no-trailing-spaces": 2,
-        "eol-last": 2
+        "eol-last": 2,
+        "space-in-parens": ["error", "never"]
     }
 }

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -1,8 +1,5 @@
 {
-    "extends": "eslint:recommended",
     "env": {
-        "node": true,
-        "es6": true,
         "jasmine": true
     },
     "globals": {
@@ -29,9 +26,6 @@
       "arrayContains": true
     },
     "rules": {
-      "no-console": [0],
-      "indent": ["error", 2],
-      "no-trailing-spaces": 2,
-      "eol-last": 2
+      "no-console": [0]
     }
 }

--- a/spec/EmailVerificationToken.spec.js
+++ b/spec/EmailVerificationToken.spec.js
@@ -460,7 +460,7 @@ describe("Email Verification Token Expiration: ", () => {
       user.set('email', 'user@parse.com');
       return new Promise((resolve) => {
         // wait for half a sec to get a new expiration time
-        setTimeout( () => resolve(user.save()), 500 );
+        setTimeout(() => resolve(user.save()), 500);
       });
     })
     .then(() => {

--- a/spec/ParseAPI.spec.js
+++ b/spec/ParseAPI.spec.js
@@ -816,7 +816,7 @@ describe('miscellaneous', function() {
 
   it('should return the updated fields on PUT', done => {
     let obj = new Parse.Object('GameScore');
-    obj.save({a:'hello', c: 1, d: ['1'], e:['1'], f:['1','2']}).then(( ) => {
+    obj.save({a:'hello', c: 1, d: ['1'], e:['1'], f:['1','2']}).then(() => {
       var headers = {
         'Content-Type': 'application/json',
         'X-Parse-Application-Id': 'test',

--- a/spec/ParseHooks.spec.js
+++ b/spec/ParseHooks.spec.js
@@ -26,7 +26,7 @@ describe('Hooks', () => {
   });
 
   it("should have no triggers registered", (done) => {
-    Parse.Hooks.getTriggers().then( (res) => {
+    Parse.Hooks.getTriggers().then((res) => {
       expect(res.constructor).toBe(Array.prototype.constructor);
       done();
     }, (err) => {
@@ -143,11 +143,11 @@ describe('Hooks', () => {
   });
 
   it("should fail trying to create two times the same function", (done) => {
-    Parse.Hooks.createFunction("my_new_function", "http://url.com").then( () => {
+    Parse.Hooks.createFunction("my_new_function", "http://url.com").then(() => {
       return  Parse.Hooks.createFunction("my_new_function", "http://url.com")
     }, () => {
       fail("should create a new function");
-    }).then( () => {
+    }).then(() => {
       fail("should not be able to create the same function");
     }, (err) => {
       expect(err).not.toBe(undefined);
@@ -166,11 +166,11 @@ describe('Hooks', () => {
   });
 
   it("should fail trying to create two times the same trigger", (done) => {
-    Parse.Hooks.createTrigger("MyClass", "beforeSave", "http://url.com").then( () => {
+    Parse.Hooks.createTrigger("MyClass", "beforeSave", "http://url.com").then(() => {
       return  Parse.Hooks.createTrigger("MyClass", "beforeSave", "http://url.com")
     }, () => {
       fail("should create a new trigger");
-    }).then( () => {
+    }).then(() => {
       fail("should not be able to create the same trigger");
     }, (err) => {
       expect(err).not.toBe(undefined);
@@ -189,7 +189,7 @@ describe('Hooks', () => {
   });
 
   it("should fail trying to update a function that don't exist", (done) => {
-    Parse.Hooks.updateFunction("A_COOL_FUNCTION", "http://url.com").then( () => {
+    Parse.Hooks.updateFunction("A_COOL_FUNCTION", "http://url.com").then(() => {
       fail("Should not succeed")
     }, (err) => {
       expect(err).not.toBe(undefined);
@@ -214,7 +214,7 @@ describe('Hooks', () => {
   });
 
   it("should fail trying to update a trigger that don't exist", (done) => {
-    Parse.Hooks.updateTrigger("AClassName","beforeSave",  "http://url.com").then( () => {
+    Parse.Hooks.updateTrigger("AClassName","beforeSave",  "http://url.com").then(() => {
       fail("Should not succeed")
     }, (err) => {
       expect(err).not.toBe(undefined);
@@ -240,7 +240,7 @@ describe('Hooks', () => {
 
 
   it("should fail trying to create a malformed function", (done) => {
-    Parse.Hooks.createFunction("MyFunction").then( (res) => {
+    Parse.Hooks.createFunction("MyFunction").then((res) => {
       fail(res);
     }, (err) => {
       expect(err).not.toBe(undefined);

--- a/spec/ParseObject.spec.js
+++ b/spec/ParseObject.spec.js
@@ -1842,10 +1842,10 @@ describe('Parse.Object testing', () => {
         "_nested": "key"
       }
     });
-    object.save().then( res => {
+    object.save().then(res => {
       ok(res);
       return res.fetch();
-    }).then( res => {
+    }).then(res => {
       const foo = res.get("foo");
       expect(foo["_bar"]).toEqual("_");
       expect(foo["baz_bar"]).toEqual(1);
@@ -1853,7 +1853,7 @@ describe('Parse.Object testing', () => {
       expect(foo["_0"]).toEqual("underscore_zero");
       expect(foo["_more"]["_nested"]).toEqual("key");
       done();
-    }).fail( err => {
+    }).fail(err => {
       jfail(err);
       fail("should not fail");
       done();

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -816,7 +816,7 @@ describe('Parse.Query testing', () => {
     var makeBoxedNumber = function(i) {
       return new BoxedNumber({ number: i });
     };
-    Parse.Object.saveAll([3, 1, 2].map(makeBoxedNumber)).then( function() {
+    Parse.Object.saveAll([3, 1, 2].map(makeBoxedNumber)).then(function() {
       var query = new Parse.Query(BoxedNumber);
       query.descending("number");
       query.find(expectSuccess({
@@ -2435,7 +2435,7 @@ describe('Parse.Query testing', () => {
     var user = new Parse.User();
     user.set("username", "foo");
     user.set("password", "bar");
-    return user.save().then( (user) => {
+    return user.save().then((user) => {
       var objIdQuery = new Parse.Query("_User").equalTo("objectId", user.id);
       var blockedUserQuery = user.relation("blockedUsers").query();
 

--- a/spec/ParseRole.spec.js
+++ b/spec/ParseRole.spec.js
@@ -98,10 +98,10 @@ describe('Parse Role testing', () => {
     var user,
       auth,
       getAllRolesSpy;
-    createTestUser().then( (newUser) => {
+    createTestUser().then((newUser) => {
       user = newUser;
       return createAllRoles(user);
-    }).then ( (roles) => {
+    }).then ((roles) => {
       var rootRoleObj = roleObjs[rootRole];
       roles.forEach(function(role, i) {
         // Add all roles to the RootRole
@@ -115,12 +115,12 @@ describe('Parse Role testing', () => {
       });
 
       return Parse.Object.saveAll(roles, { useMasterKey: true });
-    }).then( () => {
+    }).then(() => {
       auth = new Auth({config: new Config("test"), isMaster: true, user: user});
       getAllRolesSpy = spyOn(auth, "_getAllRolesNamesForRoleIds").and.callThrough();
 
       return auth._loadRoles();
-    }).then ( (roles) => {
+    }).then ((roles) => {
       expect(roles.length).toEqual(4);
 
       allRoles.forEach(function(name) {
@@ -135,7 +135,7 @@ describe('Parse Role testing', () => {
       // 1 call for the 2nd layer
       expect(getAllRolesSpy.calls.count()).toEqual(2);
       done()
-    }).catch( () =>  {
+    }).catch(() =>  {
       fail("should succeed");
       done();
     });
@@ -145,26 +145,26 @@ describe('Parse Role testing', () => {
   it("should recursively load roles", (done) => {
     var rolesNames = ["FooRole", "BarRole", "BazRole"];
     var roleIds = {};
-    createTestUser().then( (user) => {
+    createTestUser().then((user) => {
        // Put the user on the 1st role
-      return createRole(rolesNames[0], null, user).then( (aRole) => {
+      return createRole(rolesNames[0], null, user).then((aRole) => {
         roleIds[aRole.get("name")] = aRole.id;
          // set the 1st role as a sibling of the second
          // user will should have 2 role now
         return createRole(rolesNames[1], aRole, null);
-      }).then( (anotherRole) => {
+      }).then((anotherRole) => {
         roleIds[anotherRole.get("name")] = anotherRole.id;
          // set this role as a sibling of the last
          // the user should now have 3 roles
         return createRole(rolesNames[2], anotherRole, null);
-      }).then( (lastRole) => {
+      }).then((lastRole) => {
         roleIds[lastRole.get("name")] = lastRole.id;
         var auth = new Auth({ config: new Config("test"), isMaster: true, user: user });
         return auth._loadRoles();
       })
-    }).then( (roles) => {
+    }).then((roles) => {
       expect(roles.length).toEqual(3);
-      rolesNames.forEach( (name) => {
+      rolesNames.forEach((name) => {
         expect(roles.indexOf('role:'+name)).not.toBe(-1);
       });
       done();

--- a/spec/PurchaseValidation.spec.js
+++ b/spec/PurchaseValidation.spec.js
@@ -20,7 +20,7 @@ function createProduct() {
 }
 
 describe("test validate_receipt endpoint", () => {
-  beforeEach( done => {
+  beforeEach(done => {
     createProduct().then(done).fail(function(){
       done();
     });

--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -1283,13 +1283,13 @@ describe('schemas', () => {
       })
     }).then(() => {
       return Parse.User.logIn('admin', 'admin');
-    }).then( () => {
+    }).then(() => {
       let query = new Parse.Query('AClass');
       return query.find();
     }).then((results) => {
       expect(results.length).toBe(1);
       done();
-    }).catch( (err) => {
+    }).catch((err) => {
       jfail(err);
       done();
     })
@@ -1346,13 +1346,13 @@ describe('schemas', () => {
       });
     }).then(() => {
       return Parse.User.logIn('admin', 'admin');
-    }).then( () => {
+    }).then(() => {
       let query = new Parse.Query('AClass');
       return query.find();
     }).then((results) => {
       expect(results.length).toBe(1);
       done();
-    }).catch( (err) => {
+    }).catch((err) => {
       jfail(err);
       done();
     })
@@ -1404,7 +1404,7 @@ describe('schemas', () => {
       });
     }).then(() => {
       return Parse.User.logIn('admin', 'admin');
-    }).then( () => {
+    }).then(() => {
       let query = new Parse.Query('AClass');
       return query.find();
     }).then((results) => {
@@ -1470,13 +1470,13 @@ describe('schemas', () => {
       });
     }).then(() => {
       return Parse.User.logIn('admin', 'admin');
-    }).then( () => {
+    }).then(() => {
       let query = new Parse.Query('AClass');
       return query.find();
     }).then((results) => {
       expect(results.length).toBe(1);
       done();
-    }).catch( (err) => {
+    }).catch((err) => {
       jfail(err);
       done();
     })
@@ -1523,7 +1523,7 @@ describe('schemas', () => {
       })
     }).then(() => {
       return Parse.User.logIn('admin', 'admin');
-    }).then( () => {
+    }).then(() => {
       let query = new Parse.Query('AClass');
       return query.find();
     }).then(() => {
@@ -1534,7 +1534,7 @@ describe('schemas', () => {
       return Promise.resolve();
     }).then(() => {
       return Parse.User.logIn('user2', 'user2');
-    }).then( () => {
+    }).then(() => {
       let query = new Parse.Query('AClass');
       return query.find();
     }).then(() => {

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -258,7 +258,7 @@ const buildWhereClause = ({ schema, query, index }) => {
       let allowNull = false;
       values.push(fieldName);
       fieldValue.$in.forEach((listElem, listIndex) => {
-        if (listElem === null ) {
+        if (listElem === null) {
           allowNull = true;
         } else {
           values.push(listElem);

--- a/src/Config.js
+++ b/src/Config.js
@@ -131,7 +131,7 @@ export class Config {
         throw 'passwordPolicy.validatorPattern must be a RegExp.';
       }
 
-      if(passwordPolicy.validatorCallback && typeof passwordPolicy.validatorCallback !== 'function' ) {
+      if(passwordPolicy.validatorCallback && typeof passwordPolicy.validatorCallback !== 'function') {
         throw 'passwordPolicy.validatorCallback must be a function.';
       }
 

--- a/src/Controllers/AdaptableController.js
+++ b/src/Controllers/AdaptableController.js
@@ -49,7 +49,7 @@ export class AdaptableController {
     }
 
     // Makes sure the prototype matches
-    let mismatches = Object.getOwnPropertyNames(Type.prototype).reduce( (obj, key) => {
+    let mismatches = Object.getOwnPropertyNames(Type.prototype).reduce((obj, key) => {
       const adapterType = typeof adapter[key];
       const expectedType = typeof Type.prototype[key];
       if (adapterType !== expectedType) {

--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -305,7 +305,7 @@ class ParseServer {
     //This causes tests to spew some useless warnings, so disable in test
     if (!process.env.TESTING) {
       process.on('uncaughtException', (err) => {
-        if ( err.code === "EADDRINUSE" ) { // user-friendly message for this common error
+        if (err.code === "EADDRINUSE") { // user-friendly message for this common error
           /* eslint-disable no-console */
           console.error(`Unable to listen on port ${err.port}. The port is already in use.`);
           /* eslint-enable no-console */

--- a/src/Routers/HooksRouter.js
+++ b/src/Routers/HooksRouter.js
@@ -4,7 +4,7 @@ import * as middleware from "../middlewares";
 
 export class HooksRouter extends PromiseRouter {
   createHook(aHook, config) {
-    return config.hooksController.createHook(aHook).then( (hook) => ({response: hook}));
+    return config.hooksController.createHook(aHook).then((hook) => ({response: hook}));
   }
 
   updateHook(aHook, config) {
@@ -18,7 +18,7 @@ export class HooksRouter extends PromiseRouter {
   handleGetFunctions(req) {
     var hooksController = req.config.hooksController;
     if (req.params.functionName) {
-      return hooksController.getFunction(req.params.functionName).then( (foundFunction) => {
+      return hooksController.getFunction(req.params.functionName).then((foundFunction) => {
         if (!foundFunction) {
           throw new Parse.Error(143, `no function named: ${req.params.functionName} is defined`);
         }

--- a/src/Routers/IAPValidationRouter.js
+++ b/src/Routers/IAPValidationRouter.js
@@ -88,13 +88,13 @@ export class IAPValidationRouter extends PromiseRouter {
       return Promise.resolve({response: appStoreError(error.status) });
     }
 
-    return validateWithAppStore(IAP_PRODUCTION_URL, receipt).then( () => {
+    return validateWithAppStore(IAP_PRODUCTION_URL, receipt).then(() => {
 
       return successCallback();
 
     }, (error) => {
       if (error.status == 21007) {
-        return validateWithAppStore(IAP_SANDBOX_URL, receipt).then( () => {
+        return validateWithAppStore(IAP_SANDBOX_URL, receipt).then(() => {
           return successCallback();
         }, (error) => {
           return errorCallback(error);

--- a/src/Routers/PublicAPIRouter.js
+++ b/src/Routers/PublicAPIRouter.js
@@ -24,7 +24,7 @@ export class PublicAPIRouter extends PromiseRouter {
     }
 
     let userController = config.userController;
-    return userController.verifyEmail(username, token).then( () => {
+    return userController.verifyEmail(username, token).then(() => {
       let params = qs.stringify({username});
       return Promise.resolve({
         status: 302,
@@ -71,7 +71,7 @@ export class PublicAPIRouter extends PromiseRouter {
       return this.invalidLink(req);
     }
 
-    return config.userController.checkResetTokenValidity(username, token).then( () => {
+    return config.userController.checkResetTokenValidity(username, token).then(() => {
       let params = qs.stringify({token, id: config.applicationId, username, app: config.appName, });
       return Promise.resolve({
         status: 302,

--- a/src/authDataManager/OAuth1Client.js
+++ b/src/authDataManager/OAuth1Client.js
@@ -118,7 +118,7 @@ OAuth.nonce = function(){
   var text = "";
   var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-  for( var i=0; i < 30; i++ )
+  for(var i=0; i < 30; i++)
     text += possible.charAt(Math.floor(Math.random() * possible.length));
 
   return text;

--- a/src/authDataManager/vkontakte.js
+++ b/src/authDataManager/vkontakte.js
@@ -25,7 +25,7 @@ function validateAuthData(authData, params) {
 function vkOAuth2Request(params) {
   var promise = new Parse.Promise();
   return promise.then(function(){
-    if (!params || !params.appIds || !params.appIds.length || !params.appSecret || !params.appSecret.length ) {
+    if (!params || !params.appIds || !params.appIds.length || !params.appSecret || !params.appSecret.length) {
       logger.error('Vk Auth', 'Vk auth is not configured. Missing appIds or appSecret.');
       throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Vk auth is not configured. Missing appIds or appSecret.');
     }


### PR DESCRIPTION
1. Add no space in paren rule
2. fix spec/eslintrc.json so it allow for inheriting from root rc.

Because the spec/eslintrc.json specified recommended, it "turned off" all of the
rule tweaks in the root.  This fixes that so that there is no need to duplicate anything (in fact you shouldn't) from the root eslintrc.json.....nice