### PR TITLE
Fixes SchemaController data for Volatile Classes

### DIFF
--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -880,6 +880,36 @@ describe('SchemaController', () => {
       done();
     });
   });
+
+  it('properly handles volatile _Schemas', done => {
+    function validateSchemaStructure(schema) {
+      console.log(schema);
+      expect(schema.hasOwnProperty('className')).toBe(true);
+      expect(schema.hasOwnProperty('fields')).toBe(true);
+      expect(schema.hasOwnProperty('classLevelPermissions')).toBe(true);
+    }
+    function validateSchemaDataStructure(schemaData) {
+      Object.keys(schemaData).forEach(className => {
+        let schema = schemaData[className];
+        expect(schema.hasOwnProperty('className')).toBe(false);
+        expect(schema.hasOwnProperty('fields')).toBe(false);
+        expect(schema.hasOwnProperty('classLevelPermissions')).toBe(false);
+      });
+    }
+    let schema;
+    config.database.loadSchema().then(s => {
+      schema = s;
+      return schema.getOneSchema('_User', false);
+    }).then(userSchema => {
+      validateSchemaStructure(userSchema);
+      validateSchemaDataStructure(schema.data);
+      return schema.getOneSchema('_PushStatus', true);
+    }).then(pushStatusSchema => {
+      validateSchemaStructure(pushStatusSchema);
+      validateSchemaDataStructure(schema.data);
+      done();
+    });
+  });
 });
 
 describe('Class Level Permissions for requiredAuth', () => {

--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -883,7 +883,6 @@ describe('SchemaController', () => {
 
   it('properly handles volatile _Schemas', done => {
     function validateSchemaStructure(schema) {
-      console.log(schema);
       expect(schema.hasOwnProperty('className')).toBe(true);
       expect(schema.hasOwnProperty('fields')).toBe(true);
       expect(schema.hasOwnProperty('classLevelPermissions')).toBe(true);
@@ -891,7 +890,10 @@ describe('SchemaController', () => {
     function validateSchemaDataStructure(schemaData) {
       Object.keys(schemaData).forEach(className => {
         let schema = schemaData[className];
-        expect(schema.hasOwnProperty('className')).toBe(false);
+        // Hooks has className...
+        if (className != '_Hooks') {
+          expect(schema.hasOwnProperty('className')).toBe(false);
+        }
         expect(schema.hasOwnProperty('fields')).toBe(false);
         expect(schema.hasOwnProperty('classLevelPermissions')).toBe(false);
       });

--- a/src/Controllers/SchemaController.js
+++ b/src/Controllers/SchemaController.js
@@ -346,11 +346,9 @@ export default class SchemaController {
 
       // Inject the in-memory classes
       volatileClasses.forEach(className => {
-        this.data[className] = injectDefaultSchema({
-          className,
-          fields: {},
-          classLevelPermissions: {}
-        });
+        let schema = injectDefaultSchema({ className });
+        this.data[className] = schema.fields;
+        this.perms[className] = schema.classLevelPermissions;
       });
       delete this.reloadDataPromise;
     }, (err) => {
@@ -388,7 +386,11 @@ export default class SchemaController {
     }
     return promise.then(() => {
       if (allowVolatileClasses && volatileClasses.indexOf(className) > -1) {
-        return Promise.resolve(this.data[className]);
+        return Promise.resolve({
+          className,
+          fields: this.data[className],
+          classLevelPermissions: this.perms[className]
+        });
       }
       return this._cache.getOneSchema(className).then((cached) => {
         if (cached && !options.clearCache) {


### PR DESCRIPTION
In the SchemaController, Volatile classes and regular classes were not stored/returned with the same format.

This PR ensures the internal storage format matches for all classes and well as the returned format.