### PR TITLE
Add a CLI option to specify the host

### DIFF
--- a/src/cli/definitions/parse-server.js
+++ b/src/cli/definitions/parse-server.js
@@ -26,6 +26,11 @@ export default {
     default: 1337,
     action: numberParser("port")
   },
+  "host": {
+    env: "PARSE_SERVER_HOST",
+    help: "The host to serve ParseServer on. defaults to 0.0.0.0",
+    default: '0.0.0.0',
+  },
   "databaseURI": {
     env: "PARSE_SERVER_DATABASE_URI",
     help: "The full URI to your mongodb database"

--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -35,7 +35,7 @@ function startServer(options, callback) {
 
   app.use(options.mountPath, api);
 
-  let server = app.listen(options.port, callback);
+  let server = app.listen(options.port, options.host, callback);
   server.on('connection', initializeConnections);
 
   if (options.startLiveQueryServer || options.liveQueryServerOptions) {


### PR DESCRIPTION
By default, parse server accepts connections on `0.0.0.0`. In cases when it is being run behind a reverse proxy, it would be useful to be able to configure the host to something like `127.0.0.1` or on an internal IP address.