### PR TITLE
Fixes #3195

### DIFF
--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -2486,7 +2486,7 @@ describe('Parse.Query testing', () => {
       return new Parse.Query(PostObject)
         .matchesKeyInQuery("author", "members", new Parse.Query(GroupObject))
         .find()
-        .then(r => {
+        .then((r) => {
           expect(r.length).toEqual(1);
           if (r.length > 0) {
             expect(r[0].id).toEqual(p.id);

--- a/spec/ParseQuery.spec.js
+++ b/spec/ParseQuery.spec.js
@@ -2467,6 +2467,35 @@ describe('Parse.Query testing', () => {
     });
   });
 
+  it("should match a key in an array (#3195)", function(done) {
+    var AuthorObject = Parse.Object.extend("Author");
+    var GroupObject = Parse.Object.extend("Group");
+    var PostObject = Parse.Object.extend("Post");
+
+    return new AuthorObject().save().then((user) => {
+      const post = new PostObject({
+        author: user
+      });
+
+      const group = new GroupObject({
+        members: [user],
+      });
+
+      return Parse.Promise.when(post.save(), group.save());
+    }).then((p) => {
+      return new Parse.Query(PostObject)
+        .matchesKeyInQuery("author", "members", new Parse.Query(GroupObject))
+        .find()
+        .then(r => {
+          expect(r.length).toEqual(1);
+          if (r.length > 0) {
+            expect(r[0].id).toEqual(p.id);
+          }
+          done();
+        }, done.fail);
+    });
+  });
+
   it('should find objects with array of pointers', (done) => {
     var objects = [];
     while(objects.length != 5) {

--- a/src/Adapters/Storage/Mongo/MongoTransform.js
+++ b/src/Adapters/Storage/Mongo/MongoTransform.js
@@ -223,7 +223,7 @@ function transformQueryKeyValue(className, key, value, schema) {
   }
 
   // Handle query constraints
-  let transformedConstraint = transformConstraint(value, expectedTypeIsArray);
+  const transformedConstraint = transformConstraint(value, expectedTypeIsArray);
   if (transformedConstraint !== CannotTransform) {
     return {key, value: transformedConstraint};
   }

--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -1,5 +1,6 @@
 import { createClient } from './PostgresClient';
 import Parse            from 'parse/node';
+import _                from 'lodash';
 
 const PostgresRelationDoesNotExistError = '42P01';
 const PostgresDuplicateRelationError = '42P07';
@@ -296,10 +297,10 @@ const buildWhereClause = ({ schema, query, index }) => {
         }
       }
       if (fieldValue.$in) {
-        createConstraint(fieldValue.$in, false);
+        createConstraint(_.flatMap(fieldValue.$in, elt => elt), false);
       }
       if (fieldValue.$nin) {
-        createConstraint(fieldValue.$nin, true);
+        createConstraint(_.flatMap(fieldValue.$nin, elt => elt), true);
       }
     }
 


### PR DESCRIPTION
Issue 3195 was resolved by flattening the query constraints on $in/$nin operators, that may occur as the topLevelAtoms may be results from another query. Nonetheless, the bad atom was triggered because $in clause was having nested arrays.

Fixes #3195 