### PR TITLE
Adds depreciation notes for Parse.Cloud.useMasterKey()

### DIFF
--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -60,7 +60,7 @@ ParseCloud._removeAllHooks = () => {
 }
 
 ParseCloud.useMasterKey = () => {
-  // eslint-disable-next-line instead
+  // eslint-disable-next-line
   console.warn("Parse.Cloud.useMasterKey is deprecated (and has no effect anymore) on parse-server, please refer to the cloud code migration notes: https://github.com/ParsePlatform/parse-server/wiki/Compatibility-with-Hosted-Parse#cloud-code")
 }
 

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -59,6 +59,12 @@ ParseCloud._removeAllHooks = () => {
   triggers._unregisterAll();
 }
 
+ParseCloud.useMasterKey = () => {
+  /* eslint-disable no-console */
+  console.warn("Parse.Cloud.useMasterKey is deprecated (and has no effect anymore) on parse-server, please refer to the cloud code migration notes: https://github.com/ParsePlatform/parse-server/wiki/Compatibility-with-Hosted-Parse#cloud-code")
+  /* eslint-enable */
+}
+
 ParseCloud.httpRequest = require("./httpRequest");
 
 module.exports = ParseCloud;

--- a/src/cloud-code/Parse.Cloud.js
+++ b/src/cloud-code/Parse.Cloud.js
@@ -60,9 +60,8 @@ ParseCloud._removeAllHooks = () => {
 }
 
 ParseCloud.useMasterKey = () => {
-  /* eslint-disable no-console */
+  // eslint-disable-next-line instead
   console.warn("Parse.Cloud.useMasterKey is deprecated (and has no effect anymore) on parse-server, please refer to the cloud code migration notes: https://github.com/ParsePlatform/parse-server/wiki/Compatibility-with-Hosted-Parse#cloud-code")
-  /* eslint-enable */
 }
 
 ParseCloud.httpRequest = require("./httpRequest");


### PR DESCRIPTION
 replaces by noop that logs a link to the migration notes.

In 2.4.0, we should throw exceptions.

Fixes: #2633 