### PR TITLE
Fixes issue affecting the auth providers

### DIFF
--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -203,6 +203,13 @@ describe('AuthenticationProviers', function() {
     expect(typeof authenticatonHandler.getValidatorForProvider).toBe('function');
   }
 
+  function validateAuthenticationAdapter(authAdapter) {
+    expect(authAdapter).not.toBeUndefined();
+    if (!authAdapter) { return; }
+    expect(typeof authAdapter.validateAuthData).toBe('function');
+    expect(typeof authAdapter.validateAppId).toBe('function');
+  }
+
   it('properly loads custom adapter', (done) => {
     var validAuthData = {
       id: 'hello',
@@ -278,5 +285,15 @@ describe('AuthenticationProviers', function() {
       jfail(err);
       done();
     })
+  });
+
+  it('properly loads a default adapter with options', () => {
+    const adapter = authenticationLoader.loadAuthAdapter('facebook', {
+      facebook: {
+        appIds: ['a', 'b']
+      }
+    });
+    console.log(adapter);
+    validateAuthenticationAdapter(adapter);
   });
 });

--- a/spec/AuthenticationAdapters.spec.js
+++ b/spec/AuthenticationAdapters.spec.js
@@ -288,12 +288,28 @@ describe('AuthenticationProviers', function() {
   });
 
   it('properly loads a default adapter with options', () => {
-    const adapter = authenticationLoader.loadAuthAdapter('facebook', {
+    const options = {
       facebook: {
         appIds: ['a', 'b']
       }
-    });
-    console.log(adapter);
+    };
+    const { adapter, appIds, providerOptions } = authenticationLoader.loadAuthAdapter('facebook', options);
     validateAuthenticationAdapter(adapter);
+    expect(appIds).toEqual(['a', 'b']);
+    expect(providerOptions).toEqual(options.facebook);
+  });
+
+  it('properly loads a custom adapter with options', () => {
+    const options = {
+      custom: {
+        validateAppId: () => {},
+        validateAuthData: () => {},
+        appIds: ['a', 'b']
+      }
+    };
+    const { adapter, appIds, providerOptions } = authenticationLoader.loadAuthAdapter('custom', options);
+    validateAuthenticationAdapter(adapter);
+    expect(appIds).toEqual(['a', 'b']);
+    expect(providerOptions).toEqual(options.custom);
   });
 });


### PR DESCRIPTION
With 2.3.0, and issue was introduces that would effectively override the default auth provider when passing options in the ParseServer constructor.

This fix makes sure that the options passed do not override the validator methods if none are passed.

Fixes #3208