### PR TITLE
added publicServerURL & PARSE_PUBLIC_SERVER_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ var api = new ParseServer({
   appId: 'myAppId',
   masterKey: 'myMasterKey', // Keep this key secret!
   fileKey: 'optionalFileKey',
-  serverURL: 'http://localhost:1337/parse' // Don't forget to change to https if needed
+  serverURL: 'http://localhost:1337/parse', // Don't forget to change to https if needed
+  publicServerURL: 'https://localhost:1337/parse' // must set equal to serverURL if using https
 });
 
 // Serve the Parse API on the /parse URL prefix
@@ -314,6 +315,7 @@ PARSE_SERVER_MASTER_KEY
 PARSE_SERVER_DATABASE_URI
 PARSE_SERVER_URL
 PARSE_SERVER_CLOUD_CODE_MAIN
+PARSE_PUBLIC_SERVER_URL
 ```
 
 The default port is 1337, to use a different port set the PORT environment variable:
@@ -321,6 +323,8 @@ The default port is 1337, to use a different port set the PORT environment varia
 ```bash
 $ PORT=8080 parse-server --appId APPLICATION_ID --masterKey MASTER_KEY
 ```
+
+Must set `PARSE_PUBLIC_SERVER_URL` equal to `PARSE_SERVER_URL` if using HTTPS ([details here](https://github.com/ParsePlatform/parse-server/issues/2743)).
 
 For the full list of configurable environment variables, run `parse-server --help`.
 


### PR DESCRIPTION
These variables must be set equal to serverURL & PARSE_SERVER_URL if using HTTPS and to avoid ParseFile.getDataInBackground(...) causing iOS application transport security (ATS) error or Android com.parse.ParseRequest$ParseRequestException: i/o failure.

It seems that a lot of people get around the iOS ATS issue simply by disabling ATS when all they need to do is set these variables that do not appear in the docs.