### PR TITLE
Add parseFrameURL for masking user-facing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ The client keys used with Parse are no longer necessary with Parse Server. If yo
 * `revokeSessionOnPasswordReset` - When a user changes their password, either through the reset password email or while logged in, all sessions are revoked if this is true. Set to false if you don't want to revoke sessions.
 * `accountLockout` - Lock account when a malicious user is attempting to determine an account password by trial and error.
 * `passwordPolicy` - Optional password policy rules to enforce.
+* `customPages` - A hash with urls to override email verification links, password reset links and specify frame url for masking user-facing pages. Available keys: `parseFrameURL`, `invalidLink`, `choosePassword`, `passwordResetSuccess`, `verifyEmailSuccess`.
 
 ##### Logging
 

--- a/spec/UserController.spec.js
+++ b/spec/UserController.spec.js
@@ -13,7 +13,7 @@ describe('UserController', () => {
     describe('parseFrameURL not provided', () => {
       it('uses publicServerURL', (done) => {
 
-        AppCache.put(defaultConfiguration.appId, Object.assign(defaultConfiguration, {
+        AppCache.put(defaultConfiguration.appId, Object.assign({}, defaultConfiguration, {
           publicServerURL: 'http://www.example.com',
           customPages: {
             parseFrameURL: undefined
@@ -36,7 +36,7 @@ describe('UserController', () => {
     describe('parseFrameURL provided', () => {
       it('uses parseFrameURL and includes the destination in the link parameter', (done) => {
 
-        AppCache.put(defaultConfiguration.appId, Object.assign(defaultConfiguration, {
+        AppCache.put(defaultConfiguration.appId, Object.assign({}, defaultConfiguration, {
           publicServerURL: 'http://www.example.com',
           customPages: {
             parseFrameURL: 'http://someother.example.com/handle-parse-iframe'

--- a/spec/UserController.spec.js
+++ b/spec/UserController.spec.js
@@ -1,0 +1,59 @@
+var UserController = require('../src/Controllers/UserController').UserController;
+var emailAdapter = require('./MockEmailAdapter')
+var AppCache = require('../src/cache').AppCache;
+
+describe('UserController', () => {
+  var user = {
+    _email_verify_token: 'testToken',
+    username: 'testUser',
+    email: 'test@example.com'
+  }
+
+  describe('sendVerificationEmail', () => {
+    describe('parseFrameURL not provided', () => {
+      it('uses publicServerURL', (done) => {
+
+        AppCache.put(defaultConfiguration.appId, Object.assign(defaultConfiguration, {
+          publicServerURL: 'http://www.example.com',
+          customPages: {
+            parseFrameURL: undefined
+          }
+        }))
+
+        emailAdapter.sendVerificationEmail = (options) => {
+          expect(options.link).toEqual('http://www.example.com/apps/test/verify_email?token=testToken&username=testUser')
+          done()
+        }
+
+        var userController = new UserController(emailAdapter, 'test', {
+          verifyUserEmails: true
+        })
+
+        userController.sendVerificationEmail(user)
+      })
+    })
+
+    describe('parseFrameURL provided', () => {
+      it('uses parseFrameURL and includes the destination in the link parameter', (done) => {
+
+        AppCache.put(defaultConfiguration.appId, Object.assign(defaultConfiguration, {
+          publicServerURL: 'http://www.example.com',
+          customPages: {
+            parseFrameURL: 'http://someother.example.com/handle-parse-iframe'
+          }
+        }))
+
+        emailAdapter.sendVerificationEmail = (options) => {
+          expect(options.link).toEqual('http://someother.example.com/handle-parse-iframe?link=%2Fapps%2Ftest%2Fverify_email&token=testToken&username=testUser')
+          done()
+        }
+
+        var userController = new UserController(emailAdapter, 'test', {
+          verifyUserEmails: true
+        })
+
+        userController.sendVerificationEmail(user)
+      })
+    })
+  })
+});

--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -12,7 +12,8 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
         invalidLink: "myInvalidLink",
         verifyEmailSuccess: "myVerifyEmailSuccess",
         choosePassword: "myChoosePassword",
-        passwordResetSuccess: "myPasswordResetSuccess"
+        passwordResetSuccess: "myPasswordResetSuccess",
+        parseFrameURL: "http://example.com/handle-parse-iframe"
       },
       publicServerURL: "https://my.public.server.com/1"
     })
@@ -22,6 +23,7 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
       expect(config.verifyEmailSuccessURL).toEqual("myVerifyEmailSuccess");
       expect(config.choosePasswordURL).toEqual("myChoosePassword");
       expect(config.passwordResetSuccessURL).toEqual("myPasswordResetSuccess");
+      expect(config.parseFrameURL).toEqual("http://example.com/handle-parse-iframe");
       expect(config.verifyEmailURL).toEqual("https://my.public.server.com/1/apps/test/verify_email");
       expect(config.requestResetPasswordURL).toEqual("https://my.public.server.com/1/apps/test/request_password_reset");
       done();

--- a/src/Config.js
+++ b/src/Config.js
@@ -240,6 +240,10 @@ export class Config {
     return this.customPages.passwordResetSuccess || `${this.publicServerURL}/apps/password_reset_success.html`;
   }
 
+  get parseFrameURL() {
+    return this.customPages.parseFrameURL;
+  }
+
   get verifyEmailURL() {
     return `${this.publicServerURL}/apps/${this.applicationId}/verify_email`;
   }

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -119,6 +119,7 @@ export class UserController extends AdaptableController {
     // We may need to fetch the user in case of update email
     this.getUserIfNeeded(user).then((user) => {
       const username = encodeURIComponent(user.username);
+
       const link = buildEmailLink(this.config.verifyEmailURL, username, token, this.config);
       const options = {
         appName: this.config.appName,
@@ -216,10 +217,11 @@ function updateUserPassword(userId, password, config) {
 }
 
 function buildEmailLink(destination, username, token, config) {
-  let usernameAndToken = `token=${token}&username=${username}`
+  const usernameAndToken = `token=${token}&username=${username}`
 
   if (config.parseFrameURL) {
-    let destinationWithoutHost = destination.replace(config.publicServerURL, '');
+    const destinationWithoutHost = destination.replace(config.publicServerURL, '');
+
     return `${config.parseFrameURL}?link=${encodeURIComponent(destinationWithoutHost)}&${usernameAndToken}`;
   } else {
     return `${destination}?${usernameAndToken}`;

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -119,7 +119,7 @@ export class UserController extends AdaptableController {
     // We may need to fetch the user in case of update email
     this.getUserIfNeeded(user).then((user) => {
       const username = encodeURIComponent(user.username);
-      const link = `${this.config.verifyEmailURL}?token=${token}&username=${username}`;
+      const link = buildVerificationLink(this.config.verifyEmailURL, username, token);
       const options = {
         appName: this.config.appName,
         link: link,
@@ -153,8 +153,8 @@ export class UserController extends AdaptableController {
     .then(user => {
       const token = encodeURIComponent(user._perishable_token);
       const username = encodeURIComponent(user.username);
-      const link = `${this.config.requestResetPasswordURL}?token=${token}&username=${username}`
 
+      const link = buildVerificationLink(this.config.requestResetPasswordURL, username, token);
       const options = {
         appName: this.config.appName,
         link: link,
@@ -213,6 +213,17 @@ function updateUserPassword(userId, password, config) {
   return rest.update(config, Auth.master(config), '_User', userId, {
     password: password
   });
+}
+
+function buildVerificationLink(destination, username, token) {
+  let usernameAndToken = `token=${token}&username=${username}`
+
+  if (this.config.parseFrameURL) {
+    let destinationWithoutHost = destination.replace(this.config.publicServerURL, '');
+   return `${this.config.parseFrameURL}?link=${encodeURIComponent(destinationWithoutHost)}&${usernameAndToken}`;
+  } else {
+    return `${destination}?${usernameAndToken}`;
+  }
 }
 
 export default UserController;

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -220,7 +220,7 @@ function buildVerificationLink(destination, username, token) {
 
   if (this.config.parseFrameURL) {
     let destinationWithoutHost = destination.replace(this.config.publicServerURL, '');
-   return `${this.config.parseFrameURL}?link=${encodeURIComponent(destinationWithoutHost)}&${usernameAndToken}`;
+    return `${this.config.parseFrameURL}?link=${encodeURIComponent(destinationWithoutHost)}&${usernameAndToken}`;
   } else {
     return `${destination}?${usernameAndToken}`;
   }

--- a/src/Controllers/UserController.js
+++ b/src/Controllers/UserController.js
@@ -119,7 +119,7 @@ export class UserController extends AdaptableController {
     // We may need to fetch the user in case of update email
     this.getUserIfNeeded(user).then((user) => {
       const username = encodeURIComponent(user.username);
-      const link = buildVerificationLink(this.config.verifyEmailURL, username, token);
+      const link = buildEmailLink(this.config.verifyEmailURL, username, token, this.config);
       const options = {
         appName: this.config.appName,
         link: link,
@@ -154,7 +154,7 @@ export class UserController extends AdaptableController {
       const token = encodeURIComponent(user._perishable_token);
       const username = encodeURIComponent(user.username);
 
-      const link = buildVerificationLink(this.config.requestResetPasswordURL, username, token);
+      const link = buildEmailLink(this.config.requestResetPasswordURL, username, token, this.config);
       const options = {
         appName: this.config.appName,
         link: link,
@@ -215,12 +215,12 @@ function updateUserPassword(userId, password, config) {
   });
 }
 
-function buildVerificationLink(destination, username, token) {
+function buildEmailLink(destination, username, token, config) {
   let usernameAndToken = `token=${token}&username=${username}`
 
-  if (this.config.parseFrameURL) {
-    let destinationWithoutHost = destination.replace(this.config.publicServerURL, '');
-    return `${this.config.parseFrameURL}?link=${encodeURIComponent(destinationWithoutHost)}&${usernameAndToken}`;
+  if (config.parseFrameURL) {
+    let destinationWithoutHost = destination.replace(config.publicServerURL, '');
+    return `${config.parseFrameURL}?link=${encodeURIComponent(destinationWithoutHost)}&${usernameAndToken}`;
   } else {
     return `${destination}?${usernameAndToken}`;
   }


### PR DESCRIPTION
Allow users to specify a different address which is used to mask parse requests for verifying email and resetting password. This is how Parse.com used to allow customers to gain control over page content, styling etc.

On the destination page javascript is used to check the link in the request and embed the parse server page using IFRAME.

This is a clone of a closed PR (#3091) because I reorganized git branches. Thanks to @jure for adding tests.