### PR TITLE
Feature(QueryTools): added possibility to query subobjects in livequery

### DIFF
--- a/spec/QueryTools.spec.js
+++ b/spec/QueryTools.spec.js
@@ -88,6 +88,22 @@ describe('queryHash', function() {
 });
 
 describe('matchesQuery', function() {
+  it('matches subquery', function() {
+    var obj = {
+      id: new Id('Item', '01'),
+      value: 42,
+      component: {
+        name: 'World',
+        type: 'question'
+      }
+    };
+    var q = new Parse.Query('Item');
+    q.equalTo('component.name', 'World');
+    expect(matchesQuery(obj, q)).toBe(true);
+    obj['component.name'] = 'Other world';
+    expect(matchesQuery(obj, q)).toBe(false);
+  });
+
   it('matches blanket queries', function() {
     var obj = {
       id: new Id('Klass', 'O1'),


### PR DESCRIPTION
I've added possibility to subscribe to nested object with LiveQuery.
(not real code example)
```
{
    ...
    type: 'input',
    attributes: {
      disabled: false,
      class: 'input-class'
    }
}
```
For example, at this moment I can't subscribe for `object.attributes.class`. I've added possibility to look up for nested keys, but left match detection unchanged.

```
var q = new Parse.Query('Activities');
q.equalTo('attributes.class', 'input-class');
```

- [X] Tests added 
- [X] Whole-project tests passed