### PR TITLE
winston-daily-roate-file-1.4.2 makes a change where timestamp is not …

### DIFF
--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -21,12 +21,12 @@ function updateTransports(options) {
         Object.assign({}, {
           filename: 'parse-server.info',
           name: 'parse-server',
-        }, options));
+        }, options, { timestamp: true }));
       transports['parse-server-error'] = new (DailyRotateFile)(
         Object.assign({}, {
           filename: 'parse-server.err',
           name: 'parse-server-error',
-        }, options, { level: 'error'}));
+        }, options, { level: 'error', timestamp: true  }));
     }
 
     transports.console = new (winston.transports.Console)(


### PR DESCRIPTION
…on be default anymore.

see: https://github.com/winstonjs/winston-daily-rotate-file/commit/aa28f522718778fe8210ced1090353ffc29c6f31

pretty incredible that they would release this as a patch release, but this fix is solid anyway.