### PR TITLE
chore(package): update jasmine-spec-reporter to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gaze": "1.1.1",
     "istanbul": "1.0.0-alpha.1",
     "jasmine": "2.5.2",
-    "jasmine-spec-reporter": "^2.7.0",
+    "jasmine-spec-reporter": "^3.0.0",
     "mongodb-runner": "3.4.0",
     "nodemon": "1.11.0",
     "request-promise": "4.1.1"

--- a/spec/helper.js
+++ b/spec/helper.js
@@ -1,6 +1,6 @@
 "use strict"
 // Sets up a Parse API server for testing.
-const SpecReporter = require('jasmine-spec-reporter');
+const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = process.env.PARSE_SERVER_TEST_TIMEOUT || 5000;
 


### PR DESCRIPTION
https://greenkeeper.io/

Fix parse-server to work with jasmine-spec-reporter-3.0.0

note that this replaces: #3307 which i closed.