### PR TITLE
fix parse-server to work with winston-daily-rotate-1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "semver": "5.2.0",
     "tv4": "1.2.7",
     "winston": "2.3.0",
-    "winston-daily-rotate-file": "1.4.1",
+    "winston-daily-rotate-file": "1.4.2",
     "ws": "1.1.1"
   },
   "devDependencies": {

--- a/src/Adapters/Logger/WinstonLogger.js
+++ b/src/Adapters/Logger/WinstonLogger.js
@@ -21,12 +21,12 @@ function updateTransports(options) {
         Object.assign({}, {
           filename: 'parse-server.info',
           name: 'parse-server',
-        }, options));
+        }, options, { timestamp: true }));
       transports['parse-server-error'] = new (DailyRotateFile)(
         Object.assign({}, {
           filename: 'parse-server.err',
           name: 'parse-server-error',
-        }, options, { level: 'error'}));
+        }, options, { level: 'error', timestamp: true  }));
     }
 
     transports.console = new (winston.transports.Console)(


### PR DESCRIPTION
winston-daily-roate-file-1.4.2 makes a change where timestamp is not on by default anymore.

see: https://github.com/winstonjs/winston-daily-rotate-file/commit/aa28f522718778fe8210ced1090353ffc29c6f31

this replaces: #3318 

pretty incredible that they would release this as a patch release, but my fix is solid and defensive

chore(package): update winston-daily-rotate-file to version 1.4.2