### PR TITLE
Add logging on failure to create file

### DIFF
--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -4,6 +4,7 @@ import * as Middlewares    from '../middlewares';
 import Parse               from 'parse/node';
 import Config              from '../Config';
 import mime                from 'mime';
+import logger              from '../logger';
 
 export class FilesRouter {
 
@@ -87,7 +88,8 @@ export class FilesRouter {
       res.status(201);
       res.set('Location', result.url);
       res.json(result);
-    }).catch(() => {
+    }).catch((e) => {
+      logger.error(e.message, e);
       next(new Parse.Error(Parse.Error.FILE_SAVE_ERROR, 'Could not store file.'));
     });
   }


### PR DESCRIPTION
We're making some s3 changes and I was updating our config.

I did it wrong, and the create file failed.  No big deal, but parse-server's response was a very unhelpful: `[object Object]` output to console.error :(

This change is local only to the FileRouter, which is necessary since we'll lose `e` which has the important bit of info in it as to why the operation failed.....

but i think we need a more global solution......

