### PR TITLE
WIP: Create a ServerError class.

### DIFF
--- a/src/ParseServer.js
+++ b/src/ParseServer.js
@@ -394,4 +394,6 @@ function addParseCloud() {
   global.Parse = Parse;
 }
 
+ParseServer.Error = require('./ServerError').default;
+
 export default ParseServer;

--- a/src/Routers/FilesRouter.js
+++ b/src/Routers/FilesRouter.js
@@ -1,9 +1,10 @@
-import express             from 'express';
-import BodyParser          from 'body-parser';
-import * as Middlewares    from '../middlewares';
-import Parse               from 'parse/node';
-import Config              from '../Config';
-import mime                from 'mime';
+import express from 'express';
+import BodyParser from 'body-parser';
+import * as Middlewares from '../middlewares';
+import Parse from 'parse/node';
+import Config from '../Config';
+import mime from 'mime';
+import ParseServer from '../ParseServer';
 
 export class FilesRouter {
 
@@ -87,8 +88,10 @@ export class FilesRouter {
       res.status(201);
       res.set('Location', result.url);
       res.json(result);
-    }).catch(() => {
-      next(new Parse.Error(Parse.Error.FILE_SAVE_ERROR, 'Could not store file.'));
+    }).catch((e) => {
+      const parseError = new Parse.Error(Parse.Error.FILE_SAVE_ERROR, 'Could not store file.');
+      const parseServerError = new ParseServer.Error(e.message, parseError);
+      next(parseServerError);
     });
   }
 

--- a/src/ServerError.js
+++ b/src/ServerError.js
@@ -1,0 +1,19 @@
+/**
+ * Constructs a new ServerError object with the given message and source.
+ *
+ * The message is an error that the consumer of the server API will see,
+ * while the source message is intended for the server logs to aid a developer
+ *
+ * @class ServerError
+ * @constructor
+ * @param {String} message A detailed description of the error.
+ * @param {ParseError} source The
+ */
+export default class ServerError extends Error {
+  source;
+
+  constructor(message, source) {
+    super(message);
+    this.source = source;
+  }
+}


### PR DESCRIPTION
NOTE: This is a preview, I'm looking for some feedback and the definition of ServerError...once we settle on the basic idea, then i'll go and change as many ParseErrors into ServerErrors that makes sense.

see: #661

The problem this pr is trying to solve:

When an error occurs on the server, a message should
be returned to the client, and a message should be logged.

Currently, noting is often logged.

Byt adding a ServerError class, we can embed a ParseError into
the ServerError.  The ServerError contains the message for the log
and the ParseError contains the error for the client.

In addition, this pr will stop calling the default express error handler
which causes two problems: 1. it writes to console instead of log file
2. the output is completely useless! :)