### PR TITLE
Remove duplicate word form the README log section

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ For a full list of available options, run `parse-server --help`.
 
 ## Logging
 
-Parse Server will, by default, will log:
+Parse Server will, by default, log:
 * to the console
 * daily rotating files as new line delimited JSON
 


### PR DESCRIPTION
I noticed a tiny bit of wording in the Logging section of the README which doesn't read so well.

It originally read: "Parse Server, will, by default, will log:", I've removed the second "will" to make "Parse Server will, by default, log:".

Sorry for the smallest PR ever!