### PR TITLE
Fix PostgresStorageAdapter Pointers not working 

### DIFF
--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -23,7 +23,7 @@ const parseTypeToPostgresType = type => {
   case 'Object': return 'jsonb';
   case 'File': return 'text';
   case 'Boolean': return 'boolean';
-  case 'Pointer': return 'char(10)';
+  case 'Pointer': return 'text';
   case 'Number': return 'double precision';
   case 'GeoPoint': return 'point';
   case 'Array':


### PR DESCRIPTION
In PostgresStorageAdapter the pointer type is declared as char[10], but if the size of the pointer is less than 10 chars, then it adds whitespace for the remaining characters, this cause the pointer to stop working