### PR TITLE
Update MongoDB $or queries to avoid SERVER-13732 bug

### DIFF
--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -18,7 +18,14 @@ function addWriteACL(query, acl) {
 function addReadACL(query, acl) {
   const newQuery = _.cloneDeep(query);
   //Can't be any existing '_rperm' query, we don't allow client queries on that, no need to $and
-  newQuery._rperm = { "$in" : [null, "*", ...acl]};
+  if (newQuery.hasOwnProperty('$or')) {
+    newQuery.$or = newQuery.$or.map(function(qobj) {
+      qobj._rperm = {'$in' : [null, '*', ...acl]};
+      return qobj;
+    });
+  } else {
+    newQuery._rperm = { "$in" : [null, "*", ...acl]};
+  }
   return newQuery;
 }
 


### PR DESCRIPTION
MongoDB has an unfixed bug in all supported versions 2.6-3.4 which
results in suboptimal index usage for `$or` queries when the query has
implicit `$and`s at the query root.

When adding `_rperm` to `$or` queries, Parse accidentally creates
queries which hit this bug.

The fix in this commit applies the suggested workaround of putting the
`_rperm` property inside all `$or` subdocuments, moving it from the top
level and leaving `$or` as the only top-level operator.

MongoDB Bug Link: https://jira.mongodb.org/browse/SERVER-13732