### PR TITLE
Allow empty client key

### DIFF
--- a/spec/Middlewares.spec.js
+++ b/spec/Middlewares.spec.js
@@ -79,6 +79,19 @@ describe('middlewares', () => {
     });
   });
 
+  it('should succeed when client key supplied but empty', (done) => {
+    AppCache.put(fakeReq.body._ApplicationId, {
+      clientKey: '',
+      masterKey: 'masterKey',
+      restAPIKey: 'restAPIKey'
+    });
+    fakeReq.headers['x-parse-client-key'] = '';
+    middlewares.handleParseHeaders(fakeReq, fakeRes, () => {
+      expect(fakeRes.status).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
   it('should succeed when no keys are configured and none supplied', (done) => {
     AppCache.put(fakeReq.body._ApplicationId, {
       masterKey: 'masterKey'

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -122,10 +122,10 @@ export function handleParseHeaders(req, res, next) {
   //  to preserve original behavior.
   const keys = ["clientKey", "javascriptKey", "dotNetKey", "restAPIKey"];
   const oneKeyConfigured = keys.some(function(key) {
-    return req.config[key];
+    return req.config[key] !== undefined;
   });
   const oneKeyMatches = keys.some(function(key){
-    return req.config[key] && info[key] == req.config[key];
+    return req.config[key] !== undefined && info[key] === req.config[key];
   });
 
   if (oneKeyConfigured && !oneKeyMatches) {


### PR DESCRIPTION
fixes: #3486 

FYI, I tried solving with `_.has(obj, key)`,  but that gives false positives.  I found that in the case of our current coverage and doing my best to reason over the relevant code that a test of `undefined` would both "do what we want" and be backwards compatible.
