### PR TITLE
Use flushdb instead of flushall in RedisCacheAdapter

### DIFF
--- a/src/Adapters/Cache/RedisCacheAdapter.js
+++ b/src/Adapters/Cache/RedisCacheAdapter.js
@@ -71,7 +71,7 @@ export class RedisCacheAdapter {
     debug('clear');
     this.p = this.p.then(() => {
       return new Promise((resolve) => {
-        this.client.flushall(function() {
+        this.client.flushdb(function() {
           resolve();
         });
       });


### PR DESCRIPTION
When a different db on the same redis server is used by another service Parse Server will currently flush that db on `clear()`.

The Parse Server RedisCacheAdapter only reads/writes to one db on the redis server and should only flush that database (instead of all databases).

This fix replaces [`flushall`](https://redis.io/commands/flushall) with [`flushdb`](https://redis.io/commands/flushdb).