### PR TITLE
Fix LiveQuery unsafe user

### DIFF
--- a/spec/SessionTokenCache.spec.js
+++ b/spec/SessionTokenCache.spec.js
@@ -4,13 +4,14 @@ describe('SessionTokenCache', function() {
 
   beforeEach(function(done) {
     var Parse = require('parse/node');
-    // Mock parse
-    var mockUser = {
-      become: jasmine.createSpy('become').and.returnValue(Parse.Promise.as({
-        id: 'userId'
-      }))
-    }
-    jasmine.mockLibrary('parse/node', 'User', mockUser);
+
+    spyOn(Parse, "Query").and.returnValue({
+      first: jasmine.createSpy("first").and.returnValue(Parse.Promise.as(new Parse.Object("_Session", {
+        user: new Parse.User({id:"userId"})
+      }))),
+      equalTo: function(){}
+    })
+
     done();
   });
 
@@ -46,7 +47,4 @@ describe('SessionTokenCache', function() {
     });
   });
 
-  afterEach(function() {
-    jasmine.restoreLibrary('parse/node', 'User');
-  });
 });

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -37,7 +37,6 @@ class ParseLiveQueryServer {
 
     // Initialize Parse
     Parse.Object.disableSingleInstance();
-    Parse.User.enableUnsafeCurrentUser();
 
     const serverURL = config.serverURL || Parse.serverURL;
     Parse.serverURL = serverURL;

--- a/src/LiveQuery/ParseLiveQueryServer.js
+++ b/src/LiveQuery/ParseLiveQueryServer.js
@@ -362,7 +362,7 @@ class ParseLiveQueryServer {
             // Then get the user's roles
           var rolesQuery = new Parse.Query(Parse.Role);
           rolesQuery.equalTo("users", user);
-          return rolesQuery.find();
+          return rolesQuery.find({useMasterKey:true});
         }).
         then((roles) => {
 


### PR DESCRIPTION
The LiveQuery server was explicitly calling `enableUnsafeCurrentUser()`, which should not be used in a server environment.

As far as I can tell, this was only used to provide a convenient way to get the user for a session token. I've replaced that mechanism with one that is safe to use when `unsafeCurrentUser` is disabled. I've also reviewed the LiveQuery code and fixed a place where it was issuing a call without using the master key.

The combination of these issues could result in unexpected failures for invalid session tokens.

Fixes #3516