### PR TITLE
Resend Verification Email Endpoint

### DIFF
--- a/spec/ValidationAndPasswordsReset.spec.js
+++ b/spec/ValidationAndPasswordsReset.spec.js
@@ -383,7 +383,7 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
         fail('sending password reset email should not have succeeded');
         done();
       }, error => {
-        expect(error.message).toEqual('An appName, publicServerURL, and emailAdapter are required for password reset functionality.')
+        expect(error.message).toEqual('An appName, publicServerURL, and emailAdapter are required for password reset and email verification functionality.')
         done();
       });
     })
@@ -414,7 +414,7 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
         fail('sending password reset email should not have succeeded');
         done();
       }, error => {
-        expect(error.message).toEqual('An appName, publicServerURL, and emailAdapter are required for password reset functionality.')
+        expect(error.message).toEqual('An appName, publicServerURL, and emailAdapter are required for password reset and email verification functionality.')
         done();
       });
     })
@@ -442,7 +442,7 @@ describe("Custom Pages, Email Verification, Password Reset", () => {
         fail('sending password reset email should not have succeeded');
         done();
       }, error => {
-        expect(error.message).toEqual('An appName, publicServerURL, and emailAdapter are required for password reset functionality.')
+        expect(error.message).toEqual('An appName, publicServerURL, and emailAdapter are required for password reset and email verification functionality.')
         done();
       });
     })

--- a/src/Routers/UsersRouter.js
+++ b/src/Routers/UsersRouter.js
@@ -246,12 +246,12 @@ export class UsersRouter extends ClassesRouter {
 
     return req.config.database.find('_User', { email: email }).then((results) => {
       if (!results.length || results.length < 1) {
-        throw new Parse.Error(Parse.Error.EMAIL_NOT_FOUND, 'Invalid email.');
+        throw new Parse.Error(Parse.Error.EMAIL_NOT_FOUND, `No user found with email ${email}`);
       }
       const user = results[0];
 
       if (user.emailVerified) {
-        throw new Parse.Error(Parse.Error.OTHER_CAUSE, 'User email is already verified.');
+        throw new Parse.Error(Parse.Error.OTHER_CAUSE, `Email ${email} is already verified.`);
       }
 
       const userController = req.config.userController;


### PR DESCRIPTION
This adds an endpoint, `/verificationEmailRequest`, that allows a client to request a re-send of a verification email. I had implemented this for my own private use, but I noticed an [issue](https://github.com/ParsePlatform/parse-server/issues/3088) and [Stack Overflow question](https://stackoverflow.com/questions/31413758/parse-com-resend-verification-email) asking about this, so I'd like to get it upstream if possible.