### PR TITLE
Alleviate SERVER-13732 on all top level filters

### DIFF
--- a/spec/DatabaseController.spec.js
+++ b/spec/DatabaseController.spec.js
@@ -1,0 +1,28 @@
+var DatabaseController = require('../src/Controllers/DatabaseController.js');
+var validateQuery = DatabaseController._validateQuery;
+
+describe('DatabaseController', function() {
+
+  describe('validateQuery', function() {
+
+    it('should restructure simple cases of SERVER-13732', (done) => {
+      var query = {$or: [{a: 1}, {a: 2}], _rperm: {$in: ['a', 'b']}, foo: 3};
+      validateQuery(query);
+      expect(query).toEqual({$or: [{a: 1, _rperm: {$in: ['a', 'b']}, foo: 3},
+                                   {a: 2, _rperm: {$in: ['a', 'b']}, foo: 3}]});
+      done();
+    });
+
+    it('should reject invalid queries', (done) => {
+      expect(() => validateQuery({$or: {'a': 1}})).toThrow();
+      done();
+    });
+
+    it('should accept valid queries', (done) => {
+      expect(() => validateQuery({$or: [{'a': 1}, {'b': 2}]})).not.toThrow();
+      done();
+    });
+
+  });
+
+});


### PR DESCRIPTION
In a prior commit, improvements were made to the addition of `_rperm`
in the case of `$or` queries, to avoid MongoDB bug SERVER-13732.

As the vast majority of $or queries previously hit this bug due to the
presence of `_rperm` on most Parse queries, the present solution
avoids the bug and improves query performance in most cases.

However, it's still possible for clients to supply their own queries
which hit that bug, such as those with `_created_at` or `_updated_at`
filters, or their own properties from their data model.

This commit makes the logic currently present for `_rperm` available
to all top level filters that exist alongside an $or query, meaning
SERVER-13732 should be avoided in all cases where keys at the top and
inner levels do not have name clashes.

Additionally, simple tests are added for the `DatabaseController` source.

- https://github.com/ParsePlatform/parse-server/pull/3476
- https://jira.mongodb.org/browse/SERVER-13732