### PR TITLE
Logger MaskSentive just for strings and array string items

### DIFF
--- a/src/Controllers/LoggerController.js
+++ b/src/Controllers/LoggerController.js
@@ -41,7 +41,18 @@ export class LoggerController extends AdaptableController {
 
       // check the url
       if (e.url) {
-        e.url = this.maskSensitiveUrl(e.url);
+        // for strings
+        if (typeof e.url === 'string') {
+          e.url = this.maskSensitiveUrl(e.url);
+        } else if (Array.isArray(e.url)) { // for strings in array
+          e.url = e.url.map(item => {
+            if (typeof item === 'string') {
+              return this.maskSensitiveUrl(item);
+            }
+
+            return item;
+          });
+        }
       }
 
       if (e.body) {


### PR DESCRIPTION
For this.. #3569 

I hope it's the best solution. Mask sensitive data just for strings and array string items for avoid breaks.