### PR TITLE
Adds index on _Role name property

### DIFF
--- a/spec/ParseRole.spec.js
+++ b/spec/ParseRole.spec.js
@@ -192,6 +192,24 @@ describe('Parse Role testing', () => {
     });
   });
 
+  it("Different _Role objects cannot have the same name.", (done) => {
+    const roleName = "MyRole";
+    let aUser;
+    createTestUser().then((user) => {
+      aUser = user;
+      return createRole(roleName, null, aUser);
+    }).then((firstRole) => {
+      expect(firstRole.getName()).toEqual(roleName);
+      return createRole(roleName, null, aUser);
+    }).then(() => {
+      fail("_Role cannot have the same name as another role");
+      done();
+    }, (error) => {
+      expect(error.code).toEqual(137);
+      done();
+    });
+  });
+
   it("Should properly resolve roles", (done) => {
     const admin = new Parse.Role("Admin", new Parse.ACL());
     const moderator = new Parse.Role("Moderator", new Parse.ACL());

--- a/spec/Schema.spec.js
+++ b/spec/Schema.spec.js
@@ -494,7 +494,8 @@ describe('SchemaController', () => {
 
   it('creates non-custom classes which include relation field', done => {
     config.database.loadSchema()
-    .then(schema => schema.addClassIfNotExists('_Role', {}))
+    //as `_Role` is always created by default, we only get it here
+    .then(schema => schema.getOneSchema('_Role'))
     .then(actualSchema => {
       const expectedSchema = {
         className: '_Role',

--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -183,7 +183,7 @@ describe('schemas', () => {
       var expected = {
         results: [userSchema,roleSchema]
       };
-      expect(dd(body.results.sort(s => s.className), expected.results.sort(s => s.className))).toEqual();
+      expect(dd(body.results.sort((s1, s2) => s1.className > s2.className), expected.results.sort((s1, s2) => s1.className > s2.className))).toEqual(undefined);
       done();
     });
   });
@@ -205,7 +205,7 @@ describe('schemas', () => {
         var expected = {
           results: [userSchema,roleSchema,plainOldDataSchema,pointersAndRelationsSchema]
         };
-        expect(dd(body.results.sort(s => s.className), expected.results.sort(s => s.className))).toEqual(undefined);
+        expect(dd(body.results.sort((s1, s2) => s1.className > s2.className), expected.results.sort((s1, s2) => s1.className > s2.className))).toEqual(undefined);
         done();
       })
     });

--- a/spec/schemas.spec.js
+++ b/spec/schemas.spec.js
@@ -102,6 +102,20 @@ const userSchema = {
   "classLevelPermissions": defaultClassLevelPermissions,
 }
 
+const roleSchema = {
+  "className": "_Role",
+  "fields": {
+    "objectId": {"type": "String"},
+    "createdAt": {"type": "Date"},
+    "updatedAt": {"type": "Date"},
+    "ACL": {"type": "ACL"},
+    "name":  {"type":"String"},
+    "users": {"type":"Relation", "targetClass":"_User"},
+    "roles": {"type":"Relation", "targetClass":"_Role"}
+  },
+  "classLevelPermissions": defaultClassLevelPermissions,
+}
+
 var noAuthHeaders = {
   'X-Parse-Application-Id': 'test',
 };
@@ -166,7 +180,10 @@ describe('schemas', () => {
       json: true,
       headers: masterKeyHeaders,
     }, (error, response, body) => {
-      expect(dd(body.results, [userSchema])).toEqual();
+      var expected = {
+        results: [userSchema,roleSchema]
+      };
+      expect(dd(body.results.sort(s => s.className), expected.results.sort(s => s.className))).toEqual();
       done();
     });
   });
@@ -186,9 +203,9 @@ describe('schemas', () => {
         headers: masterKeyHeaders,
       }, (error, response, body) => {
         var expected = {
-          results: [userSchema,plainOldDataSchema,pointersAndRelationsSchema]
+          results: [userSchema,roleSchema,plainOldDataSchema,pointersAndRelationsSchema]
         };
-        expect(dd(body, expected)).toEqual(undefined);
+        expect(dd(body.results.sort(s => s.className), expected.results.sort(s => s.className))).toEqual(undefined);
         done();
       })
     });

--- a/src/Controllers/DatabaseController.js
+++ b/src/Controllers/DatabaseController.js
@@ -920,21 +920,21 @@ DatabaseController.prototype.performInitialization = function() {
     .then(() => this.adapter.ensureUniqueness('_User', requiredUserFields, ['username']))
     .catch(error => {
       logger.warn('Unable to ensure uniqueness for usernames: ', error);
-      return Promise.reject(error);
+      throw error;
     });
 
   const emailUniqueness = userClassPromise
     .then(() => this.adapter.ensureUniqueness('_User', requiredUserFields, ['email']))
     .catch(error => {
       logger.warn('Unable to ensure uniqueness for user email addresses: ', error);
-      return Promise.reject(error);
+      throw error;
     });
 
   const roleUniqueness = roleClassPromise
     .then(() => this.adapter.ensureUniqueness('_Role', requiredRoleFields, ['name']))
     .catch(error => {
       logger.warn('Unable to ensure uniqueness for role name: ', error);
-      return Promise.reject(error);
+      throw error;
     });
 
   // Create tables for volatile classes


### PR DESCRIPTION
In order to avoid having different `_Role` objects with the same name, adding an index on the name property of `_Role` is necessary.

In apps migrated from Parse.com, the index ensuring uniqueness on `_Role` names already existed. This issue only happens on new Parse Server apps.

Fixes #3579