### PR TITLE
Allow user to lockout with the master key

### DIFF
--- a/src/RestWrite.js
+++ b/src/RestWrite.js
@@ -890,7 +890,7 @@ RestWrite.prototype.runDatabaseOperation = function() {
   if (this.query) {
     // Force the user to not lockout
     // Matched with parse.com
-    if (this.className === '_User' && this.data.ACL) {
+    if (this.className === '_User' && this.data.ACL && !this.auth.isMaster) {
       this.data.ACL[this.query.objectId] = { read: true, write: true };
     }
     // update password timestamp if user password is being changed


### PR DESCRIPTION
Fixes #3565 by allowing a user to remove the ACL of a User object completely when providing the master key. This way you could lockout specific users without removing their user account.

Not really sure about the unit test though. Since the master key is always used, I can't check if the user login actually fails. Is there a way to use Parse.User.logIn without the master key in the test suite?