### PR TITLE
Do not exit(0) so each module can close its connections

### DIFF
--- a/src/cli/parse-server.js
+++ b/src/cli/parse-server.js
@@ -84,9 +84,7 @@ function startServer(options, callback) {
   const handleShutdown = function() {
     console.log('Termination signal received. Shutting down.');
     destroyAliveConnections();
-    server.close(function () {
-      process.exit(0);
-    });
+    server.close();
   };
   process.on('SIGTERM', handleShutdown);
   process.on('SIGINT', handleShutdown);


### PR DESCRIPTION
When using the CLI, with an adapter that may need to so some cleanup on exit, the exit(0) prevents the cleanup to occur correctly.
