### PR TITLE
Update push adapter to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "multer": "1.3.0",
     "parse": "1.9.2",
     "parse-server-fs-adapter": "1.0.1",
-    "parse-server-push-adapter": "1.2.0",
+    "parse-server-push-adapter": "1.3.0",
     "parse-server-s3-adapter": "1.0.6",
     "parse-server-simple-mailgun-adapter": "1.0.0",
     "pg-promise": "5.6.4",


### PR DESCRIPTION
Parse server push adapter does now support sending push notifications to `osx` and `tvos` device types with the release of `1.3.0`.