### PR TITLE
Ignore duplicate_object error on create _Schema if not exists

### DIFF
--- a/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
+++ b/src/Adapters/Storage/Postgres/PostgresStorageAdapter.js
@@ -6,6 +6,7 @@ import sql              from './sql';
 const PostgresRelationDoesNotExistError = '42P01';
 const PostgresDuplicateRelationError = '42P07';
 const PostgresDuplicateColumnError = '42701';
+const PostgresDuplicateObjectError = '42710';
 const PostgresUniqueIndexViolationError = '23505';
 const PostgresTransactionAbortedError = '25P02';
 const logger = require('../../../logger');
@@ -416,7 +417,9 @@ export class PostgresStorageAdapter {
     conn = conn || this._client;
     return conn.none('CREATE TABLE IF NOT EXISTS "_SCHEMA" ( "className" varChar(120), "schema" jsonb, "isParseClass" bool, PRIMARY KEY ("className") )')
     .catch(error => {
-      if (error.code === PostgresDuplicateRelationError || error.code === PostgresUniqueIndexViolationError) {
+      if (error.code === PostgresDuplicateRelationError
+          || error.code === PostgresUniqueIndexViolationError
+          || error.code === PostgresDuplicateObjectError) {
         // Table already exists, must have been created by a different request. Ignore error.
       } else {
         throw error;


### PR DESCRIPTION
@acinader probably something that you'll like as we probably should ignore this error as well. @vitaly-t @kulshekhar what do you think? Does it make sense?