### PR TITLE
Added exception for Twitter and OAuth missing options

### DIFF
--- a/spec/OAuth1.spec.js
+++ b/spec/OAuth1.spec.js
@@ -133,4 +133,14 @@ describe('OAuth', function() {
       done();
     })
   });
+
+  it("Should fail with missing options", (done) => {
+    var options = undefined;
+    try {
+      new OAuth(options);
+    } catch (error) {
+      jequal(error.message, 'No options passed to OAuth');
+      done();
+    }
+  });
 });

--- a/spec/TwitterAuth.spec.js
+++ b/spec/TwitterAuth.spec.js
@@ -9,7 +9,7 @@ describe('Twitter Auth', () => {
       consumer_key: 'hello'
     }, {
       consumer_key: 'world'
-    }]).consumer_key).toEqual('hello')
+    }]).consumer_key).toEqual('hello');
 
     // Multiple options, consumer_key not found
     expect(function(){
@@ -46,5 +46,19 @@ describe('Twitter Auth', () => {
     }, {
       consumer_key: 'hello'
     }).consumer_key).toEqual('hello');
+  });
+
+  it("Should fail with missing options", (done) => {
+    try {
+      twitter.validateAuthData({
+        consumer_key: 'key',
+        consumer_secret: 'secret',
+        auth_token: 'token',
+        auth_token_secret: 'secret'
+      }, undefined);
+    } catch (error) {
+      jequal(error.message, 'Twitter auth configuration missing');
+      done();
+    }
   });
 });

--- a/src/Adapters/Auth/OAuth1Client.js
+++ b/src/Adapters/Auth/OAuth1Client.js
@@ -4,7 +4,7 @@ var Parse = require('parse/node').Parse;
 
 var OAuth = function(options) {
   if(!options) {
-    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'No options passed to OAuth');
+    throw new Parse.Error(Parse.Error.INTERNAL_SERVER_ERROR, 'No options passed to OAuth');
   }
   this.consumer_key = options.consumer_key;
   this.consumer_secret = options.consumer_secret;

--- a/src/Adapters/Auth/OAuth1Client.js
+++ b/src/Adapters/Auth/OAuth1Client.js
@@ -1,7 +1,11 @@
 var https = require('https'),
   crypto = require('crypto');
+var Parse = require('parse/node').Parse;
 
 var OAuth = function(options) {
+  if(!options) {
+    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'No options passed to OAuth');
+  }
   this.consumer_key = options.consumer_key;
   this.consumer_secret = options.consumer_secret;
   this.auth_token = options.auth_token;

--- a/src/Adapters/Auth/twitter.js
+++ b/src/Adapters/Auth/twitter.js
@@ -6,7 +6,7 @@ var logger = require('../../logger').default;
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData, options) {
   if(!options) {
-    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Twitter auth configuration missing');
+    throw new Parse.Error(Parse.Error.INTERNAL_SERVER_ERROR, 'Twitter auth configuration missing');
   }
   options = handleMultipleConfigurations(authData, options);
   var client = new OAuth(options);

--- a/src/Adapters/Auth/twitter.js
+++ b/src/Adapters/Auth/twitter.js
@@ -5,6 +5,9 @@ var logger = require('../../logger').default;
 
 // Returns a promise that fulfills iff this user id is valid.
 function validateAuthData(authData, options) {
+  if(!options) {
+    throw new Parse.Error(Parse.Error.OBJECT_NOT_FOUND, 'Twitter auth configuration missing');
+  }
   options = handleMultipleConfigurations(authData, options);
   var client = new OAuth(options);
   client.host = "api.twitter.com";


### PR DESCRIPTION
Bringing over a patch for a noted issue in a PR from the [php sdk](https://github.com/ParsePlatform/parse-php-sdk/pull/297). 

It looks like while attempting to utilize third party authentication via twitter there is the possibility for the server to experience an error. This can be caused if the server is either missing it's ```auth``` configuration option entirely or just the ```twitter``` component.

Taking a look at ```src/Adapters/Auth/twitter.js``` under ```validateAuthData``` on line 9 you can see where an ```options``` object (from the server config) of undefined may be passed unchecked into the constructor of ```OAuth```.
```javascript
var client = new OAuth(options);
```
Internally OAuth won't attempt to discern whether it's been passed a valid object or not, and will attempt to extract the properties regardless. This ends up with a ```TypeError``` being thrown with the message ```Cannot read property 'consumer_key' of undefined``` when access is attempted on the first property. 

Ultimately the exception is noted in the server logs but the client receives the following response:
```json
{"code":1,"message":"Internal server error."}
```
This is particularly troublesome as this is a _valid_ response to most SDKs, in this case to the php sdk. Without any ```error``` property in sight the sdk will proceed to return the results for further use as legitimate data.

While the SDKs could attempt to screen for this type of response it's not very specific or helpful without the server logs. This PR attempts to address that by adding a check and exception throw in both ```twitter.js``` and in ```OAuth1Client.js```.

The exception thrown in OAuth is more general, simply indicating that no options were passed for OAuth. This is mostly to prevent unintended usage in the future.

However, for the sdks this response may not be specific enough for say, a missing twitter auth. In this regard ```twitter.validateAuthData``` can check and throw a specific exception ```'Twitter auth configuration missing'``` upon a missing options parameter. This exception is more pointed towards notifying the SDK (and it's developers) that their server is missing the required configuration. This not only plugs up the current internal server error, but, ideally, promotes correction of it as well.

Tests have been updated to account for this behavior in both cases. Also a little typo fix in ```TwitterAuth.spec.js```, missing semi-colon :).