### PR TITLE
Add -d flag to link parse with mgo container

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongo
 ```
 $ docker build --tag parse-server .
 $ docker run --name my-mongo -d mongo
-$ docker run --name my-parse-server --link my-mongo:mongo parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongodb://mongo/test
+$ docker run --name my-parse-server --link my-mongo:mongo -d parse-server --appId APPLICATION_ID --masterKey MASTER_KEY --databaseURI mongodb://mongo/test
 ```  
 
 You can use any arbitrary string as your application id and master key. These will be used by your clients to authenticate with the Parse Server.


### PR DESCRIPTION
Needed to run docker run --name my-parse-server --link my-mongo:mongo -d parse-server --appId APPLICATION_ID --masterKey MASTER_KEY to link the containers